### PR TITLE
Fix stream authentication protocol implementation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -594,13 +594,13 @@ When streams require authentication and CDN caching, implementers should conside
 
 #### Embedded Authentication
 
-When streaming logic is embedded in your application server, authentication can be handled directly using your application's existing auth mechanisms. The application validates credentials and serves stream data in a single request path:
+When streaming logic is embedded in your application server, authentication can be handled directly using your application's existing auth mechanisms:
 
 ```
-Client → CDN → Application Server (auth + streaming)
+Client → Application Server (auth + streaming)
 ```
 
-This is the simplest pattern and works well when the application already handles authentication for other endpoints.
+This is the simplest pattern and works well when the application already handles authentication for other endpoints. However, CDN caching is not compatible with this pattern since the CDN cannot validate credentials. Use `Cache-Control: private` to enable browser caching while preventing CDN caching, or use the proxy pattern below if CDN caching is required.
 
 #### Proxy Authentication Pattern
 


### PR DESCRIPTION
The protocol previously suggested using Cache-Control: private and
Vary: Authorization for authenticated streams. This was problematic:

1. Most CDNs ignore Vary header (except Accept-Encoding)
2. Cache-Control: private disables CDN caching entirely

The correct approach (following Electric SQL's auth patterns):
- Use an authorizing proxy that validates credentials BEFORE the CDN
- Cache keys are based on resource (URL, offset), not user identity
- Multiple authorized users share cached responses for same resource
- Proxy adds Vary: Authorization for BROWSER cache isolation between login sessions (not CDN isolation)

Changes:
- Section 8.1: Clarify Vary is for browser cache isolation only, CDNs ignore it. Proxy should add it for session isolation.
- Section 8.3: Add comprehensive auth/caching guidance including:
  - Proxy authentication pattern
  - Gatekeeper authentication pattern (shape-scoped tokens)
  - Cache architecture diagram
  - Note about proxy adding Vary header
  - Guidance for user-specific data
- Section 10.1: Update cross-reference to recommend proxy pattern

References:
- Electric SQL auth guide: https://electric-sql.com/docs/guides/auth

Fixes: #27