### PR TITLE
Fix JSON parsing across multiple SSE lines

### DIFF
--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -49,8 +49,8 @@ export function processJsonAppend(
     const elements = parsed.map((item) => JSON.stringify(item))
     result = elements.join(`,`) + `,`
   } else {
-    // Single value - add trailing comma
-    result = text.trim() + `,`
+    // Single value - re-serialize to normalize whitespace (single-line JSON)
+    result = JSON.stringify(parsed) + `,`
   }
 
   return new TextEncoder().encode(result)


### PR DESCRIPTION
- Server now re-serializes single JSON objects to ensure single-line format (arrays were already normalized via JSON.stringify per element)
- Added parseSSEEvents helper to properly parse SSE events with multi-line data
- Updated JSON conformance test to use parseSSEEvents helper for robustness