### PR TITLE
Update out-dated docs

### DIFF
--- a/packages/client-py/README.md
+++ b/packages/client-py/README.md
@@ -132,7 +132,7 @@ asyncio.run(main())
 
 ### Top-Level Functions
 
-#### `stream(url, *, offset=None, live="auto", ...)`
+#### `stream(url, *, offset=None, live=True, ...)`
 
 Create a synchronous streaming session.
 
@@ -142,13 +142,13 @@ from durable_streams import stream
 res = stream(
     url="https://example.com/stream",
     offset="12345",           # Resume from offset
-    live="auto",              # Live mode (see below)
+    live=True,                # Live mode (see below)
     headers={"Authorization": "Bearer token"},
     params={"tenant": "my-tenant"},
 )
 ```
 
-#### `astream(url, *, offset=None, live="auto", ...)`
+#### `astream(url, *, offset=None, live=True, ...)`
 
 Create an asynchronous streaming session.
 
@@ -158,7 +158,7 @@ from durable_streams import astream
 res = await astream(
     url="https://example.com/stream",
     offset="12345",
-    live="auto",
+    live=True,
 )
 ```
 
@@ -167,9 +167,7 @@ res = await astream(
 The `live` parameter controls streaming behavior:
 
 - `False` - Catch-up only. Stop after reaching the end of the stream.
-- `"auto"` (default) - Behavior depends on consumption method:
-  - `read_*()` methods: Stop after reaching up-to-date
-  - Iteration methods: Continue with long-poll for live updates
+- `True` (default) - Catch-up first, then continue with long-poll for live updates
 - `"long-poll"` - Explicit long-poll mode for live updates
 - `"sse"` - Explicit Server-Sent Events mode for live updates
 
@@ -413,7 +411,7 @@ class StreamEvent(Generic[T]):
 ### LiveMode
 
 ```python
-LiveMode = Literal["auto", "long-poll", "sse"] | bool
+LiveMode = Literal["long-poll", "sse"] | bool
 ```
 
 ### HeadResult

--- a/packages/client-rb/README.md
+++ b/packages/client-rb/README.md
@@ -99,11 +99,6 @@ stream.read(live: :sse).each do |msg|
   puts msg
 end
 
-# Auto-detect best mode
-stream.read(live: :auto).each do |msg|
-  handle(msg)
-end
-
 # Lazy enumeration works with Enumerator
 stream.read(live: :sse).each.lazy.take(10).to_a
 ```
@@ -235,7 +230,7 @@ stream.close  # Shutdown transport
 ```ruby
 stream.read(
   offset: "-1",      # Starting position ("-1" = beginning)
-  live: false,       # false, :auto, :long_poll, :sse
+  live: false,       # false, :long_poll, :sse
   format: :auto,     # :auto, :json, :bytes
   cursor: nil        # Server-provided cursor for continuation
 )
@@ -246,7 +241,6 @@ stream.read(
 | `false`      | Return immediately when caught up (catch-up only)     |
 | `:long_poll` | Wait for new data, return when available or timeout   |
 | `:sse`       | Server-Sent Events stream with automatic reconnection |
-| `:auto`      | SSE for JSON/text streams, long-poll otherwise        |
 
 | `format` | Behavior                                |
 | -------- | --------------------------------------- |

--- a/packages/client-rb/lib/durable_streams.rb
+++ b/packages/client-rb/lib/durable_streams.rb
@@ -97,7 +97,7 @@ module DurableStreams
     # Read from a stream
     # @param url [String] Stream URL or path
     # @param offset [String] Starting offset (default: "-1" for beginning)
-    # @param live [Boolean, Symbol] Live mode (false, :auto, :long_poll, :sse)
+    # @param live [Boolean, Symbol] Live mode (false, :long_poll, :sse)
     # @param format [Symbol] Format hint (:auto, :json, :bytes)
     # @param context [Context] Optional context
     # @return [JsonReader, ByteReader] Reader for iterating messages

--- a/packages/client-rb/lib/durable_streams/stream.rb
+++ b/packages/client-rb/lib/durable_streams/stream.rb
@@ -211,7 +211,7 @@ module DurableStreams
 
     # Read from stream
     # @param offset [String] Starting offset (default: "-1" for beginning)
-    # @param live [Boolean, Symbol] Live mode (false, :auto, :long_poll, :sse)
+    # @param live [Boolean, Symbol] Live mode (false, :long_poll, :sse)
     # @param format [Symbol] Format hint (:auto, :json, :bytes)
     # @param cursor [String, nil] Optional cursor for continuation
     # @yield [Reader] Optional block for automatic cleanup


### PR DESCRIPTION
…lients

PR #177 removed the "auto" live mode from all client implementations, replacing it with `live: true` (TypeScript/Python) or explicit mode selection (Ruby). However, the documentation was not fully updated.

- Python README: Update to use `live=True` instead of `live="auto"`
- Ruby README: Remove `:auto` from live mode examples and tables
- Ruby docstrings: Remove `:auto` from @param documentation