### PR TITLE
fix: Remove optional tag for stream cursor

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -269,7 +269,7 @@ For non-live reads without data beyond the requested offset, servers **SHOULD** 
 - `Cache-Control`: Derived from TTL/expiry (see Section 8)
 - `ETag: {internal_stream_id}:{start_offset}:{end_offset}`
   - Entity tag for cache validation
-- `Stream-Cursor: <cursor>` (optional)
+- `Stream-Cursor: <cursor>`
   - Cursor to echo on subsequent long-poll requests to improve CDN collapsing
 - `Stream-Next-Offset: <offset>`
   - The next offset to read from (for subsequent requests)


### PR DESCRIPTION
The `PROTOCOL.md` was marking the `Stream-Cursor` header as an optional response header, but further down in the spec at 8.1:

> To prevent infinite CDN cache loops (where clients receive the same cached empty response indefinitely), servers **MUST** generate cursors on all live mode responses:

And the conformance tests are also forcing implementers to make servers return the cursors. I believe that this means this should not be marked as optional in the spec - OR we should rephrase the 8.1 section and make the conformance only optionally do cursor tests.