### PR TITLE
fix: Increase long poll timeout and make configurable

### DIFF
--- a/.changeset/two-bees-appear.md
+++ b/.changeset/two-bees-appear.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/server-conformance-tests": patch
+---
+
+Increase timeout for long poll tests and make timeout configurable

--- a/packages/server-conformance-tests/tsconfig.json
+++ b/packages/server-conformance-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*", "*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
The hardcoded 10 second timeout on long poll tests is forcing implementations to set their long polling timeout to 10 seconds or less.

Also added a missing tsconfig