### PR TITLE
Fix aggregating benchmark results from multiple CI jobs

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -394,13 +394,8 @@ jobs:
       - name: Generate benchmark report
         run: |
           cd packages/client-conformance-tests
-          echo "# Client Benchmark Results" > benchmark-report.md
-          echo "" >> benchmark-report.md
-
-          # Generate report for each client
-          pnpm tsx src/cli.ts --bench ts --format markdown >> benchmark-report.md 2>/dev/null || echo "TypeScript: No results" >> benchmark-report.md
-          echo "" >> benchmark-report.md
-
+          # Aggregate all benchmark results from downloaded artifacts
+          pnpm tsx src/cli.ts --report ../../benchmark-results > benchmark-report.md
           cat benchmark-report.md
 
       - name: Comment on PR with benchmark results


### PR DESCRIPTION
The benchmark-report job was re-running TypeScript benchmarks instead of aggregating the downloaded JSON artifacts from all client benchmark jobs.

Added --report flag to CLI that reads benchmark JSON files from a directory and generates a combined markdown report with a summary table showing results from all clients.