### PR TITLE
fix: remove unnecessary async from functions without await

### DIFF
--- a/examples/test-ui/src/lib/stream-db-context.tsx
+++ b/examples/test-ui/src/lib/stream-db-context.tsx
@@ -54,7 +54,7 @@ export function getUserColor(userId: string): string {
 // StreamDB Factories with Actions
 // ============================================================================
 
-async function createRegistryDB(url: string) {
+function createRegistryDB(url: string) {
   return createStreamDB({
     streamOptions: {
       url,
@@ -81,7 +81,7 @@ async function createRegistryDB(url: string) {
   })
 }
 
-async function createPresenceDB(url: string) {
+function createPresenceDB(url: string) {
   return createStreamDB({
     streamOptions: {
       url,

--- a/examples/test-ui/src/lib/stream-store.ts
+++ b/examples/test-ui/src/lib/stream-store.ts
@@ -73,7 +73,7 @@ class StreamStore {
         signal: subscription.abortController!.signal,
       })
 
-      response.subscribeText(async (chunk) => {
+      response.subscribeText((chunk) => {
         if (chunk.text !== ``) {
           // Create new array reference so React detects the change
           subscription.messages = [
@@ -83,6 +83,7 @@ class StreamStore {
           // Notify all listeners
           subscription.listeners.forEach((listener) => listener())
         }
+        return Promise.resolve()
       })
     } catch (err: any) {
       // Ignore abort errors - expected when navigating away or during cleanup

--- a/packages/benchmarks/src/index.ts
+++ b/packages/benchmarks/src/index.ts
@@ -162,13 +162,14 @@ export function runBenchmarks(options: BenchmarkOptions): void {
             live: `long-poll`,
           })
           await new Promise<void>((resolve) => {
-            const unsubscribe = res.subscribeBytes(async (chunk) => {
+            const unsubscribe = res.subscribeBytes((chunk) => {
               if (chunk.data.length > 0) {
                 offset = chunk.offset
                 unsubscribe()
                 res.cancel()
                 resolve()
               }
+              return Promise.resolve()
             })
           })
         })()
@@ -183,12 +184,13 @@ export function runBenchmarks(options: BenchmarkOptions): void {
             live: `long-poll`,
           })
           await new Promise<void>((resolve) => {
-            const unsubscribe = res.subscribeBytes(async (chunk) => {
+            const unsubscribe = res.subscribeBytes((chunk) => {
               if (chunk.data.length > 0) {
                 unsubscribe()
                 res.cancel()
                 resolve()
               }
+              return Promise.resolve()
             })
           })
         })()

--- a/packages/client-conformance-tests/src/adapters/typescript-adapter.ts
+++ b/packages/client-conformance-tests/src/adapters/typescript-adapter.ts
@@ -702,12 +702,13 @@ async function handleBenchmark(command: BenchmarkCommand): Promise<TestResult> {
 
           // Wait for data
           return new Promise<Uint8Array>((resolve) => {
-            const unsubscribe = res.subscribeBytes(async (chunk) => {
+            const unsubscribe = res.subscribeBytes((chunk) => {
               if (chunk.data.length > 0) {
                 unsubscribe()
                 res.cancel()
                 resolve(chunk.data)
               }
+              return Promise.resolve()
             })
           })
         })()

--- a/packages/state/src/stream-db.ts
+++ b/packages/state/src/stream-db.ts
@@ -823,7 +823,7 @@ export function createStreamDB<
     let lastBatchTime = Date.now()
 
     // Process events as they come in
-    streamResponse.subscribeJson(async (batch) => {
+    streamResponse.subscribeJson((batch) => {
       try {
         batchCount++
         lastBatchTime = Date.now()
@@ -863,6 +863,7 @@ export function createStreamDB<
         abortController.abort()
         // Don't rethrow - we've already rejected the promise
       }
+      return Promise.resolve()
     })
 
     // Health check to detect silent stalls

--- a/packages/state/test/stream-db.test.ts
+++ b/packages/state/test/stream-db.test.ts
@@ -1682,7 +1682,7 @@ describe(`Stream DB Actions`, () => {
     db.close()
   })
 
-  it(`should provide stream context to actions`, async () => {
+  it(`should provide stream context to actions`, () => {
     const streamState = createStateSchema({
       users: {
         schema: userSchema,


### PR DESCRIPTION
## Summary
- Remove `async` keyword from functions/callbacks that have no `await` expressions
- Fixes eslint `@typescript-eslint/require-await` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)