### PR TITLE
Add client conformance tests to ensure SSE parsers don't split on unicode line separators

### DIFF
--- a/.changeset/unicode-line-separator-tests.md
+++ b/.changeset/unicode-line-separator-tests.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/client-conformance-tests": patch
+---
+
+Add conformance tests for Unicode line separator preservation in SSE parsing. Per the HTML Living Standard, SSE parsers must only split on CRLF, LF, or CR. Other Unicode line separators (U+0085 NEL, U+2028 Line Separator, U+2029 Paragraph Separator) must be preserved as data characters.

--- a/packages/client-conformance-tests/test-cases/consumer/read-sse.yaml
+++ b/packages/client-conformance-tests/test-cases/consumer/read-sse.yaml
@@ -143,3 +143,90 @@ tests:
         expect:
           minChunks: 1
           upToDate: true
+
+  - id: sse-preserves-nel-character
+    name: SSE preserves NEL character (U+0085)
+    description: |
+      SSE parsers must NOT split on U+0085 (Next Line / NEL).
+      Per HTML Living Standard, SSE lines end only with CRLF, LF, or CR.
+      Other Unicode line separators must be preserved as data.
+    setup:
+      - action: create
+        as: streamPath
+        contentType: text/plain
+      - action: append
+        path: ${streamPath}
+        data: "before\u0085after"
+    operations:
+      - action: read
+        path: ${streamPath}
+        live: sse
+        waitForUpToDate: true
+        expect:
+          data: "before\u0085after"
+          minChunks: 1
+
+  - id: sse-preserves-line-separator
+    name: SSE preserves Line Separator (U+2028)
+    description: |
+      SSE parsers must NOT split on U+2028 (Line Separator).
+      This character can appear in JSON payloads and AI token streams.
+      It must be preserved as ordinary data, not treated as a line break.
+    setup:
+      - action: create
+        as: streamPath
+        contentType: text/plain
+      - action: append
+        path: ${streamPath}
+        data: "hello\u2028world"
+    operations:
+      - action: read
+        path: ${streamPath}
+        live: sse
+        waitForUpToDate: true
+        expect:
+          data: "hello\u2028world"
+          minChunks: 1
+
+  - id: sse-preserves-paragraph-separator
+    name: SSE preserves Paragraph Separator (U+2029)
+    description: |
+      SSE parsers must NOT split on U+2029 (Paragraph Separator).
+      This character can appear in JSON payloads and AI token streams.
+      It must be preserved as ordinary data, not treated as a line break.
+    setup:
+      - action: create
+        as: streamPath
+        contentType: text/plain
+      - action: append
+        path: ${streamPath}
+        data: "para1\u2029para2"
+    operations:
+      - action: read
+        path: ${streamPath}
+        live: sse
+        waitForUpToDate: true
+        expect:
+          data: "para1\u2029para2"
+          minChunks: 1
+
+  - id: sse-preserves-all-unicode-separators
+    name: SSE preserves all Unicode line separators together
+    description: |
+      Combined test ensuring NEL (U+0085), LS (U+2028), and PS (U+2029)
+      are all preserved in the same payload without being split.
+    setup:
+      - action: create
+        as: streamPath
+        contentType: text/plain
+      - action: append
+        path: ${streamPath}
+        data: "a\u0085b\u2028c\u2029d"
+    operations:
+      - action: read
+        path: ${streamPath}
+        live: sse
+        waitForUpToDate: true
+        expect:
+          data: "a\u0085b\u2028c\u2029d"
+          minChunks: 1


### PR DESCRIPTION
SSE parsers must only split on CRLF, LF, or CR per the HTML Living Standard. Unicode line separators (U+0085 NEL, U+2028 LS, U+2029 PS) must be preserved as data, not treated as line breaks.

Adds tests to the client conformance test suite (YAML) for cross-client validation of this behavior.