### PR TITLE
test: verify Cache-Control: no-store for offset=now catch-up

### DIFF
--- a/packages/server-conformance-tests/src/index.ts
+++ b/packages/server-conformance-tests/src/index.ts
@@ -1389,6 +1389,9 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
       expect(text).toBe(``)
       expect(response.headers.get(STREAM_UP_TO_DATE_HEADER)).toBe(`true`)
       expect(response.headers.get(STREAM_OFFSET_HEADER)).toBeDefined()
+      // Cache-Control: no-store prevents caching of the tail offset
+      const cacheControl = response.headers.get(`cache-control`)
+      expect(cacheControl).toContain(`no-store`)
     })
 
     test(`should return correct tail offset for offset=now`, async () => {


### PR DESCRIPTION
## Summary
- Adds assertion to verify servers return `Cache-Control: no-store` on `offset=now` catch-up responses
- Per PROTOCOL.md Section 6: "Servers SHOULD return `Cache-Control: no-store` to prevent caching of the tail offset"

This was identified as a gap in server conformance test coverage—the protocol specifies this behavior but no test verified it.

## Test plan
- [x] All conformance tests pass (730 passed, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)