### PR TITLE
fix(ci): remove GORELEASER_CURRENT_TAG that conflicts with monorepo config

### DIFF
--- a/.github/workflows/release-caddy.yml
+++ b/.github/workflows/release-caddy.yml
@@ -32,7 +32,6 @@ jobs:
           workdir: packages/caddy-plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
GORELEASER_CURRENT_TAG bypasses the monorepo.tag_prefix stripping. Let GoReleaser detect the caddy-* tag using the monorepo configuration.