### PR TITLE
state: synchronous createStreamDB.

### DIFF
--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -64,7 +64,7 @@ const schema = createStateSchema({
 })
 
 // Create a stream-backed database
-const db = await createStreamDB({
+const db = createStreamDB({
   streamOptions: {
     url: "https://api.example.com/streams/my-stream",
     contentType: "application/json",
@@ -228,7 +228,7 @@ const eventWithTxId = schema.users.insert({
 ### Creating a Database
 
 ```typescript
-const db = await createStreamDB({
+const db = createStreamDB({
   streamOptions: {
     url: "https://api.example.com/streams/my-stream",
     contentType: "application/json",
@@ -337,7 +337,7 @@ await db.utils.awaitTxId("txid-uuid", 5000) // 5 second timeout
 Define actions with optimistic updates and server confirmation:
 
 ```typescript
-const db = await createStreamDB({
+const db = createStreamDB({
   streamOptions: { url: streamUrl, contentType: "application/json" },
   state: schema,
   actions: ({ db, stream }) => ({

--- a/packages/state/examples/CLAUDE.md
+++ b/packages/state/examples/CLAUDE.md
@@ -83,7 +83,7 @@ if (query.isLoading()) {
 StreamDB collections are TanStack DB collections internally, so `useLiveQuery` works seamlessly:
 
 ```typescript
-const db = await createStreamDB({
+const db = createStreamDB({
   streamOptions: { url: streamUrl },
   state: stateSchema,
 })

--- a/packages/state/examples/background-jobs/index.html
+++ b/packages/state/examples/background-jobs/index.html
@@ -331,7 +331,7 @@
           }
 
           // Create StreamDB
-          db = await createStreamDB({
+          db = createStreamDB({
             streamOptions: {
               url: streamUrl,
               contentType: "application/json",

--- a/packages/state/examples/wikipedia-events/README.md
+++ b/packages/state/examples/wikipedia-events/README.md
@@ -109,7 +109,7 @@ Each event shows:
 ### StreamDB Integration
 
 ```typescript
-const db = await createStreamDB({
+const db = createStreamDB({
   streamOptions: {
     url: "http://localhost:4437/v1/stream/wikipedia-events",
     contentType: "application/json",

--- a/packages/state/examples/wikipedia-events/src/lib/stream-db.tsx
+++ b/packages/state/examples/wikipedia-events/src/lib/stream-db.tsx
@@ -59,7 +59,7 @@ export function WikipediaDBProvider(props: WikipediaDBProviderProps) {
         console.log(`[WikipediaDB] Stream created`)
       }
 
-      const database = await createStreamDB({
+      const database = createStreamDB({
         streamOptions: {
           url: streamUrl,
           contentType: `application/json`,

--- a/packages/state/src/stream-db.ts
+++ b/packages/state/src/stream-db.ts
@@ -726,6 +726,10 @@ export function createStateSchema<
 /**
  * Create a stream-backed database with TanStack DB collections
  *
+ * This function is synchronous - it creates the stream handle and collections
+ * but does not start the stream connection. Call `db.preload()` to connect
+ * and sync initial data.
+ *
  * @example
  * ```typescript
  * const stateSchema = createStateSchema({
@@ -733,8 +737,8 @@ export function createStateSchema<
  *   messages: { schema: messageSchema, type: "message", primaryKey: "id" },
  * })
  *
- * // Create a stream DB (stream is created lazily on preload)
- * const db = await createStreamDB({
+ * // Create a stream DB (synchronous - stream is created lazily on preload)
+ * const db = createStreamDB({
  *   streamOptions: {
  *     url: "https://api.example.com/streams/my-stream",
  *     contentType: "application/json",
@@ -747,8 +751,7 @@ export function createStateSchema<
  * const user = await db.collections.users.get("123")
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/require-await
-export async function createStreamDB<
+export function createStreamDB<
   TDef extends StreamStateDefinition,
   TActions extends Record<string, ActionDefinition<any>> = Record<
     string,
@@ -756,11 +759,9 @@ export async function createStreamDB<
   >,
 >(
   options: CreateStreamDBOptions<TDef, TActions>
-): Promise<
-  TActions extends Record<string, never>
-    ? StreamDB<TDef>
-    : StreamDBWithActions<TDef, TActions>
-> {
+): TActions extends Record<string, never>
+  ? StreamDB<TDef>
+  : StreamDBWithActions<TDef, TActions> {
   const { streamOptions, state, actions: actionsFactory } = options
 
   // Create a stream handle (lightweight, doesn't connect until stream() is called)

--- a/packages/state/test/stream-db.test.ts
+++ b/packages/state/test/stream-db.test.ts
@@ -92,7 +92,7 @@ describe(`Stream DB`, () => {
     })
 
     // Create the stream DB (will create its own stream handle for reading)
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: `${baseUrl}${streamPath}`,
         contentType: `application/json`,
@@ -159,7 +159,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -201,7 +201,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -242,7 +242,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -272,7 +272,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -315,7 +315,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -367,7 +367,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -419,7 +419,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -486,7 +486,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -554,7 +554,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -640,7 +640,7 @@ describe(`Stream DB`, () => {
     )
 
     // Create StreamDB
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: { url: stream.url, contentType: stream.contentType },
       state: streamState,
     })
@@ -725,7 +725,7 @@ describe(`Stream DB`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -797,7 +797,7 @@ describe(`Stream DB`, () => {
       headers: { operation: `insert` },
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: { url: stream.url, contentType: stream.contentType },
       state: streamState,
     })
@@ -1295,7 +1295,7 @@ describe(`Upsert Operations`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1331,7 +1331,7 @@ describe(`Upsert Operations`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1374,7 +1374,7 @@ describe(`Upsert Operations`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1421,7 +1421,7 @@ describe(`Upsert Operations`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1463,7 +1463,7 @@ describe(`Upsert Operations`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1540,7 +1540,7 @@ describe(`Stream DB Actions`, () => {
 
     const mutationResults: Array<{ name: string; signal: AbortSignal }> = []
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1618,7 +1618,7 @@ describe(`Stream DB Actions`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1693,7 +1693,7 @@ describe(`Stream DB Actions`, () => {
 
     let capturedStream: unknown = null
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: `${baseUrl}/db/actions-stream-${Date.now()}`,
         contentType: `application/json`,
@@ -1753,7 +1753,7 @@ describe(`Stream DB Actions`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1811,7 +1811,7 @@ describe(`Stream DB Actions`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1885,7 +1885,7 @@ describe(`Stream DB TxId Tracking`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1932,7 +1932,7 @@ describe(`Stream DB TxId Tracking`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -1977,7 +1977,7 @@ describe(`Stream DB TxId Tracking`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -2013,7 +2013,7 @@ describe(`Stream DB TxId Tracking`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,
@@ -2078,7 +2078,7 @@ describe(`Stream DB TxId Tracking`, () => {
       contentType: `application/json`,
     })
 
-    const db = await createStreamDB({
+    const db = createStreamDB({
       streamOptions: {
         url: streamUrl,
         contentType: `application/json`,


### PR DESCRIPTION
The `createStreamDB` function in the state package doesn't need to be async and, if it's synchronous, this significantly improves the DX of working with it.

For example, in a `const { messages, client, collections } = useDurableChat(...)` hook, it avoids the client and collections ever being undefined which avoids a bunch of annoying conditional logic.