### PR TITLE
Add --flag=value syntax support to CLI

### DIFF
--- a/.changeset/fix-cli-content-type-syntax.md
+++ b/.changeset/fix-cli-content-type-syntax.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/cli": patch
+---
+
+Add support for `--flag=value` syntax for all CLI flags that take values (`--url`, `--auth`, `--content-type`). Previously only the space-separated syntax (`--flag value`) was supported, causing the `=` syntax to be silently ignored. Also improves error messages when command-specific flags like `--content-type` are placed before the command instead of after.

--- a/packages/cli/test/parseGlobalOptions.test.ts
+++ b/packages/cli/test/parseGlobalOptions.test.ts
@@ -20,6 +20,16 @@ describe(`parseGlobalOptions`, () => {
     expect(result.remainingArgs).toEqual([`read`, `my-stream`])
   })
 
+  it(`parses --url=value syntax`, () => {
+    const result = parseGlobalOptions([
+      `--url=http://example.com:8080`,
+      `read`,
+      `my-stream`,
+    ])
+    expect(result.options.url).toBe(`http://example.com:8080`)
+    expect(result.remainingArgs).toEqual([`read`, `my-stream`])
+  })
+
   it(`parses --url flag after command`, () => {
     const result = parseGlobalOptions([
       `read`,
@@ -67,6 +77,16 @@ describe(`parseGlobalOptions`, () => {
     const result = parseGlobalOptions([
       `--auth`,
       `Bearer token`,
+      `read`,
+      `my-stream`,
+    ])
+    expect(result.options.auth).toBe(`Bearer token`)
+    expect(result.remainingArgs).toEqual([`read`, `my-stream`])
+  })
+
+  it(`parses --auth=value syntax`, () => {
+    const result = parseGlobalOptions([
+      `--auth=Bearer token`,
       `read`,
       `my-stream`,
     ])

--- a/packages/cli/test/parseWriteArgs.test.ts
+++ b/packages/cli/test/parseWriteArgs.test.ts
@@ -27,6 +27,12 @@ describe(`parseWriteArgs`, () => {
     expect(result.content).toBe(`hello`)
   })
 
+  it(`parses --content-type=value syntax`, () => {
+    const result = parseWriteArgs([`--content-type=text/plain`, `hello`])
+    expect(result.contentType).toBe(`text/plain`)
+    expect(result.content).toBe(`hello`)
+  })
+
   it(`parses --content-type flag after content`, () => {
     const result = parseWriteArgs([`hello`, `--content-type`, `text/plain`])
     expect(result.contentType).toBe(`text/plain`)


### PR DESCRIPTION
## Summary

Adds `--flag=value` syntax support to all CLI flags that accept values. Previously, `--url=http://...` and `--content-type=text/plain` were silently ignored, falling back to defaults.

---

## Root Cause

The CLI's argument parser only checked for exact flag matches (`arg === '--url'`), then consumed the next argument as the value. When users passed `--url=http://...` (a single argument), it didn't match the exact string `'--url'` and was pushed to `remainingArgs`, eventually triggering an unhelpful "Unknown option" error.

## Approach

Added explicit handling for `--flag=` prefix patterns before the existing space-separated parsing:

```typescript
// Handle --url=value syntax
if (arg.startsWith(`--url=`)) {
  const value = arg.slice(`--url=`.length)
  // ... validation and assignment
  continue
}

// Handle --url value syntax (existing)
if (arg === `--url`) { ... }
```

This pattern was applied to all three value-accepting flags: `--url`, `--auth`, and `--content-type`.

**Bonus fix**: When users place command-specific flags before the command (e.g., `durable-stream --content-type text/plain create foo`), the error now explains correct placement instead of just saying "Unknown option".

## Key Invariants

1. Both syntaxes produce identical behavior
2. `--flag=` with empty value throws the same error as `--flag` without a following value
3. Last flag wins when specified multiple times (existing behavior preserved)

## Non-goals

- Did not refactor to use a CLI parsing library (commander, yargs)—the hand-rolled parser is simple enough for now
- Did not add `=` syntax to boolean flags (`--json`, `--batch-json`)—they don't take values

## Trade-offs

Could have used a regex like `/^--(url|auth|content-type)(?:=(.*))?$/` for DRYer code, but explicit `startsWith` checks are more readable and the duplication is minimal.

---

## Verification

```bash
# Build and test locally
pnpm build --filter @durable-streams/cli
pnpm test --filter @durable-streams/cli

# Manual verification
node packages/cli/dist/index.js --url=http://localhost:4437/v1/stream create test --content-type=text/plain
```

## Files Changed

| File | Change |
|------|--------|
| `packages/cli/src/index.ts` | Added `=` syntax for `--url`, `--auth`, `--content-type`; improved misplaced flag errors |
| `packages/cli/src/parseWriteArgs.ts` | Added `--content-type=value` parsing for write command |
| `packages/cli/test/cli.test.ts` | Integration tests for `=` syntax and error messages |
| `packages/cli/test/parseGlobalOptions.test.ts` | Unit tests for `--url=` and `--auth=` |
| `packages/cli/test/parseWriteArgs.test.ts` | Unit test for `--content-type=` |
| `.changeset/fix-cli-content-type-syntax.md` | Changeset for release |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)