### PR TITLE
Add stream close method to protocol (without deletion)

### DIFF
--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -688,7 +688,7 @@ export class FileBackedStreamStore {
         if (messageOffset > startByte) {
           messages.push({
             data: new Uint8Array(messageData),
-            offset: `${currentSeq}_${messageOffset}`,
+            offset: `${String(currentSeq).padStart(16, `0`)}_${String(messageOffset).padStart(16, `0`)}`,
             timestamp: 0, // Not stored in MVP
           })
         }


### PR DESCRIPTION
This is for finite length streams e.g. LLM token streaming. It allows the client to stop polling for updates when the stream closes.