### PR TITLE
(WIP) fix: add server-conformance-tests project to vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -78,6 +78,17 @@ export default defineConfig({
         },
         resolve: { alias },
       }),
+      defineProject({
+        test: {
+          name: "server-conformance-tests",
+          include: [
+            "packages/server-conformance-tests/src/test-runner.ts",
+            "packages/server-conformance-tests/dist/test-runner.js",
+          ],
+          exclude: ["**/node_modules/**"],
+        },
+        resolve: { alias },
+      }),
     ],
     coverage: {
       provider: `v8`,


### PR DESCRIPTION
This is not ready -- it's just to unlock local development

The server-conformance-tests CLI was not finding tests because vitest uses workspace projects with specific include patterns, and there was no project that matched the test-runner files.