### PR TITLE
Don't try to post PR comments for forked repos

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -515,7 +515,8 @@ jobs:
           cat benchmark-report.md
 
       - name: Comment on PR with benchmark results
-        if: always() && github.event_name == 'pull_request'
+        # Skip for fork PRs - GITHUB_TOKEN doesn't have write access for security reasons
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Skip the PR comment step when the workflow is running on a fork PR, since GITHUB_TOKEN doesn't have write access to the target repository for security reasons. This prevents the "Resource not accessible by integration" 403 error.