### PR TITLE
fix(caddy): add monorepo tag_prefix config for GoReleaser

### DIFF
--- a/packages/caddy-plugin/.goreleaser.yml
+++ b/packages/caddy-plugin/.goreleaser.yml
@@ -1,5 +1,8 @@
 version: 2
 
+monorepo:
+  tag_prefix: caddy-
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
GoReleaser needs to know about the 'caddy-' prefix to correctly parse tags like 'caddy-v0.1.1' as semver version '0.1.1'.