### PR TITLE
Add community implementations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ See [@durable-streams/server](./packages/server) for more details.
 
 **Go**
 
-* [ahimsalabs/durable-streams-go](https://github.com/ahimsalabs/durable-streams-go): A client and server implementation that has full coverage of the conformance test suite.
+- [ahimsalabs/durable-streams-go](https://github.com/ahimsalabs/durable-streams-go): A client and server implementation that has full coverage of the conformance test suite.
 
 ## CLI Tool
 


### PR DESCRIPTION
Added a section for community implementations, seeding with the Go implementation (durable-streams-go).