### PR TITLE
fix(cli): resolve symlinks in isMainModule for npx support

### DIFF
--- a/.changeset/fix-cli-npx-symlink.md
+++ b/.changeset/fix-cli-npx-symlink.md
@@ -1,0 +1,5 @@
+---
+'@durable-streams/cli': patch
+---
+
+Fix CLI not running when invoked via npx by resolving symlinks in the isMainModule check.


### PR DESCRIPTION
CLI commands via `npx @durable-streams/cli` were silently doing nothing. Now they work.

## Root Cause

The CLI uses an `isMainModule()` check to determine if it should run `main()` vs being imported as a library. This check compared `process.argv[1]` (the script path) to `import.meta.url` (the module path).

When invoked via `npx`, npm creates a symlink in its cache pointing to the actual package file. The comparison was:
- `process.argv[1]`: `/Users/.../.npm/_npx/.../node_modules/.bin/cli` (symlink)
- `import.meta.url`: `/Users/.../.npm/_npx/.../node_modules/@durable-streams/cli/dist/index.js` (real file)

These don't match → `isMainModule()` returns false → `main()` never runs → silent exit.

## Approach

Use `realpathSync` to resolve both paths to their canonical locations before comparing:

```typescript
const scriptPath = realpathSync(resolvePath(process.argv[1]))
const modulePath = realpathSync(fileURLToPath(import.meta.url))
return scriptPath === modulePath
```

With a try/catch fallback for edge cases where the file might not exist.

## Key Invariants

- `isMainModule()` must return `true` when CLI is the entry point (direct invocation, npx, global install)
- `isMainModule()` must return `false` when imported as a library
- The check must not throw on malformed paths

## Non-goals

- Changing the dual CLI/library architecture
- Alternative detection methods (checking for specific CLI flags, etc.)

## Verification

```bash
# Run CLI tests (includes new symlink test)
cd /path/to/repo && pnpm vitest run --project=cli

# After publish, verify npx works
npx @durable-streams/cli --help
```

## Files changed

| File | Change |
|------|--------|
| `packages/cli/src/index.ts` | Add `realpathSync` to resolve symlinks in `isMainModule()` |
| `packages/cli/test/cli.test.ts` | Add test that invokes CLI through a symlink |
| `.changeset/fix-cli-npx-symlink.md` | Changeset for patch release |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)