### PR TITLE
fix(ci): pass explicit tag to GoReleaser for caddy releases

### DIFF
--- a/.github/workflows/release-caddy.yml
+++ b/.github/workflows/release-caddy.yml
@@ -32,6 +32,7 @@ jobs:
           workdir: packages/caddy-plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
In a monorepo with multiple package tags, GoReleaser's git describe picks up the wrong tag. Fix by explicitly setting GORELEASER_CURRENT_TAG to the workflow's triggering tag via github.ref_name.