### PR TITLE
feat: TanStack AI chat example with durable proxy integration

### DIFF
--- a/examples/chat-tanstack/.env.example
+++ b/examples/chat-tanstack/.env.example
@@ -1,0 +1,11 @@
+# Required: Your Anthropic API key
+ANTHROPIC_API_KEY=your-api-key-here
+
+# Optional: Override the default model (claude-sonnet-4-20250514)
+# MODEL=claude-sonnet-4-20250514
+
+# Optional: Durable proxy settings (defaults shown)
+# PROXY_SECRET=dev-secret
+# VITE_PROXY_URL=http://localhost:4440/v1/proxy
+# VITE_PROXY_SECRET=dev-secret
+# VITE_UPSTREAM_URL=http://localhost:3002/api/chat

--- a/examples/chat-tanstack/.gitignore
+++ b/examples/chat-tanstack/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+node_modules/
+
+# Build
+dist/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Logs
+npm-debug.log*

--- a/examples/chat-tanstack/index.html
+++ b/examples/chat-tanstack/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/chat-tanstack/package.json
+++ b/examples/chat-tanstack/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@durable-streams/example-chat-tanstack",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently \"npm run dev:durable\" \"npm run dev:server\" \"npm run dev:client\"",
+    "dev:durable": "tsx server/durable-proxy.ts",
+    "dev:server": "tsx watch server/index.ts",
+    "dev:client": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.0",
+    "@durable-streams/proxy": "workspace:*",
+    "@durable-streams/server": "workspace:*",
+    "@tanstack/ai-react": "^0.2.0",
+    "@tanstack/react-router": "^1.95.0",
+    "dotenv": "^17.2.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "concurrently": "^9.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/chat-tanstack/server/durable-proxy.ts
+++ b/examples/chat-tanstack/server/durable-proxy.ts
@@ -1,0 +1,49 @@
+import "dotenv/config"
+import { DurableStreamTestServer } from "@durable-streams/server"
+import { createProxyServer } from "@durable-streams/proxy"
+
+const DS_PORT = 4437
+const PROXY_PORT = 4440
+const JWT_SECRET = process.env.PROXY_SECRET || `dev-secret`
+const CHAT_SERVER_PORT = process.env.SERVER_PORT
+  ? parseInt(process.env.SERVER_PORT)
+  : 3002
+
+// Start the durable streams storage server
+const dsServer = new DurableStreamTestServer({
+  port: DS_PORT,
+  host: `0.0.0.0`,
+})
+
+const dsUrl = await dsServer.start()
+console.log(`✓ Durable Streams server running at ${dsUrl}`)
+
+// Start the proxy server
+const proxy = await createProxyServer({
+  port: PROXY_PORT,
+  host: `0.0.0.0`,
+  durableStreamsUrl: dsUrl,
+  jwtSecret: JWT_SECRET,
+  allowlist: [
+    `localhost:${CHAT_SERVER_PORT}/*`,
+    `127.0.0.1:${CHAT_SERVER_PORT}/*`,
+    `0.0.0.0:${CHAT_SERVER_PORT}/*`,
+  ],
+})
+
+console.log(`✓ Durable Proxy server running at ${proxy.url}`)
+console.log(
+  `  Proxying to upstream servers matching: localhost:${CHAT_SERVER_PORT}/*`
+)
+console.log(`  Secret: ${JWT_SECRET}`)
+
+// Handle graceful shutdown
+const shutdown = async () => {
+  console.log(`\nShutting down...`)
+  await proxy.stop()
+  await dsServer.stop()
+  process.exit(0)
+}
+
+process.on(`SIGINT`, shutdown)
+process.on(`SIGTERM`, shutdown)

--- a/examples/chat-tanstack/server/index.ts
+++ b/examples/chat-tanstack/server/index.ts
@@ -1,0 +1,160 @@
+import "dotenv/config"
+import { createServer } from "node:http"
+import Anthropic from "@anthropic-ai/sdk"
+import type { IncomingMessage, ServerResponse } from "node:http"
+
+const DEFAULT_MODEL = `claude-sonnet-4-20250514`
+
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY
+if (!ANTHROPIC_API_KEY) {
+  console.error(`ANTHROPIC_API_KEY is required`)
+  process.exit(1)
+}
+
+const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY })
+const model = process.env.MODEL || DEFAULT_MODEL
+
+async function parseBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = ``
+    req.on(`data`, (chunk) => (body += chunk))
+    req.on(`end`, () => resolve(body))
+    req.on(`error`, reject)
+  })
+}
+
+function setCorsHeaders(res: ServerResponse) {
+  res.setHeader(`Access-Control-Allow-Origin`, `*`)
+  res.setHeader(`Access-Control-Allow-Methods`, `POST, OPTIONS`)
+  res.setHeader(`Access-Control-Allow-Headers`, `Content-Type`)
+}
+
+interface MessagePart {
+  type: string
+  content: string
+}
+
+interface UIMessage {
+  id?: string
+  role: `user` | `assistant`
+  parts?: Array<MessagePart>
+  content?: string
+}
+
+function getMessageContent(message: UIMessage): string {
+  // Handle messages with parts array (TanStack AI format)
+  if (message.parts && Array.isArray(message.parts)) {
+    return message.parts
+      .filter((p) => p.type === `text`)
+      .map((p) => p.content)
+      .join(``)
+  }
+  // Handle messages with direct content string
+  if (typeof message.content === `string`) {
+    return message.content
+  }
+  return ``
+}
+
+function convertMessagesToAnthropic(
+  messages: Array<UIMessage>
+): Array<{ role: `user` | `assistant`; content: string }> {
+  return messages.map((m) => ({
+    role: m.role,
+    content: getMessageContent(m),
+  }))
+}
+
+async function handleChat(req: IncomingMessage, res: ServerResponse) {
+  try {
+    const body = await parseBody(req)
+    const { messages } = JSON.parse(body) as { messages: Array<UIMessage> }
+
+    const anthropicMessages = convertMessagesToAnthropic(messages)
+
+    setCorsHeaders(res)
+    res.setHeader(`Content-Type`, `text/event-stream`)
+    res.setHeader(`Cache-Control`, `no-cache`)
+    res.setHeader(`Connection`, `keep-alive`)
+
+    const stream = anthropic.messages.stream({
+      model,
+      max_tokens: 4096,
+      messages: anthropicMessages,
+    })
+
+    const id = `msg-${Date.now()}`
+    let accumulatedContent = ``
+
+    for await (const event of stream) {
+      if (event.type === `content_block_delta`) {
+        const delta = event.delta
+        if (`text` in delta) {
+          accumulatedContent += delta.text
+          const chunk = {
+            type: `content`,
+            id,
+            model,
+            timestamp: Date.now(),
+            delta: delta.text,
+            content: accumulatedContent,
+            role: `assistant`,
+          }
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`)
+        }
+      } else if (event.type === `message_stop`) {
+        const doneChunk = {
+          type: `done`,
+          id,
+          model,
+          timestamp: Date.now(),
+          finishReason: `stop`,
+        }
+        res.write(`data: ${JSON.stringify(doneChunk)}\n\n`)
+        res.write(`data: [DONE]\n\n`)
+      }
+    }
+
+    res.end()
+  } catch (err) {
+    console.error(`Chat error:`, err)
+    const errorChunk = {
+      type: `error`,
+      id: `error-${Date.now()}`,
+      model,
+      timestamp: Date.now(),
+      error: { message: String(err), code: `500` },
+    }
+    res.write(`data: ${JSON.stringify(errorChunk)}\n\n`)
+    res.write(`data: [DONE]\n\n`)
+    res.end()
+  }
+
+  // Handle client disconnect
+  req.on(`close`, () => {
+    // Stream aborted
+  })
+}
+
+const server = createServer((req, res) => {
+  // Handle CORS preflight
+  if (req.method === `OPTIONS`) {
+    setCorsHeaders(res)
+    res.statusCode = 204
+    res.end()
+    return
+  }
+
+  if (req.method === `POST` && req.url === `/api/chat`) {
+    handleChat(req, res)
+    return
+  }
+
+  res.statusCode = 404
+  res.end(`Not found`)
+})
+
+const PORT = process.env.SERVER_PORT ? parseInt(process.env.SERVER_PORT) : 3002
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`)
+})

--- a/examples/chat-tanstack/src/Chat.tsx
+++ b/examples/chat-tanstack/src/Chat.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useChat } from "@tanstack/ai-react"
+import { createDurableAdapter } from "@durable-streams/proxy/transports"
+import { getMessages, saveMessages } from "./storage"
+import type { UIMessage } from "@tanstack/ai-react"
+import type { FormEvent, KeyboardEvent } from "react"
+
+// Helper to extract text content from UIMessage parts
+function getMessageContent(message: UIMessage): string {
+  return message.parts
+    .filter(
+      (part): part is { type: `text`; content: string } => part.type === `text`
+    )
+    .map((part) => part.content)
+    .join(``)
+}
+
+interface ChatProps {
+  conversationId: string
+  sidebarOpen: boolean
+  onToggleSidebar: () => void
+  onMessagesChange?: () => void
+}
+
+const PROXY_URL =
+  import.meta.env.VITE_PROXY_URL || `http://localhost:4440/v1/proxy`
+const PROXY_SECRET = import.meta.env.VITE_PROXY_SECRET || `dev-secret`
+const UPSTREAM_URL =
+  import.meta.env.VITE_UPSTREAM_URL || `http://localhost:3002/api/chat`
+
+export function Chat({
+  conversationId,
+  sidebarOpen,
+  onToggleSidebar,
+  onMessagesChange,
+}: ChatProps) {
+  const [input, setInput] = useState(``)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const initialMessages = useMemo(
+    () => getMessages(conversationId),
+    [conversationId]
+  )
+
+  // Create a durable adapter that routes through the proxy for resumable streaming.
+  // The requestId is scoped per conversation turn so each assistant response
+  // gets its own durable stream that can be resumed on page refresh.
+  const connection = useMemo(
+    () =>
+      createDurableAdapter(UPSTREAM_URL, {
+        proxyUrl: PROXY_URL,
+        proxyAuthorization: PROXY_SECRET,
+        getRequestId: (messages) => `${conversationId}-turn-${messages.length}`,
+      }) as any,
+    [conversationId]
+  )
+
+  const { messages, sendMessage, isLoading, error, stop, reload } = useChat({
+    connection,
+    initialMessages,
+  })
+
+  // Persist messages to localStorage on every change
+  const prevLengthRef = useRef(0)
+  useEffect(() => {
+    if (messages.length > 0) {
+      saveMessages(conversationId, messages)
+      // Only notify sidebar when message count changes (not during streaming deltas)
+      if (messages.length !== prevLengthRef.current) {
+        prevLengthRef.current = messages.length
+        onMessagesChange?.()
+      }
+    }
+  }, [messages, conversationId, onMessagesChange])
+
+  // Auto-scroll to bottom while streaming
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: `smooth` })
+  }, [messages])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = `auto`
+      textareaRef.current.style.height =
+        Math.min(textareaRef.current.scrollHeight, 120) + `px`
+    }
+  }, [input])
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (input.trim() && !isLoading) {
+      sendMessage(input.trim())
+      setInput(``)
+    }
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === `Enter` && !e.shiftKey) {
+      e.preventDefault()
+      if (input.trim() && !isLoading) {
+        sendMessage(input.trim())
+        setInput(``)
+      }
+    }
+  }
+
+  const handleRetry = () => {
+    reload()
+  }
+
+  return (
+    <div className="chat-container">
+      <header className="chat-header">
+        <button className="sidebar-toggle" onClick={onToggleSidebar}>
+          {sidebarOpen ? `\u2190` : `\u2192`}
+        </button>
+        <span>Chat</span>
+      </header>
+
+      <main className="chat-messages">
+        {messages.map((message, index) => (
+          <div
+            key={message.id}
+            className={`message ${message.role} ${
+              message.role === `assistant` &&
+              isLoading &&
+              index === messages.length - 1
+                ? `streaming`
+                : ``
+            }`}
+          >
+            {getMessageContent(message)}
+          </div>
+        ))}
+
+        {error && (
+          <div className="error-banner">
+            <span>Error: {error.message || `Something went wrong`}</span>
+            <button onClick={handleRetry}>Retry</button>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </main>
+
+      <form className="chat-composer" onSubmit={onSubmit}>
+        <textarea
+          ref={textareaRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Type a message..."
+          rows={1}
+        />
+        {isLoading ? (
+          <button type="button" className="stop" onClick={() => stop()}>
+            Stop
+          </button>
+        ) : (
+          <button type="submit" className="send" disabled={!input.trim()}>
+            Send
+          </button>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/examples/chat-tanstack/src/Sidebar.tsx
+++ b/examples/chat-tanstack/src/Sidebar.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from "@tanstack/react-router"
+import { createConversation, deleteConversation } from "./storage"
+import type { Conversation } from "./storage"
+
+interface SidebarProps {
+  conversations: Array<Conversation>
+  activeId: string | undefined
+  open: boolean
+  onConversationsChange: () => void
+}
+
+export function Sidebar({
+  conversations,
+  activeId,
+  open,
+  onConversationsChange,
+}: SidebarProps) {
+  const navigate = useNavigate()
+
+  const handleNew = () => {
+    const conversation = createConversation()
+    onConversationsChange()
+    navigate({ to: `/chat/$id`, params: { id: conversation.id } })
+  }
+
+  const handleDelete = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation()
+    deleteConversation(id)
+    onConversationsChange()
+    if (id === activeId) {
+      navigate({ to: `/` })
+    }
+  }
+
+  return (
+    <aside className={`sidebar ${open ? `open` : `closed`}`}>
+      <div className="sidebar-header">
+        <span className="sidebar-title">Conversations</span>
+        <button className="new-chat-btn" onClick={handleNew}>
+          + New
+        </button>
+      </div>
+      <div className="sidebar-list">
+        {conversations.map((conv) => (
+          <div
+            key={conv.id}
+            className={`sidebar-item ${conv.id === activeId ? `active` : ``}`}
+            onClick={() =>
+              navigate({ to: `/chat/$id`, params: { id: conv.id } })
+            }
+          >
+            <span className="sidebar-item-title">{conv.title}</span>
+            <button
+              className="delete-btn"
+              onClick={(e) => handleDelete(e, conv.id)}
+              aria-label="Delete conversation"
+            >
+              &times;
+            </button>
+          </div>
+        ))}
+        {conversations.length === 0 && (
+          <div className="sidebar-empty">No conversations yet</div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/examples/chat-tanstack/src/main.tsx
+++ b/examples/chat-tanstack/src/main.tsx
@@ -1,0 +1,173 @@
+import { StrictMode, useSyncExternalStore } from "react"
+import { createRoot } from "react-dom/client"
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router"
+import { Chat } from "./Chat"
+import { Sidebar } from "./Sidebar"
+import { createConversation, getConversations } from "./storage"
+import "./styles.css"
+
+// Simple pub/sub so Chat can notify the root layout when conversations change
+let listeners: Array<() => void> = []
+let conversationsSnapshot = getConversations()
+
+function subscribe(listener: () => void) {
+  listeners = [...listeners, listener]
+  return () => {
+    listeners = listeners.filter((l) => l !== listener)
+  }
+}
+
+function getSnapshot() {
+  return conversationsSnapshot
+}
+
+export function notifyConversationsChanged() {
+  conversationsSnapshot = getConversations()
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+// Sidebar state shared between root layout and child pages
+let sidebarOpen = true
+let sidebarListeners: Array<() => void> = []
+
+function subscribeSidebar(listener: () => void) {
+  sidebarListeners = [...sidebarListeners, listener]
+  return () => {
+    sidebarListeners = sidebarListeners.filter((l) => l !== listener)
+  }
+}
+
+function getSidebarSnapshot() {
+  return sidebarOpen
+}
+
+function toggleSidebar() {
+  sidebarOpen = !sidebarOpen
+  for (const listener of sidebarListeners) {
+    listener()
+  }
+}
+
+function RootLayout() {
+  const conversations = useSyncExternalStore(subscribe, getSnapshot)
+  const isSidebarOpen = useSyncExternalStore(
+    subscribeSidebar,
+    getSidebarSnapshot
+  )
+
+  // Extract active conversation ID from router state
+  const location = useRouterState({ select: (s) => s.location })
+  const match = location.pathname.match(/^\/chat\/(.+)$/)
+  const activeId = match ? match[1] : undefined
+
+  return (
+    <div className="app-layout">
+      <Sidebar
+        conversations={conversations}
+        activeId={activeId}
+        open={isSidebarOpen}
+        onConversationsChange={notifyConversationsChanged}
+      />
+      <Outlet />
+    </div>
+  )
+}
+
+function WelcomePage() {
+  const navigate = useNavigate()
+  const isSidebarOpen = useSyncExternalStore(
+    subscribeSidebar,
+    getSidebarSnapshot
+  )
+
+  const handleNewChat = () => {
+    const conversation = createConversation()
+    notifyConversationsChanged()
+    navigate({ to: `/chat/$id`, params: { id: conversation.id } })
+  }
+
+  return (
+    <div className="chat-container">
+      <header className="chat-header">
+        <button className="sidebar-toggle" onClick={toggleSidebar}>
+          {isSidebarOpen ? `\u2190` : `\u2192`}
+        </button>
+        <span>Chat</span>
+      </header>
+      <main className="chat-messages">
+        <div className="empty-state">
+          <button className="new-chat-btn primary" onClick={handleNewChat}>
+            Start a new conversation
+          </button>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function ChatPage() {
+  const { id } = chatRoute.useParams()
+  const navigate = useNavigate()
+  const conversations = useSyncExternalStore(subscribe, getSnapshot)
+  const isSidebarOpen = useSyncExternalStore(
+    subscribeSidebar,
+    getSidebarSnapshot
+  )
+
+  if (!conversations.some((c) => c.id === id)) {
+    navigate({ to: `/` })
+    return null
+  }
+
+  return (
+    <Chat
+      key={id}
+      conversationId={id}
+      sidebarOpen={isSidebarOpen}
+      onToggleSidebar={toggleSidebar}
+      onMessagesChange={notifyConversationsChanged}
+    />
+  )
+}
+
+const rootRoute = createRootRoute({
+  component: RootLayout,
+})
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: `/`,
+  component: WelcomePage,
+})
+
+const chatRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: `/chat/$id`,
+  component: ChatPage,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, chatRoute])
+
+const router = createRouter({ routeTree })
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router
+  }
+}
+
+createRoot(document.getElementById(`root`)!).render(
+  <StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>
+)

--- a/examples/chat-tanstack/src/storage.ts
+++ b/examples/chat-tanstack/src/storage.ts
@@ -1,0 +1,92 @@
+import type { UIMessage } from "@tanstack/ai-react"
+
+const CONVERSATIONS_KEY = `chat-conversations`
+const MESSAGES_PREFIX = `chat-messages-`
+
+export interface Conversation {
+  id: string
+  title: string
+  createdAt: number
+  updatedAt: number
+}
+
+export function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+}
+
+export function getConversations(): Array<Conversation> {
+  const raw = localStorage.getItem(CONVERSATIONS_KEY)
+  if (!raw) return []
+  try {
+    const conversations: Array<Conversation> = JSON.parse(raw)
+    return conversations.sort((a, b) => b.updatedAt - a.updatedAt)
+  } catch {
+    return []
+  }
+}
+
+function saveConversations(conversations: Array<Conversation>) {
+  localStorage.setItem(CONVERSATIONS_KEY, JSON.stringify(conversations))
+}
+
+export function createConversation(): Conversation {
+  const conversation: Conversation = {
+    id: generateId(),
+    title: `New chat`,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+  const conversations = getConversations()
+  conversations.unshift(conversation)
+  saveConversations(conversations)
+  return conversation
+}
+
+export function deleteConversation(id: string) {
+  const conversations = getConversations().filter((c) => c.id !== id)
+  saveConversations(conversations)
+  localStorage.removeItem(MESSAGES_PREFIX + id)
+}
+
+export function getMessages(conversationId: string): Array<UIMessage> {
+  const raw = localStorage.getItem(MESSAGES_PREFIX + conversationId)
+  if (!raw) return []
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return []
+  }
+}
+
+export function saveMessages(
+  conversationId: string,
+  messages: Array<UIMessage>
+) {
+  localStorage.setItem(
+    MESSAGES_PREFIX + conversationId,
+    JSON.stringify(messages)
+  )
+
+  // Update conversation title and timestamp
+  const conversations = getConversations()
+  const conversation = conversations.find((c) => c.id === conversationId)
+  if (conversation) {
+    conversation.updatedAt = Date.now()
+    if (conversation.title === `New chat` && messages.length > 0) {
+      const firstUserMessage = messages.find((m) => m.role === `user`)
+      if (firstUserMessage) {
+        const text = firstUserMessage.parts
+          .filter(
+            (p): p is { type: `text`; content: string } => p.type === `text`
+          )
+          .map((p) => p.content)
+          .join(``)
+        if (text) {
+          conversation.title =
+            text.length > 50 ? text.slice(0, 50) + `...` : text
+        }
+      }
+    }
+    saveConversations(conversations)
+  }
+}

--- a/examples/chat-tanstack/src/styles.css
+++ b/examples/chat-tanstack/src/styles.css
@@ -1,0 +1,316 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  min-height: 100vh;
+}
+
+.app-layout {
+  display: flex;
+  height: 100vh;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 280px;
+  background: #fafafa;
+  border-right: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.sidebar.closed {
+  width: 0;
+  border-right: none;
+}
+
+.sidebar-header {
+  padding: 16px;
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sidebar-title {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.new-chat-btn {
+  background: #007aff;
+  color: white;
+  border: none;
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.new-chat-btn:hover {
+  background: #0056b3;
+}
+
+.sidebar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.sidebar-item {
+  display: flex;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: none;
+  background: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #333;
+  align-items: center;
+  gap: 8px;
+}
+
+.sidebar-item:hover {
+  background: #e9e9eb;
+}
+
+.sidebar-item.active {
+  background: #007aff;
+  color: white;
+}
+
+.sidebar-item-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: #999;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.sidebar-item:hover .delete-btn {
+  opacity: 1;
+}
+
+.sidebar-item.active .delete-btn {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.sidebar-item.active .delete-btn:hover {
+  color: white;
+}
+
+.delete-btn:hover {
+  color: #dc2626;
+}
+
+.sidebar-empty {
+  padding: 20px 12px;
+  color: #999;
+  font-size: 14px;
+  text-align: center;
+}
+
+/* Chat */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100vh;
+  max-width: 800px;
+  margin: 0 auto;
+  background: white;
+}
+
+.chat-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #e0e0e0;
+  font-size: 20px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebar-toggle {
+  background: none;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 16px;
+  color: #666;
+}
+
+.sidebar-toggle:hover {
+  background: #f0f0f0;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: #999;
+  font-size: 16px;
+}
+
+.new-chat-btn.primary {
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 16px;
+}
+
+.message {
+  max-width: 70%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: #007aff;
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+
+.message.assistant {
+  align-self: flex-start;
+  background: #e9e9eb;
+  color: #333;
+  border-bottom-left-radius: 4px;
+}
+
+.message.streaming {
+  position: relative;
+}
+
+.message.streaming::after {
+  content: '\25CB';
+  animation: blink 1s infinite;
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.error-banner {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  color: #dc2626;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.error-banner button {
+  background: #dc2626;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.error-banner button:hover {
+  background: #b91c1c;
+}
+
+.chat-composer {
+  padding: 16px 20px;
+  border-top: 1px solid #e0e0e0;
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.chat-composer textarea {
+  flex: 1;
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 16px;
+  font-family: inherit;
+  resize: none;
+  min-height: 44px;
+  max-height: 120px;
+  line-height: 1.4;
+}
+
+.chat-composer textarea:focus {
+  outline: none;
+  border-color: #007aff;
+}
+
+.chat-composer button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.2s;
+}
+
+.chat-composer button.send {
+  background: #007aff;
+  color: white;
+}
+
+.chat-composer button.send:hover:not(:disabled) {
+  background: #0056b3;
+}
+
+.chat-composer button.send:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.chat-composer button.stop {
+  background: #dc2626;
+  color: white;
+}
+
+.chat-composer button.stop:hover {
+  background: #b91c1c;
+}

--- a/examples/chat-tanstack/tsconfig.json
+++ b/examples/chat-tanstack/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node", "vite/client"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "server"]
+}

--- a/examples/chat-tanstack/vite.config.ts
+++ b/examples/chat-tanstack/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3002',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,58 @@ importers:
         specifier: ^4.0.0
         version: 4.0.17(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  examples/chat-tanstack:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.40.0
+        version: 0.40.1
+      '@durable-streams/proxy':
+        specifier: workspace:*
+        version: link:../../packages/proxy
+      '@durable-streams/server':
+        specifier: workspace:*
+        version: link:../../packages/server
+      '@tanstack/ai-react':
+        specifier: ^0.2.0
+        version: 0.2.2(@tanstack/ai@0.2.2)(@types/react@19.2.9)(react@19.2.3)
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.154.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.7
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.9
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.9)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      concurrently:
+        specifier: ^9.0.0
+        version: 9.2.1
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
   examples/state:
     dependencies:
       '@durable-streams/client':
@@ -466,6 +518,9 @@ importers:
         version: 13.6.29
 
 packages:
+
+  '@anthropic-ai/sdk@0.40.1':
+    resolution: {integrity: sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==}
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -1390,6 +1445,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -1598,6 +1656,20 @@ packages:
     resolution: {integrity: sha512-08eKiDAjj4zLug1taXSIJ0kGL5cawjVCyJkBb6EWSg5fEPX6L+Wtr0CH2If4j5KYylz85iaZiFlUItvgJvll5g==}
     engines: {node: ^14.13.1 || ^16.0.0 || >=18}
 
+  '@tanstack/ai-client@0.2.2':
+    resolution: {integrity: sha512-7WVYzMas6ACtt4NMGqnduWbKwDr1syYrmgQoy+hw3Iu5lEEIqdI/tG4koJJROtOM7ogUjKQBpIgsX4Tej+fPWA==}
+
+  '@tanstack/ai-react@0.2.2':
+    resolution: {integrity: sha512-CNSOOoAUjre5lQxbQVqsXIJEJsTEdyPfyuvAFtgBGvbAJAVn5+6AZyOJzZZz1YKO3F05yD4hMkygelvoSPTUJA==}
+    peerDependencies:
+      '@tanstack/ai': ^0.2.2
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+
+  '@tanstack/ai@0.2.2':
+    resolution: {integrity: sha512-qqnUSKYMuJnGhiL6t8BAu3Joc9QhQTJIxUIWgQlObDhdY+dCJMLyv+Z7Zw+WqzCCjDfvWmHgLNWDI8+f3KkOPw==}
+    engines: {node: '>=18'}
+
   '@tanstack/config@0.22.2':
     resolution: {integrity: sha512-zP1b6xd864AOOJQ7u6r+kicohRc8dAyql6sBbQh2f2RjoEynAfn0GrMHGeqhl1LN8JThokCkcjfGnXbPEz3q3A==}
     engines: {node: '>=18'}
@@ -1612,6 +1684,10 @@ packages:
     resolution: {integrity: sha512-Qh33d9Idw7lEa/sg7veJfG8EUmSMtBzRkk/ghAVIDA3MJWAjyGOzU29TVZaM7K36BegTL8T/yVVlAFqjn/G2pw==}
     peerDependencies:
       typescript: '>=4.7'
+
+  '@tanstack/devtools-event-client@0.4.0':
+    resolution: {integrity: sha512-RPfGuk2bDZgcu9bAJodvO2lnZeHuz4/71HjZ0bGb/SPg8+lyTA+RLSKQvo7fSmPSi8/vcH3aKQ8EM9ywf1olaw==}
+    engines: {node: '>=18'}
 
   '@tanstack/eslint-config@0.3.3':
     resolution: {integrity: sha512-8VFyAaIFV9onJcfc5yVj5WWl6DmN3W4m+t0Mb+nZrQmqHy+kDndw5O5Xv2BHVWRRPTqnhlJYh6wHWGh0R81ZzQ==}
@@ -1779,8 +1855,14 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
@@ -1955,6 +2037,12 @@ packages:
     peerDependencies:
       valibot: ^1.0.0
 
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2061,6 +2149,10 @@ packages:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2070,6 +2162,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -2163,6 +2259,9 @@ packages:
   ast-v8-to-istanbul@0.3.10:
     resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
@@ -2217,6 +2316,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -2267,6 +2370,10 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2283,6 +2390,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -2303,6 +2414,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2364,6 +2480,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2392,15 +2512,26 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
   dts-resolver@1.2.0:
     resolution: {integrity: sha512-+xNF7raXYI1E3IFB+f3JqvoKYFI8R+1Mh9mpI75yNm3F5XuiC6ErEXe2Lqh9ach+4MQ1tOefzjxulhWGVclYbg==}
     engines: {node: '>=20.18.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   empathic@1.1.0:
     resolution: {integrity: sha512-rsPft6CK3eHtrlp9Y5ALBb+hfK+DWnA4WFebbazxjWyx8vSm3rZeoM3z9irsjcqO3PYRzlfv27XIB4tz2DV7RA==}
@@ -2430,8 +2561,24 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2585,6 +2732,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -2668,6 +2819,17 @@ packages:
     peerDependencies:
       react: ^15.0.2 || ^16.0.0 || ^17.0.0
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
   fractional-indexing@3.2.0:
     resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -2692,9 +2854,21 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -2735,12 +2909,24 @@ packages:
     peerDependencies:
       csstype: ^3.0.10
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -2766,6 +2952,9 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2810,6 +2999,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
@@ -3093,6 +3286,10 @@ packages:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -3114,6 +3311,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -3172,6 +3377,10 @@ packages:
 
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -3266,6 +3475,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -3384,6 +3596,10 @@ packages:
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -3413,6 +3629,10 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3477,6 +3697,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -3527,6 +3750,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3596,6 +3823,10 @@ packages:
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -3701,6 +3932,10 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -3797,6 +4032,9 @@ packages:
 
   unconfig@7.4.2:
     resolution: {integrity: sha512-nrMlWRQ1xdTjSnSUqvYqJzbTBFugoqHobQj58B2bc8qxHKBBHMNNsWQFP3Cd3/JZK907voM2geYPWqD4VK3MPQ==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4072,6 +4310,10 @@ packages:
   weak-lru-cache@1.2.2:
     resolution: {integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==}
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -4095,6 +4337,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -4112,6 +4358,10 @@ packages:
     peerDependencies:
       yjs: ^13.0.0
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -4122,6 +4372,14 @@ packages:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yjs@13.6.29:
     resolution: {integrity: sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==}
@@ -4135,6 +4393,18 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.40.1':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -4995,6 +5265,8 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.151352b':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.55.3)':
@@ -5179,6 +5451,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@tanstack/ai-client@0.2.2':
+    dependencies:
+      '@tanstack/ai': 0.2.2
+
+  '@tanstack/ai-react@0.2.2(@tanstack/ai@0.2.2)(@types/react@19.2.9)(react@19.2.3)':
+    dependencies:
+      '@tanstack/ai': 0.2.2
+      '@tanstack/ai-client': 0.2.2
+      '@types/react': 19.2.9
+      react: 19.2.3
+
+  '@tanstack/ai@0.2.2':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.0
+      partial-json: 0.1.7
+
   '@tanstack/config@0.22.2(@types/node@22.19.7)(@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tanstack/eslint-config': 0.3.3(@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -5207,6 +5495,8 @@ snapshots:
       '@tanstack/db-ivm': 0.1.17(typescript@5.9.3)
       '@tanstack/pacer-lite': 0.2.1
       typescript: 5.9.3
+
+  '@tanstack/devtools-event-client@0.4.0': {}
 
   '@tanstack/eslint-config@0.3.3(@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5442,7 +5732,16 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.7
+      form-data: 4.0.5
+
   '@types/node@12.20.55': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@22.19.7':
     dependencies:
@@ -5612,6 +5911,18 @@ snapshots:
     dependencies:
       valibot: 1.0.0(typescript@5.9.3)
 
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.6)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.6
@@ -5769,11 +6080,19 @@ snapshots:
       jsonparse: 1.3.1
       through: 2.3.8
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
@@ -5858,6 +6177,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
+  asynckit@0.4.0: {}
+
   babel-dead-code-elimination@1.0.12:
     dependencies:
       '@babel/core': 7.28.6
@@ -5918,6 +6239,11 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001765: {}
@@ -5970,6 +6296,12 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
 
   codemirror@6.0.2:
@@ -5990,6 +6322,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@13.1.0: {}
 
   comment-parser@1.4.4: {}
@@ -6004,6 +6340,15 @@ snapshots:
   computeds@0.0.1: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confbox@0.1.8: {}
 
@@ -6054,6 +6399,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -6072,14 +6419,24 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.2.3: {}
+
   dts-resolver@1.2.0:
     dependencies:
       oxc-resolver: 9.0.2
       pathe: 2.0.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.267: {}
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
 
   empathic@1.1.0: {}
 
@@ -6101,7 +6458,22 @@ snapshots:
 
   environment@1.1.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -6328,6 +6700,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.4: {}
 
   execa@8.0.1:
@@ -6427,6 +6801,21 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
   fractional-indexing@3.2.0: {}
 
   fs-extra@7.0.1:
@@ -6448,7 +6837,27 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.4.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@8.0.1: {}
 
@@ -6485,9 +6894,17 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -6504,6 +6921,10 @@ snapshots:
   human-id@4.1.3: {}
 
   human-signals@5.0.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -6537,6 +6958,8 @@ snapshots:
       hasown: 2.0.2
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@4.0.0: {}
 
@@ -6806,6 +7229,8 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  math-intrinsics@1.1.0: {}
+
   mdurl@2.0.0: {}
 
   meow@12.1.1: {}
@@ -6822,6 +7247,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-fn@4.0.0: {}
 
@@ -6879,6 +7310,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-addon-api@6.1.0: {}
+
+  node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -6986,6 +7419,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  partial-json@0.1.7: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -7078,6 +7513,8 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
+  react-refresh@0.17.0: {}
+
   react-refresh@0.18.0: {}
 
   react-textarea-autosize@8.5.9(@types/react@19.2.9)(react@19.2.3):
@@ -7111,6 +7548,8 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -7214,6 +7653,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
@@ -7245,6 +7688,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   siginfo@2.0.0: {}
 
@@ -7309,6 +7754,12 @@ snapshots:
   std-env@3.10.0: {}
 
   string-argv@0.3.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string-width@7.2.0:
     dependencies:
@@ -7386,6 +7837,8 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -7486,6 +7939,8 @@ snapshots:
       jiti: 2.6.1
       quansync: 1.0.0
       unconfig-core: 7.4.2
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -7786,6 +8241,8 @@ snapshots:
 
   weak-lru-cache@1.2.2: {}
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
   webidl-conversions@3.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -7806,6 +8263,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -7824,11 +8287,25 @@ snapshots:
       lib0: 0.2.117
       yjs: 13.6.29
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 
   yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yjs@13.6.29:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a TanStack AI chat example app that routes streaming responses through the durable proxy for resumable AI streaming. Also rewrites the `@durable-streams/proxy` TanStack transport to match the actual `@tanstack/ai-client` `ConnectionAdapter` interface.

**Status: WIP** — proxy forwarding works, but stream closure errors and stream resume are not yet working correctly.

## Reviewer Guidance

### Approach

The integration has three parts:

1. **Fixed TanStack transport** (`packages/proxy/src/transports/tanstack.ts`): The existing adapter used a custom `ConnectionAdapter` interface (`connect(options) → Promise<{stream, headers, status}>`) that didn't match TanStack's actual interface (`async *connect(messages, data?, abortSignal?) → AsyncIterable<StreamChunk>`). Rewrote it as an async generator that uses `durableFetch` for the two-phase POST→GET flow, then parses SSE from the response body into individual JSON chunks.

2. **Durable proxy startup script** (`examples/chat-tanstack/server/durable-proxy.ts`): Starts both the DS storage server (port 4437) and the proxy server (port 4440) with an allowlist for `localhost:3002`.

3. **Chat app wiring** (`examples/chat-tanstack/src/Chat.tsx`): Replaced `fetchServerSentEvents('/api/chat')` with `createDurableAdapter(...)`. Stream keys are scoped per conversation turn (`{conversationId}-turn-{messageCount}`).

**Architecture flow:**
```
Browser → Durable Proxy (:4440) → Chat Server (:3002) → Anthropic API
                ↕
     DS Storage Server (:4437)
```

### Known Issues

- **Stream closure fails with error**: After the upstream finishes, the stream does not close cleanly. Needs investigation into how the proxy signals stream completion and how the client detects it.
- **Stream resume not working**: On page refresh, `durableFetch` should detect stored credentials and reconnect via GET with the last known offset, but this path isn't functioning correctly yet.

### Non-goals

- No changes to the Vercel AI transport (only TanStack)
- No new tests yet (WIP)
- No production deployment config

### Trade-offs

- Used `as any` cast for the connection adapter type since `@durable-streams/proxy` doesn't depend on `@tanstack/ai` — avoids adding a peer dependency for now
- The example sends raw `UIMessage` format to the server (not `ModelMessage`), which works because the server's `convertMessagesToAnthropic` handles both formats

## Verification

```bash
cd examples/chat-tanstack
pnpm install
cp .env.example .env  # then set ANTHROPIC_API_KEY
pnpm dev              # starts all 3 servers + Vite client
```

## Files changed

| File | Description |
|------|-------------|
| `packages/proxy/src/transports/tanstack.ts` | Rewrote adapter to match TanStack's `ConnectionAdapter` async generator interface; added SSE parsing |
| `examples/chat-tanstack/package.json` | New workspace example with deps on proxy, server, TanStack AI |
| `examples/chat-tanstack/server/durable-proxy.ts` | Script that starts DS server + proxy server |
| `examples/chat-tanstack/server/index.ts` | Chat server (copied from original app, unchanged) |
| `examples/chat-tanstack/src/Chat.tsx` | Uses `createDurableAdapter` instead of `fetchServerSentEvents` |
| `examples/chat-tanstack/src/*` | Other UI files copied from original app |
| `pnpm-lock.yaml` | Updated lockfile for new example deps |