### PR TITLE
Don't return from append before fsync is finished (ref implementation)

### DIFF
--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -168,12 +168,6 @@ export class FileBackedStreamStore {
   private fileHandlePool: FileHandlePool
   private pendingLongPolls: Array<PendingLongPoll> = []
   private dataDir: string
-  /**
-   * In-memory buffer for recent appends per stream.
-   * Ensures read-your-writes consistency and fast long-poll notification.
-   * Messages remain in buffer until fsynced to disk.
-   */
-  private messageBuffers: Map<string, Array<StreamMessage>> = new Map()
 
   constructor(options: FileBackedStreamStoreOptions) {
     this.dataDir = options.dataDir
@@ -456,9 +450,6 @@ export class FileBackedStreamStore {
     // Cancel any pending long-polls for this stream
     this.cancelLongPollsForStream(streamPath)
 
-    // Clear in-memory buffer for this stream
-    this.messageBuffers.delete(streamPath)
-
     // Close any open file handle for this stream's segment file
     // This is important especially on Windows where open handles block deletion
     const segmentPath = path.join(
@@ -550,29 +541,33 @@ export class FileBackedStreamStore {
     const stream = this.fileHandlePool.getWriteStream(segmentPath)
 
     // 1. Write message with framing: [4 bytes length][data][\n]
+    //    Combine into single buffer for single syscall, and wait for write
+    //    to be flushed to kernel before calling fsync
     const lengthBuf = Buffer.allocUnsafe(4)
     lengthBuf.writeUInt32BE(processedData.length, 0)
-    stream.write(lengthBuf)
-    stream.write(processedData)
-    stream.write(`\n`)
+    const frameBuf = Buffer.concat([
+      lengthBuf,
+      processedData,
+      Buffer.from(`\n`),
+    ])
+    await new Promise<void>((resolve, reject) => {
+      stream.write(frameBuf, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
 
-    // 2. Create message and add to in-memory buffer for read-your-writes consistency
+    // 2. Create message object for return value
     const message: StreamMessage = {
       data: processedData,
       offset: newOffset,
       timestamp: Date.now(),
     }
-    const buffer = this.messageBuffers.get(streamPath) ?? []
-    buffer.push(message)
-    this.messageBuffers.set(streamPath, buffer)
 
-    // 3. Notify long-polls (minimize their latency - they read from buffer + disk)
-    this.notifyLongPolls(streamPath)
-
-    // 4. Flush to disk (blocks here until durable)
+    // 3. Flush to disk (blocks here until durable)
     await this.fileHandlePool.fsyncFile(segmentPath)
 
-    // 5. Update LMDB metadata (only after flush, so metadata reflects durability)
+    // 4. Update LMDB metadata (only after flush, so metadata reflects durability)
     const updatedMeta: StreamMetadata = {
       ...streamMeta,
       currentOffset: newOffset,
@@ -581,10 +576,10 @@ export class FileBackedStreamStore {
     }
     this.db.putSync(key, updatedMeta)
 
-    // 6. Clear from buffer (data is now durable on disk)
-    this.messageBuffers.delete(streamPath)
+    // 5. Notify long-polls (data is now readable from disk)
+    this.notifyLongPolls(streamPath)
 
-    // 7. Return (client knows data is durable)
+    // 6. Return (client knows data is durable)
     return message
   }
 
@@ -607,24 +602,13 @@ export class FileBackedStreamStore {
     const currentSeq = currentParts[0] ?? 0
     const currentByte = currentParts[1] ?? 0
 
-    // Check if there are buffered messages first (for read-your-writes during append)
-    const buffer = this.messageBuffers.get(streamPath) ?? []
-    const hasBufferedMessages = buffer.some((msg) => {
-      const msgParts = msg.offset.split(`_`).map(Number)
-      const msgByte = msgParts[1] ?? 0
-      return msgByte > startByte
-    })
-
-    // Early return if no data available (neither on disk nor in buffer)
-    if (
-      streamMeta.currentOffset === `0000000000000000_0000000000000000` &&
-      !hasBufferedMessages
-    ) {
+    // Early return if no data available
+    if (streamMeta.currentOffset === `0000000000000000_0000000000000000`) {
       return { messages: [], upToDate: true }
     }
 
-    // If start offset is at or past current offset AND no buffered messages, return empty
-    if (startByte >= currentByte && !hasBufferedMessages) {
+    // If start offset is at or past current offset, return empty
+    if (startByte >= currentByte) {
       return { messages: [], upToDate: true }
     }
 
@@ -687,20 +671,7 @@ export class FileBackedStreamStore {
       }
     } catch (err) {
       console.error(`[FileBackedStreamStore] Error reading file:`, err)
-      // Return empty messages on error (but still include buffer below)
     }
-
-    // Merge in-memory buffer messages (for read-your-writes consistency)
-    // Note: buffer already retrieved earlier for early-return check
-    const bufferMessages = buffer.filter((msg) => {
-      // Parse message offset to compare with start offset
-      const msgParts = msg.offset.split(`_`).map(Number)
-      const msgByte = msgParts[1] ?? 0
-      return msgByte > startByte
-    })
-
-    // Append buffer messages to disk messages
-    messages.push(...bufferMessages)
 
     return { messages, upToDate: true }
   }
@@ -789,9 +760,6 @@ export class FileBackedStreamStore {
       pending.resolve([])
     }
     this.pendingLongPolls = []
-
-    // Clear in-memory message buffers
-    this.messageBuffers.clear()
 
     // Clear all streams from LMDB
     const range = this.db.getRange({


### PR DESCRIPTION
The flaky "should read from offset" test was caused by a race condition where stream.write() buffered data in Node.js without waiting for it to reach the kernel before calling fdatasync(). This meant fdatasync() could complete without syncing the new data, and subsequent reads would see stale data.

Fix:
- Wait for stream.write() callback before calling fsync to ensure data is in kernel buffers
- Combine framing writes into single buffer for single syscall
- Remove redundant in-memory message buffer (no longer needed since writes are now synchronous to kernel before proceeding)