### PR TITLE
fix(ci): strip caddy- prefix before passing tag to GoReleaser

### DIFF
--- a/.github/workflows/release-caddy.yml
+++ b/.github/workflows/release-caddy.yml
@@ -23,6 +23,10 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: packages/caddy-plugin/go.sum
 
+      - name: Extract version from tag
+        id: version
+        run: echo "TAG=${GITHUB_REF_NAME#caddy-}" >> "$GITHUB_OUTPUT"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -32,6 +36,7 @@ jobs:
           workdir: packages/caddy-plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4

--- a/packages/caddy-plugin/.goreleaser.yml
+++ b/packages/caddy-plugin/.goreleaser.yml
@@ -1,8 +1,5 @@
 version: 2
 
-monorepo:
-  tag_prefix: caddy-
-
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
The monorepo config is GoReleaser Pro only. Instead, strip the 'caddy-' prefix in the workflow so 'caddy-v0.1.3' becomes 'v0.1.3' which is valid semver.