### PR TITLE
Fix vitest config resolution for npx and bundled package

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default [
       `**/.output/**`,
       `**/coverage/**`,
       `eslint.config.js`,
-      `vitest.config.ts`,
+      `**/vitest.config.ts`,
       `**/vite.config.ts`,
       `**/tsdown.config.ts`,
       `**/tsup.config.ts`,

--- a/packages/server-conformance-tests/src/vitest.config.ts
+++ b/packages/server-conformance-tests/src/vitest.config.ts
@@ -1,0 +1,43 @@
+/**
+ * Vitest configuration for the conformance test runner.
+ *
+ * This config is bundled with the package and used when running via npx.
+ * It ensures tests run in isolation without discovering or executing
+ * the caller's tests.
+ */
+
+import { defineConfig } from "vitest/config"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+// Config is in src/, package root is one level up
+const packageRoot = join(__dirname, "..")
+
+export default defineConfig({
+  test: {
+    // Only run the test-runner file, not any tests from the caller's project
+    // Include both src (development) and dist (production) locations
+    include: [
+      join(packageRoot, "src", "test-runner.ts"),
+      join(packageRoot, "dist", "test-runner.js"),
+    ],
+    // Exclude everything else
+    exclude: ["**/node_modules/**"],
+    // Don't look for workspace configs or extend parent configs
+    passWithNoTests: false,
+    // Use a reasonable timeout for network tests
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    // Don't collect coverage
+    coverage: {
+      enabled: false,
+    },
+    // Use default reporter for clear output
+    reporters: ["default"],
+    // Disable watch mode by default (CLI handles this)
+    watch: false,
+  },
+  // Set the root to this package's directory
+  root: packageRoot,
+})

--- a/packages/server-conformance-tests/tsconfig.json
+++ b/packages/server-conformance-tests/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*", "test/**/*", "*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.config.ts"]
 }


### PR DESCRIPTION
## Summary
This PR fixes vitest configuration resolution when the conformance test package is run via `npx` or installed as a dependency. It adds an explicit vitest config file and improves the binary/config path resolution logic to handle various installation scenarios.

## Key Changes
- **Added `vitest.config.ts`**: New configuration file in `src/` that's bundled with the package. It ensures only the test-runner is executed, preventing discovery of the caller's tests.
- **Improved path resolution**: Refactored `findVitestBinary()` to use a new `getPackageRoot()` helper and updated path logic to handle npx cache structures and hoisted dependencies.
- **Added config path resolution**: New `getVitestConfigPath()` function that locates the bundled vitest config with fallback for development scenarios.
- **Updated CLI invocation**: Modified `runTests()` and `runWatch()` to explicitly pass `--config` and `--root` arguments to vitest.
- **Updated ESLint config**: Changed `vitest.config.ts` pattern from exact match to `**/vitest.config.ts` glob to exclude all vitest configs.
- **Updated TypeScript config**: Added `**/*.config.ts` to exclude list to prevent config files from being compiled.

## Implementation Details
The vitest config uses explicit `include` patterns to only run the bundled test-runner file (in both `src/` for development and `dist/` for production), with `exclude` patterns to prevent test discovery in the caller's project. The path resolution logic now accounts for multiple installation scenarios: direct package node_modules, npx cache structure, hoisted monorepo dependencies, and development from source.

https://claude.ai/code/session_01TqnFDkizwLQySEStKMkEMr