### PR TITLE
fix: Remove hardcoded test timeouts on server conformance tests

### DIFF
--- a/.changeset/legal-glasses-glow.md
+++ b/.changeset/legal-glasses-glow.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/server-conformance-tests": patch
+---
+
+Remove hardcoded test timeouts

--- a/packages/server-conformance-tests/src/index.ts
+++ b/packages/server-conformance-tests/src/index.ts
@@ -4827,7 +4827,7 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
           ),
           { numRuns: 25 }
         )
-      }, 15000)
+      })
 
       test(`read-your-writes: data is immediately visible after append`, async () => {
         await fc.assert(
@@ -5350,7 +5350,7 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
           ),
           { numRuns: 15 }
         )
-      }, 15000)
+      })
 
       test(`content hash changes with each append`, async () => {
         const streamPath = `/v1/stream/hash-changes-${Date.now()}-${Math.random().toString(36).slice(2)}`


### PR DESCRIPTION
The hardcoded timeouts don't allow for timeout overrides from outside of the suite, and a slow creation implementation fails the tests with no way to increase the timeout.