### PR TITLE
Fix README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ git clone https://github.com/durable-streams/durable-streams.git
 cd durable-streams
 pnpm install
 
+pnpm build
+
 # Terminal 1: Start the local server
 pnpm start:dev
 
@@ -103,6 +105,8 @@ See the [Test UI README](./packages/test-ui/README.md) for details.
 git clone https://github.com/durable-streams/durable-streams.git
 cd durable-streams
 pnpm install
+
+pnpm build
 
 # Terminal 1: Start the local server
 pnpm start:dev


### PR DESCRIPTION
The Test UI and CLI depend on workspace packages that need to be built before the dev servers can run. Added `pnpm build` step after install in both Option 1 and Option 2 of the getting started guide.

Fixes #52