### PR TITLE
fix(ci): skip git validation for caddy releases

### DIFF
--- a/.github/workflows/release-caddy.yml
+++ b/.github/workflows/release-caddy.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean --skip=validate
           workdir: packages/caddy-plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we strip the 'caddy-' prefix from tags before passing to GoReleaser, the actual git tag (caddy-v0.1.4) doesn't match the version (v0.1.4). Skip validation to allow this.