### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm install @durable-streams/cli      # Development & testing CLI
 
 ```bash
 # Go
-go get github.com/durable-streams/durable-streams-go
+go get github.com/durable-streams/durable-streams/packages/client-go
 
 # Python
 pip install durable-streams


### PR DESCRIPTION
The README referenced a non-existent repository at github.com/durable-streams/durable-streams-go. Updated to point to the correct location at packages/client-go within this repository.

Fixes #116