### PR TITLE
feat: split up protocol files a bit more, depend on node apis for modular exports

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,6 +33,126 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./handler": {
+      "import": {
+        "types": "./dist/handler.d.ts",
+        "default": "./dist/handler.js"
+      },
+      "require": {
+        "types": "./dist/handler.d.cts",
+        "default": "./dist/handler.cjs"
+      }
+    },
+    "./types": {
+      "import": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/types.js"
+      },
+      "require": {
+        "types": "./dist/types.d.cts",
+        "default": "./dist/types.cjs"
+      }
+    },
+    "./errors": {
+      "import": {
+        "types": "./dist/errors.d.ts",
+        "default": "./dist/errors.js"
+      },
+      "require": {
+        "types": "./dist/errors.d.cts",
+        "default": "./dist/errors.cjs"
+      }
+    },
+    "./constants": {
+      "import": {
+        "types": "./dist/constants.d.ts",
+        "default": "./dist/constants.js"
+      },
+      "require": {
+        "types": "./dist/constants.d.cts",
+        "default": "./dist/constants.cjs"
+      }
+    },
+    "./offsets": {
+      "import": {
+        "types": "./dist/offsets.d.ts",
+        "default": "./dist/offsets.js"
+      },
+      "require": {
+        "types": "./dist/offsets.d.cts",
+        "default": "./dist/offsets.cjs"
+      }
+    },
+    "./cursor": {
+      "import": {
+        "types": "./dist/cursor.d.ts",
+        "default": "./dist/cursor.js"
+      },
+      "require": {
+        "types": "./dist/cursor.d.cts",
+        "default": "./dist/cursor.cjs"
+      }
+    },
+    "./protocol": {
+      "import": {
+        "types": "./dist/protocol.d.ts",
+        "default": "./dist/protocol.js"
+      },
+      "require": {
+        "types": "./dist/protocol.d.cts",
+        "default": "./dist/protocol.cjs"
+      }
+    },
+    "./path": {
+      "import": {
+        "types": "./dist/path.d.ts",
+        "default": "./dist/path.js"
+      },
+      "require": {
+        "types": "./dist/path.d.cts",
+        "default": "./dist/path.cjs"
+      }
+    },
+    "./registry": {
+      "import": {
+        "types": "./dist/registry-hook.d.ts",
+        "default": "./dist/registry-hook.js"
+      },
+      "require": {
+        "types": "./dist/registry-hook.d.cts",
+        "default": "./dist/registry-hook.cjs"
+      }
+    },
+    "./storage/memory": {
+      "import": {
+        "types": "./dist/storage/memory.d.ts",
+        "default": "./dist/storage/memory.js"
+      },
+      "require": {
+        "types": "./dist/storage/memory.d.cts",
+        "default": "./dist/storage/memory.cjs"
+      }
+    },
+    "./storage/file": {
+      "import": {
+        "types": "./dist/file-store.d.ts",
+        "default": "./dist/file-store.js"
+      },
+      "require": {
+        "types": "./dist/file-store.d.cts",
+        "default": "./dist/file-store.cjs"
+      }
+    },
+    "./node/server": {
+      "import": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      },
+      "require": {
+        "types": "./dist/server.d.cts",
+        "default": "./dist/server.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -1,0 +1,28 @@
+export const STREAM_OFFSET_HEADER = `Stream-Next-Offset`
+export const STREAM_CURSOR_HEADER = `Stream-Cursor`
+export const STREAM_UP_TO_DATE_HEADER = `Stream-Up-To-Date`
+export const STREAM_SEQ_HEADER = `Stream-Seq`
+export const STREAM_TTL_HEADER = `Stream-TTL`
+export const STREAM_EXPIRES_AT_HEADER = `Stream-Expires-At`
+export const STREAM_SSE_DATA_ENCODING_HEADER = `Stream-SSE-Data-Encoding`
+export const STREAM_CLOSED_HEADER = `Stream-Closed`
+
+export const PRODUCER_ID_HEADER = `Producer-Id`
+export const PRODUCER_EPOCH_HEADER = `Producer-Epoch`
+export const PRODUCER_SEQ_HEADER = `Producer-Seq`
+export const PRODUCER_EXPECTED_SEQ_HEADER = `Producer-Expected-Seq`
+export const PRODUCER_RECEIVED_SEQ_HEADER = `Producer-Received-Seq`
+
+export const SSE_OFFSET_FIELD = `streamNextOffset`
+export const SSE_CURSOR_FIELD = `streamCursor`
+export const SSE_UP_TO_DATE_FIELD = `upToDate`
+export const SSE_CLOSED_FIELD = `streamClosed`
+
+export const OFFSET_QUERY_PARAM = `offset`
+export const LIVE_QUERY_PARAM = `live`
+export const CURSOR_QUERY_PARAM = `cursor`
+
+export const SSE_COMPATIBLE_CONTENT_TYPES: ReadonlyArray<string> = [
+  `text/`,
+  `application/json`,
+]

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -1,0 +1,90 @@
+export class StreamNotFoundError extends Error {
+  readonly _tag = `StreamNotFoundError` as const
+  readonly path: string
+
+  constructor(path: string) {
+    super(`Stream not found: ${path}`)
+    this.name = `StreamNotFoundError`
+    this.path = path
+  }
+}
+
+export class StreamConflictError extends Error {
+  readonly _tag = `StreamConflictError` as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = `StreamConflictError`
+  }
+}
+
+export class SequenceConflictError extends Error {
+  readonly _tag = `SequenceConflictError` as const
+  readonly expected: string
+  readonly received: string
+
+  constructor(expected: string, received: string) {
+    super(`Sequence conflict: expected ${expected}, received ${received}`)
+    this.name = `SequenceConflictError`
+    this.expected = expected
+    this.received = received
+  }
+}
+
+export class ContentTypeMismatchError extends Error {
+  readonly _tag = `ContentTypeMismatchError` as const
+  readonly expected: string
+  readonly received: string
+
+  constructor(expected: string, received: string) {
+    super(`Content-Type mismatch: expected ${expected}, received ${received}`)
+    this.name = `ContentTypeMismatchError`
+    this.expected = expected
+    this.received = received
+  }
+}
+
+export class InvalidJsonError extends Error {
+  readonly _tag = `InvalidJsonError` as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = `InvalidJsonError`
+  }
+}
+
+export class InvalidOffsetError extends Error {
+  readonly _tag = `InvalidOffsetError` as const
+
+  constructor(offset: string) {
+    super(`Invalid offset format: ${offset}`)
+    this.name = `InvalidOffsetError`
+    this.offset = offset
+  }
+
+  readonly offset: string
+}
+
+export class PayloadTooLargeError extends Error {
+  readonly _tag = `PayloadTooLargeError` as const
+  readonly maxBytes: number
+  readonly receivedBytes: number
+
+  constructor(maxBytes: number, receivedBytes: number) {
+    super(
+      `Payload too large: max ${maxBytes} bytes, received ${receivedBytes} bytes`
+    )
+    this.name = `PayloadTooLargeError`
+    this.maxBytes = maxBytes
+    this.receivedBytes = receivedBytes
+  }
+}
+
+export type StreamError =
+  | StreamNotFoundError
+  | StreamConflictError
+  | SequenceConflictError
+  | ContentTypeMismatchError
+  | InvalidJsonError
+  | InvalidOffsetError
+  | PayloadTooLargeError

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -1,0 +1,1298 @@
+/**
+ * Runtime-agnostic HTTP handler for durable streams.
+ * Uses Web Standard APIs (Request/Response/ReadableStream) so it works
+ * on Node.js, Cloudflare Workers, Deno, Bun, and other runtimes.
+ *
+ * No `node:*` imports allowed in this file.
+ */
+
+import {
+  CURSOR_QUERY_PARAM,
+  LIVE_QUERY_PARAM,
+  OFFSET_QUERY_PARAM,
+  PRODUCER_EPOCH_HEADER,
+  PRODUCER_EXPECTED_SEQ_HEADER,
+  PRODUCER_ID_HEADER,
+  PRODUCER_RECEIVED_SEQ_HEADER,
+  PRODUCER_SEQ_HEADER,
+  SSE_CLOSED_FIELD,
+  SSE_CURSOR_FIELD,
+  SSE_OFFSET_FIELD,
+  SSE_UP_TO_DATE_FIELD,
+  STREAM_CLOSED_HEADER,
+  STREAM_CURSOR_HEADER,
+  STREAM_EXPIRES_AT_HEADER,
+  STREAM_OFFSET_HEADER,
+  STREAM_SEQ_HEADER,
+  STREAM_SSE_DATA_ENCODING_HEADER,
+  STREAM_TTL_HEADER,
+  STREAM_UP_TO_DATE_HEADER,
+} from "./constants"
+import { generateResponseCursor } from "./cursor"
+import {
+  ContentTypeMismatchError,
+  InvalidJsonError,
+  PayloadTooLargeError,
+  SequenceConflictError,
+  StreamConflictError,
+  StreamNotFoundError,
+} from "./errors"
+import type { CursorOptions } from "./cursor"
+import type {
+  AppendOptions,
+  DurableStreamStore,
+  StreamLifecycleEvent,
+} from "./types"
+
+function encodeSSEData(payload: string): string {
+  const lines = payload.split(/\r\n|\r|\n/)
+  return lines.map((line) => `data:${line}`).join(`\n`) + `\n\n`
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = ``
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+function stringToBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str)
+  return uint8ArrayToBase64(bytes)
+}
+
+export interface InjectedFault {
+  status?: number
+  count: number
+  retryAfter?: number
+  delayMs?: number
+  dropConnection?: boolean
+  truncateBodyBytes?: number
+  probability?: number
+  method?: string
+  corruptBody?: boolean
+  jitterMs?: number
+  injectSseEvent?: {
+    eventType: string
+    data: string
+  }
+}
+
+export interface FetchHandlerOptions {
+  store: DurableStreamStore
+  longPollTimeout?: number
+  baseUrl?: string
+  onStreamCreated?: (event: StreamLifecycleEvent) => void | Promise<void>
+  onStreamDeleted?: (event: StreamLifecycleEvent) => void | Promise<void>
+  cursorOptions?: CursorOptions
+}
+
+export class DurableStreamHandler {
+  readonly store: DurableStreamStore
+  options: {
+    longPollTimeout: number
+    baseUrl: string
+    onStreamCreated?: (event: StreamLifecycleEvent) => void | Promise<void>
+    onStreamDeleted?: (event: StreamLifecycleEvent) => void | Promise<void>
+    cursorOptions: CursorOptions
+  }
+  private injectedFaults = new Map<string, InjectedFault>()
+  private _isShuttingDown = false
+
+  private get isShuttingDown(): boolean {
+    return this._isShuttingDown
+  }
+
+  constructor(options: FetchHandlerOptions) {
+    this.store = options.store
+    this.options = {
+      longPollTimeout: options.longPollTimeout ?? 30_000,
+      baseUrl: options.baseUrl ?? ``,
+      onStreamCreated: options.onStreamCreated,
+      onStreamDeleted: options.onStreamDeleted,
+      cursorOptions: options.cursorOptions ?? {},
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this._isShuttingDown = true
+    if (`cancelAllWaits` in this.store) {
+      await this.store.cancelAllWaits()
+    }
+  }
+
+  resetShutdown(): void {
+    this._isShuttingDown = false
+  }
+
+  injectFault(
+    path: string,
+    fault: Omit<InjectedFault, `count`> & { count?: number }
+  ): void {
+    this.injectedFaults.set(path, { count: 1, ...fault })
+  }
+
+  clearInjectedFaults(): void {
+    this.injectedFaults.clear()
+  }
+
+  private consumeInjectedFault(
+    path: string,
+    method: string
+  ): InjectedFault | null {
+    const fault = this.injectedFaults.get(path)
+    if (!fault) return null
+
+    if (fault.method && fault.method.toUpperCase() !== method.toUpperCase()) {
+      return null
+    }
+
+    if (fault.probability !== undefined && Math.random() > fault.probability) {
+      return null
+    }
+
+    fault.count--
+    if (fault.count <= 0) {
+      this.injectedFaults.delete(path)
+    }
+
+    return fault
+  }
+
+  private async applyFaultDelay(fault: InjectedFault): Promise<void> {
+    if (fault.delayMs !== undefined && fault.delayMs > 0) {
+      const jitter = fault.jitterMs ? Math.random() * fault.jitterMs : 0
+      await new Promise((resolve) =>
+        setTimeout(resolve, fault.delayMs! + jitter)
+      )
+    }
+  }
+
+  private applyFaultBodyModification(
+    body: Uint8Array,
+    fault: InjectedFault | null
+  ): Uint8Array {
+    if (!fault) return body
+
+    let modified = body
+
+    if (
+      fault.truncateBodyBytes !== undefined &&
+      modified.length > fault.truncateBodyBytes
+    ) {
+      modified = modified.slice(0, fault.truncateBodyBytes)
+    }
+
+    if (fault.corruptBody && modified.length > 0) {
+      modified = new Uint8Array(modified)
+      modified[0] = 0x58
+      if (modified.length > 1) {
+        modified[1] = 0x59
+      }
+      const numCorrupt = Math.max(1, Math.floor(modified.length * 0.1))
+      for (let i = 0; i < numCorrupt; i++) {
+        const pos = Math.floor(Math.random() * modified.length)
+        modified[pos] = 0x5a
+      }
+    }
+
+    return modified
+  }
+
+  private corsHeaders(): Record<string, string> {
+    return {
+      "access-control-allow-origin": `*`,
+      "access-control-allow-methods": `GET, POST, PUT, DELETE, HEAD, OPTIONS`,
+      "access-control-allow-headers": `content-type, authorization, Stream-Seq, Stream-TTL, Stream-Expires-At, Stream-Closed, Producer-Id, Producer-Epoch, Producer-Seq`,
+      "access-control-expose-headers": `Stream-Next-Offset, Stream-Cursor, Stream-Up-To-Date, Stream-Closed, Producer-Epoch, Producer-Seq, Producer-Expected-Seq, Producer-Received-Seq, etag, content-type, content-encoding, vary`,
+      "x-content-type-options": `nosniff`,
+      "cross-origin-resource-policy": `cross-origin`,
+    }
+  }
+
+  private response(
+    body: BodyInit | null,
+    status: number,
+    headers: Record<string, string> = {}
+  ): Response {
+    return new Response(body, {
+      status,
+      headers: { ...this.corsHeaders(), ...headers },
+    })
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    const path = url.pathname
+    const method = request.method.toUpperCase()
+
+    if (method === `OPTIONS`) {
+      return this.response(null, 204)
+    }
+
+    if (path === `/_test/inject-error`) {
+      return this.handleTestInjectError(method, request)
+    }
+
+    const fault = this.consumeInjectedFault(path, method)
+    if (fault) {
+      await this.applyFaultDelay(fault)
+
+      if (fault.dropConnection) {
+        return this.response(null, 502, {
+          "content-type": `text/plain`,
+          "x-drop-connection": `true`,
+        })
+      }
+
+      if (fault.status !== undefined) {
+        const headers: Record<string, string> = {
+          "content-type": `text/plain`,
+        }
+        if (fault.retryAfter !== undefined) {
+          headers[`retry-after`] = fault.retryAfter.toString()
+        }
+        return this.response(
+          `Injected error for testing`,
+          fault.status,
+          headers
+        )
+      }
+    }
+
+    const activeFault =
+      fault &&
+      (fault.truncateBodyBytes !== undefined ||
+        fault.corruptBody ||
+        fault.injectSseEvent)
+        ? fault
+        : null
+
+    try {
+      switch (method) {
+        case `PUT`:
+          return await this.handleCreate(path, request)
+        case `HEAD`:
+          return this.handleHead(path)
+        case `GET`:
+          return await this.handleRead(path, url, request, activeFault)
+        case `POST`:
+          return await this.handleAppend(path, request)
+        case `DELETE`:
+          return await this.handleDelete(path)
+        default:
+          return this.response(`Method not allowed`, 405, {
+            "content-type": `text/plain`,
+          })
+      }
+    } catch (err) {
+      if (err instanceof StreamNotFoundError) {
+        return this.response(`Stream not found`, 404, {
+          "content-type": `text/plain`,
+        })
+      } else if (err instanceof StreamConflictError) {
+        return this.response(err.message, 409, {
+          "content-type": `text/plain`,
+        })
+      } else if (err instanceof SequenceConflictError) {
+        return this.response(`Sequence conflict`, 409, {
+          "content-type": `text/plain`,
+        })
+      } else if (err instanceof ContentTypeMismatchError) {
+        return this.response(`Content-type mismatch`, 409, {
+          "content-type": `text/plain`,
+        })
+      } else if (err instanceof InvalidJsonError) {
+        return this.response(err.message, 400, {
+          "content-type": `text/plain`,
+        })
+      } else if (err instanceof PayloadTooLargeError) {
+        return this.response(err.message, 413, {
+          "content-type": `text/plain`,
+        })
+      }
+      if (err instanceof Error) {
+        const msg = err.message.toLowerCase()
+        if (msg.includes(`not found`)) {
+          return this.response(`Stream not found`, 404, {
+            "content-type": `text/plain`,
+          })
+        } else if (
+          msg.includes(`already exists with different configuration`)
+        ) {
+          return this.response(
+            `Stream already exists with different configuration`,
+            409,
+            { "content-type": `text/plain` }
+          )
+        } else if (msg.includes(`sequence conflict`)) {
+          return this.response(`Sequence conflict`, 409, {
+            "content-type": `text/plain`,
+          })
+        } else if (msg.includes(`content-type mismatch`)) {
+          return this.response(`Content-type mismatch`, 409, {
+            "content-type": `text/plain`,
+          })
+        } else if (msg.includes(`invalid json`)) {
+          return this.response(`Invalid JSON`, 400, {
+            "content-type": `text/plain`,
+          })
+        } else if (
+          msg.includes(`empty arrays are not allowed`) ||
+          msg.includes(`empty array`)
+        ) {
+          return this.response(`Empty arrays are not allowed`, 400, {
+            "content-type": `text/plain`,
+          })
+        } else if (msg.includes(`payload too large`)) {
+          return this.response(err.message, 413, {
+            "content-type": `text/plain`,
+          })
+        }
+      }
+      throw err
+    }
+  }
+
+  // ============================================================================
+  // PUT - create stream
+  // ============================================================================
+
+  private async handleCreate(
+    path: string,
+    request: Request
+  ): Promise<Response> {
+    let contentType = request.headers.get(`content-type`)
+
+    if (
+      !contentType ||
+      contentType.trim() === `` ||
+      !/^[\w-]+\/[\w-]+/.test(contentType)
+    ) {
+      contentType = `application/octet-stream`
+    }
+
+    const ttlHeader = request.headers.get(STREAM_TTL_HEADER)
+    const expiresAtHeader = request.headers.get(STREAM_EXPIRES_AT_HEADER)
+
+    const closedHeader = request.headers.get(STREAM_CLOSED_HEADER)
+    const createClosed = closedHeader === `true`
+
+    if (ttlHeader && expiresAtHeader) {
+      return this.response(
+        `Cannot specify both Stream-TTL and Stream-Expires-At`,
+        400,
+        { "content-type": `text/plain` }
+      )
+    }
+
+    let ttlSeconds: number | undefined
+    if (ttlHeader) {
+      const ttlPattern = /^(0|[1-9]\d*)$/
+      if (!ttlPattern.test(ttlHeader)) {
+        return this.response(`Invalid Stream-TTL value`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+
+      ttlSeconds = parseInt(ttlHeader, 10)
+      if (isNaN(ttlSeconds) || ttlSeconds < 0) {
+        return this.response(`Invalid Stream-TTL value`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+    }
+
+    if (expiresAtHeader) {
+      const timestamp = new Date(expiresAtHeader)
+      if (isNaN(timestamp.getTime())) {
+        return this.response(`Invalid Stream-Expires-At timestamp`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+    }
+
+    const body = new Uint8Array(await request.arrayBuffer())
+
+    const isNew = !(await this.store.has(path))
+
+    await this.store.create(path, {
+      contentType,
+      ttlSeconds,
+      expiresAt: expiresAtHeader ?? undefined,
+      initialData: body.length > 0 ? body : undefined,
+      closed: createClosed,
+    })
+
+    const stream = (await this.store.get(path))!
+
+    if (isNew && this.options.onStreamCreated) {
+      await Promise.resolve(
+        this.options.onStreamCreated({
+          type: `created`,
+          path,
+          contentType,
+          timestamp: Date.now(),
+        })
+      )
+    }
+
+    const headers: Record<string, string> = {
+      "content-type": contentType,
+      [STREAM_OFFSET_HEADER]: stream.currentOffset,
+    }
+
+    if (isNew) {
+      headers[`location`] = `${this.options.baseUrl}${path}`
+    }
+
+    if (stream.closed) {
+      headers[STREAM_CLOSED_HEADER] = `true`
+    }
+
+    return this.response(null, isNew ? 201 : 200, headers)
+  }
+
+  // ============================================================================
+  // HEAD - get metadata
+  // ============================================================================
+
+  private async handleHead(path: string): Promise<Response> {
+    const stream = await this.store.get(path)
+    if (!stream) {
+      return this.response(null, 404, { "content-type": `text/plain` })
+    }
+
+    const headers: Record<string, string> = {
+      [STREAM_OFFSET_HEADER]: stream.currentOffset,
+      "cache-control": `no-store`,
+    }
+
+    if (stream.contentType) {
+      headers[`content-type`] = stream.contentType
+    }
+
+    if (stream.closed) {
+      headers[STREAM_CLOSED_HEADER] = `true`
+    }
+
+    const closedSuffix = stream.closed ? `:c` : ``
+    headers[`etag`] =
+      `"${stringToBase64(path)}:-1:${stream.currentOffset}${closedSuffix}"`
+
+    return this.response(null, 200, headers)
+  }
+
+  // ============================================================================
+  // GET - read data
+  // ============================================================================
+
+  private async handleRead(
+    path: string,
+    url: URL,
+    request: Request,
+    fault: InjectedFault | null
+  ): Promise<Response> {
+    const stream = await this.store.get(path)
+    if (!stream) {
+      return this.response(`Stream not found`, 404, {
+        "content-type": `text/plain`,
+      })
+    }
+
+    const offset = url.searchParams.get(OFFSET_QUERY_PARAM) ?? undefined
+    const live = url.searchParams.get(LIVE_QUERY_PARAM)
+    const cursor = url.searchParams.get(CURSOR_QUERY_PARAM) ?? undefined
+
+    if (offset !== undefined) {
+      if (offset === ``) {
+        return this.response(`Empty offset parameter`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+
+      const allOffsets = url.searchParams.getAll(OFFSET_QUERY_PARAM)
+      if (allOffsets.length > 1) {
+        return this.response(`Multiple offset parameters not allowed`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+
+      const validOffsetPattern = /^(-1|now|[0-9a-fA-F]+_[0-9a-fA-F]+)$/
+      if (!validOffsetPattern.test(offset)) {
+        return this.response(`Invalid offset format`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+    }
+
+    if ((live === `long-poll` || live === `sse`) && !offset) {
+      return this.response(
+        `${live === `sse` ? `SSE` : `Long-poll`} requires offset parameter`,
+        400,
+        { "content-type": `text/plain` }
+      )
+    }
+
+    let useBase64 = false
+    if (live === `sse`) {
+      const ct = stream.contentType?.toLowerCase().split(`;`)[0]?.trim() ?? ``
+      const isTextCompatible =
+        ct.startsWith(`text/`) || ct === `application/json`
+      useBase64 = !isTextCompatible
+    }
+
+    if (live === `sse`) {
+      const sseOffset = offset === `now` ? stream.currentOffset : offset!
+      return this.handleSSE(
+        path,
+        stream,
+        sseOffset,
+        cursor,
+        useBase64,
+        request,
+        fault
+      )
+    }
+
+    const effectiveOffset = offset === `now` ? stream.currentOffset : offset
+
+    if (offset === `now` && live !== `long-poll`) {
+      const headers: Record<string, string> = {
+        [STREAM_OFFSET_HEADER]: stream.currentOffset,
+        [STREAM_UP_TO_DATE_HEADER]: `true`,
+        "cache-control": `no-store`,
+      }
+
+      if (stream.contentType) {
+        headers[`content-type`] = stream.contentType
+      }
+
+      if (stream.closed) {
+        headers[STREAM_CLOSED_HEADER] = `true`
+      }
+
+      const isJsonMode = stream.contentType?.includes(`application/json`)
+      const responseBody = isJsonMode ? `[]` : ``
+
+      return this.response(responseBody, 200, headers)
+    }
+
+    let { messages, upToDate } = await this.store.read(path, effectiveOffset)
+
+    const clientIsCaughtUp =
+      (effectiveOffset && effectiveOffset === stream.currentOffset) ||
+      offset === `now`
+    if (live === `long-poll` && clientIsCaughtUp && messages.length === 0) {
+      if (stream.closed) {
+        return this.response(null, 204, {
+          [STREAM_OFFSET_HEADER]: stream.currentOffset,
+          [STREAM_UP_TO_DATE_HEADER]: `true`,
+          [STREAM_CLOSED_HEADER]: `true`,
+        })
+      }
+
+      const result = await this.store.waitForMessages(
+        path,
+        effectiveOffset ?? stream.currentOffset,
+        this.options.longPollTimeout
+      )
+
+      if (result.streamClosed) {
+        const responseCursor = generateResponseCursor(
+          cursor,
+          this.options.cursorOptions
+        )
+        return this.response(null, 204, {
+          [STREAM_OFFSET_HEADER]: effectiveOffset ?? stream.currentOffset,
+          [STREAM_UP_TO_DATE_HEADER]: `true`,
+          [STREAM_CURSOR_HEADER]: responseCursor,
+          [STREAM_CLOSED_HEADER]: `true`,
+        })
+      }
+
+      if (result.timedOut) {
+        const responseCursor = generateResponseCursor(
+          cursor,
+          this.options.cursorOptions
+        )
+        const currentStream = await this.store.get(path)
+        const timeoutHeaders: Record<string, string> = {
+          [STREAM_OFFSET_HEADER]: effectiveOffset ?? stream.currentOffset,
+          [STREAM_UP_TO_DATE_HEADER]: `true`,
+          [STREAM_CURSOR_HEADER]: responseCursor,
+        }
+        if (currentStream?.closed) {
+          timeoutHeaders[STREAM_CLOSED_HEADER] = `true`
+        }
+        return this.response(null, 204, timeoutHeaders)
+      }
+
+      messages = result.messages
+      upToDate = true
+    }
+
+    const headers: Record<string, string> = {}
+
+    if (stream.contentType) {
+      headers[`content-type`] = stream.contentType
+    }
+
+    const lastMessage = messages[messages.length - 1]
+    const responseOffset = lastMessage?.offset ?? stream.currentOffset
+    headers[STREAM_OFFSET_HEADER] = responseOffset
+
+    if (live === `long-poll`) {
+      headers[STREAM_CURSOR_HEADER] = generateResponseCursor(
+        cursor,
+        this.options.cursorOptions
+      )
+    }
+
+    if (upToDate) {
+      headers[STREAM_UP_TO_DATE_HEADER] = `true`
+    }
+
+    const currentStream = await this.store.get(path)
+    const clientAtTail = responseOffset === currentStream?.currentOffset
+    if (currentStream?.closed && clientAtTail && upToDate) {
+      headers[STREAM_CLOSED_HEADER] = `true`
+    }
+
+    const startOffset = offset ?? `-1`
+    const closedSuffix =
+      currentStream?.closed && clientAtTail && upToDate ? `:c` : ``
+    const etag = `"${stringToBase64(path)}:${startOffset}:${responseOffset}${closedSuffix}"`
+    headers[`etag`] = etag
+
+    const ifNoneMatch = request.headers.get(`if-none-match`)
+    if (ifNoneMatch && ifNoneMatch === etag) {
+      return this.response(null, 304, { etag })
+    }
+
+    let responseData = await this.store.formatResponse(path, messages)
+
+    responseData = this.applyFaultBodyModification(responseData, fault)
+
+    return this.response(responseData, 200, headers)
+  }
+
+  // ============================================================================
+  // SSE - Server-Sent Events
+  // ============================================================================
+
+  private handleSSE(
+    path: string,
+    stream: Awaited<ReturnType<DurableStreamStore[`get`]>>,
+    initialOffset: string,
+    cursor: string | undefined,
+    useBase64: boolean,
+    request: Request,
+    fault: InjectedFault | null
+  ): Response {
+    const encoder = new TextEncoder()
+    const decoder = new TextDecoder()
+    const isJsonStream = stream?.contentType?.includes(`application/json`)
+
+    let isConnected = true
+    const abortHandler = (): void => {
+      isConnected = false
+    }
+    request.signal.addEventListener(`abort`, abortHandler)
+
+    const readable = new ReadableStream({
+      start: async (controller) => {
+        try {
+          await this.runSSELoop(
+            controller,
+            encoder,
+            decoder,
+            path,
+            initialOffset,
+            cursor,
+            useBase64,
+            isJsonStream ?? false,
+            fault,
+            () => isConnected
+          )
+        } catch {
+          // Connection closed or error
+        } finally {
+          request.signal.removeEventListener(`abort`, abortHandler)
+          try {
+            controller.close()
+          } catch {
+            // Already closed
+          }
+        }
+      },
+    })
+
+    const sseHeaders: Record<string, string> = {
+      "content-type": `text/event-stream`,
+      "cache-control": `no-cache`,
+      connection: `keep-alive`,
+    }
+
+    if (useBase64) {
+      sseHeaders[STREAM_SSE_DATA_ENCODING_HEADER] = `base64`
+    }
+
+    return this.response(readable, 200, sseHeaders)
+  }
+
+  private async runSSELoop(
+    controller: ReadableStreamDefaultController,
+    encoder: TextEncoder,
+    decoder: TextDecoder,
+    path: string,
+    initialOffset: string,
+    cursor: string | undefined,
+    useBase64: boolean,
+    isJsonStream: boolean,
+    fault: InjectedFault | null,
+    isConnected: () => boolean
+  ): Promise<void> {
+    let currentOffset = initialOffset
+
+    if (fault?.injectSseEvent) {
+      controller.enqueue(
+        encoder.encode(
+          `event: ${fault.injectSseEvent.eventType}\n` +
+            `data: ${fault.injectSseEvent.data}\n\n`
+        )
+      )
+    }
+
+    while (isConnected() && !this.isShuttingDown) {
+      const { messages, upToDate } = await this.store.read(path, currentOffset)
+
+      let sseBatch = ``
+
+      for (const message of messages) {
+        let dataPayload: string
+        if (useBase64) {
+          dataPayload = uint8ArrayToBase64(message.data)
+        } else if (isJsonStream) {
+          const jsonBytes = await this.store.formatResponse(path, [message])
+          dataPayload = decoder.decode(jsonBytes)
+        } else {
+          dataPayload = decoder.decode(message.data)
+        }
+
+        sseBatch += `event: data\n` + encodeSSEData(dataPayload)
+
+        currentOffset = message.offset
+      }
+
+      const currentStream = await this.store.get(path)
+      const controlOffset =
+        messages[messages.length - 1]?.offset ?? currentStream!.currentOffset
+
+      const streamIsClosed = currentStream?.closed ?? false
+      const clientAtTail = controlOffset === currentStream!.currentOffset
+
+      const responseCursor = generateResponseCursor(
+        cursor,
+        this.options.cursorOptions
+      )
+      const controlData: Record<string, string | boolean> = {
+        [SSE_OFFSET_FIELD]: controlOffset,
+      }
+
+      if (streamIsClosed && clientAtTail) {
+        controlData[SSE_CLOSED_FIELD] = true
+      } else {
+        controlData[SSE_CURSOR_FIELD] = responseCursor
+        if (upToDate) {
+          controlData[SSE_UP_TO_DATE_FIELD] = true
+        }
+      }
+
+      sseBatch +=
+        `event: control\n` + encodeSSEData(JSON.stringify(controlData))
+
+      controller.enqueue(encoder.encode(sseBatch))
+
+      if (streamIsClosed && clientAtTail) {
+        break
+      }
+
+      currentOffset = controlOffset
+
+      if (upToDate) {
+        if (currentStream?.closed) {
+          const finalControlData: Record<string, string | boolean> = {
+            [SSE_OFFSET_FIELD]: currentOffset,
+            [SSE_CLOSED_FIELD]: true,
+          }
+          controller.enqueue(
+            encoder.encode(
+              `event: control\n` +
+                encodeSSEData(JSON.stringify(finalControlData))
+            )
+          )
+          break
+        }
+
+        const result = await this.store.waitForMessages(
+          path,
+          currentOffset,
+          this.options.longPollTimeout
+        )
+
+        if (!isConnected()) break
+
+        if (result.streamClosed) {
+          const finalControlData: Record<string, string | boolean> = {
+            [SSE_OFFSET_FIELD]: currentOffset,
+            [SSE_CLOSED_FIELD]: true,
+          }
+          controller.enqueue(
+            encoder.encode(
+              `event: control\n` +
+                encodeSSEData(JSON.stringify(finalControlData))
+            )
+          )
+          break
+        }
+
+        if (result.timedOut) {
+          const keepAliveCursor = generateResponseCursor(
+            cursor,
+            this.options.cursorOptions
+          )
+
+          const streamAfterWait = await this.store.get(path)
+          if (streamAfterWait?.closed) {
+            const closedControlData: Record<string, string | boolean> = {
+              [SSE_OFFSET_FIELD]: currentOffset,
+              [SSE_CLOSED_FIELD]: true,
+            }
+            controller.enqueue(
+              encoder.encode(
+                `event: control\n` +
+                  encodeSSEData(JSON.stringify(closedControlData))
+              )
+            )
+            break
+          }
+
+          const keepAliveData: Record<string, string | boolean> = {
+            [SSE_OFFSET_FIELD]: currentOffset,
+            [SSE_CURSOR_FIELD]: keepAliveCursor,
+            [SSE_UP_TO_DATE_FIELD]: true,
+          }
+          controller.enqueue(
+            encoder.encode(
+              `event: control\n` + encodeSSEData(JSON.stringify(keepAliveData))
+            )
+          )
+        }
+      }
+    }
+  }
+
+  // ============================================================================
+  // POST - append data
+  // ============================================================================
+
+  private async handleAppend(
+    path: string,
+    request: Request
+  ): Promise<Response> {
+    const contentType = request.headers.get(`content-type`)
+    const seq = request.headers.get(STREAM_SEQ_HEADER) ?? undefined
+
+    const closedHeader = request.headers.get(STREAM_CLOSED_HEADER)
+    const closeStream = closedHeader === `true`
+
+    const producerId = request.headers.get(PRODUCER_ID_HEADER) ?? undefined
+    const producerEpochStr =
+      request.headers.get(PRODUCER_EPOCH_HEADER) ?? undefined
+    const producerSeqStr = request.headers.get(PRODUCER_SEQ_HEADER) ?? undefined
+
+    const hasProducerHeaders =
+      producerId !== undefined ||
+      producerEpochStr !== undefined ||
+      producerSeqStr !== undefined
+    const hasAllProducerHeaders =
+      producerId !== undefined &&
+      producerEpochStr !== undefined &&
+      producerSeqStr !== undefined
+
+    const body = new Uint8Array(await request.arrayBuffer())
+
+    if (hasProducerHeaders && !hasAllProducerHeaders) {
+      return this.response(
+        `All producer headers (Producer-Id, Producer-Epoch, Producer-Seq) must be provided together`,
+        400,
+        { "content-type": `text/plain` }
+      )
+    }
+
+    if (hasAllProducerHeaders && producerId === ``) {
+      return this.response(`Invalid Producer-Id: must not be empty`, 400, {
+        "content-type": `text/plain`,
+      })
+    }
+
+    const STRICT_INTEGER_REGEX = /^\d+$/
+    let producerEpoch: number | undefined
+    let producerSeq: number | undefined
+    if (hasAllProducerHeaders) {
+      if (!STRICT_INTEGER_REGEX.test(producerEpochStr)) {
+        return this.response(
+          `Invalid Producer-Epoch: must be a non-negative integer`,
+          400,
+          { "content-type": `text/plain` }
+        )
+      }
+      producerEpoch = Number(producerEpochStr)
+      if (!Number.isSafeInteger(producerEpoch)) {
+        return this.response(
+          `Invalid Producer-Epoch: must be a non-negative integer`,
+          400,
+          { "content-type": `text/plain` }
+        )
+      }
+
+      if (!STRICT_INTEGER_REGEX.test(producerSeqStr)) {
+        return this.response(
+          `Invalid Producer-Seq: must be a non-negative integer`,
+          400,
+          { "content-type": `text/plain` }
+        )
+      }
+      producerSeq = Number(producerSeqStr)
+      if (!Number.isSafeInteger(producerSeq)) {
+        return this.response(
+          `Invalid Producer-Seq: must be a non-negative integer`,
+          400,
+          { "content-type": `text/plain` }
+        )
+      }
+    }
+
+    if (body.length === 0 && closeStream) {
+      if (hasAllProducerHeaders) {
+        const closeResult = await this.store.closeStreamWithProducer(path, {
+          producerId: producerId,
+          producerEpoch: producerEpoch!,
+          producerSeq: producerSeq!,
+        })
+
+        if (!closeResult) {
+          return this.response(`Stream not found`, 404, {
+            "content-type": `text/plain`,
+          })
+        }
+
+        if (closeResult.producerResult?.status === `duplicate`) {
+          return this.response(null, 204, {
+            [STREAM_OFFSET_HEADER]: closeResult.finalOffset,
+            [STREAM_CLOSED_HEADER]: `true`,
+            [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
+            [PRODUCER_SEQ_HEADER]:
+              closeResult.producerResult.lastSeq.toString(),
+          })
+        }
+
+        if (closeResult.producerResult?.status === `stale_epoch`) {
+          return this.response(`Stale producer epoch`, 403, {
+            "content-type": `text/plain`,
+            [PRODUCER_EPOCH_HEADER]:
+              closeResult.producerResult.currentEpoch.toString(),
+          })
+        }
+
+        if (closeResult.producerResult?.status === `invalid_epoch_seq`) {
+          return this.response(`New epoch must start with sequence 0`, 400, {
+            "content-type": `text/plain`,
+          })
+        }
+
+        if (closeResult.producerResult?.status === `sequence_gap`) {
+          return this.response(`Producer sequence gap`, 409, {
+            "content-type": `text/plain`,
+            [PRODUCER_EXPECTED_SEQ_HEADER]:
+              closeResult.producerResult.expectedSeq.toString(),
+            [PRODUCER_RECEIVED_SEQ_HEADER]:
+              closeResult.producerResult.receivedSeq.toString(),
+          })
+        }
+
+        if (closeResult.producerResult?.status === `stream_closed`) {
+          const stream = await this.store.get(path)
+          return this.response(`Stream is closed`, 409, {
+            "content-type": `text/plain`,
+            [STREAM_CLOSED_HEADER]: `true`,
+            [STREAM_OFFSET_HEADER]: stream?.currentOffset ?? ``,
+          })
+        }
+
+        return this.response(null, 204, {
+          [STREAM_OFFSET_HEADER]: closeResult.finalOffset,
+          [STREAM_CLOSED_HEADER]: `true`,
+          [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
+          [PRODUCER_SEQ_HEADER]: producerSeq!.toString(),
+        })
+      }
+
+      const closeResult = await this.store.closeStream(path)
+      if (!closeResult) {
+        return this.response(`Stream not found`, 404, {
+          "content-type": `text/plain`,
+        })
+      }
+
+      return this.response(null, 204, {
+        [STREAM_OFFSET_HEADER]: closeResult.finalOffset,
+        [STREAM_CLOSED_HEADER]: `true`,
+      })
+    }
+
+    if (body.length === 0) {
+      return this.response(`Empty body`, 400, {
+        "content-type": `text/plain`,
+      })
+    }
+
+    if (!contentType) {
+      return this.response(`Content-Type header is required`, 400, {
+        "content-type": `text/plain`,
+      })
+    }
+
+    const appendOptions: AppendOptions = {
+      seq,
+      contentType,
+      producerId,
+      producerEpoch,
+      producerSeq,
+      close: closeStream,
+    }
+
+    let result
+    if (producerId !== undefined) {
+      result = await this.store.appendWithProducer(path, body, appendOptions)
+    } else {
+      result = await this.store.append(path, body, appendOptions)
+    }
+
+    if (typeof result === `object` && `message` in result) {
+      const { message, producerResult, streamClosed } = result as {
+        message: { offset: string } | null
+        producerResult?: {
+          status: string
+          lastSeq?: number
+          currentEpoch?: number
+          expectedSeq?: number
+          receivedSeq?: number
+        }
+        streamClosed?: boolean
+      }
+
+      if (streamClosed && !message) {
+        if (producerResult?.status === `duplicate`) {
+          const stream = await this.store.get(path)
+          return this.response(null, 204, {
+            [STREAM_OFFSET_HEADER]: stream?.currentOffset ?? ``,
+            [STREAM_CLOSED_HEADER]: `true`,
+            [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
+            [PRODUCER_SEQ_HEADER]: producerResult.lastSeq!.toString(),
+          })
+        }
+
+        const closedStream = await this.store.get(path)
+        return this.response(`Stream is closed`, 409, {
+          "content-type": `text/plain`,
+          [STREAM_CLOSED_HEADER]: `true`,
+          [STREAM_OFFSET_HEADER]: closedStream?.currentOffset ?? ``,
+        })
+      }
+
+      if (!producerResult || producerResult.status === `accepted`) {
+        const responseHeaders: Record<string, string> = {
+          [STREAM_OFFSET_HEADER]: message!.offset,
+        }
+        if (producerEpoch !== undefined) {
+          responseHeaders[PRODUCER_EPOCH_HEADER] = producerEpoch.toString()
+        }
+        if (producerSeq !== undefined) {
+          responseHeaders[PRODUCER_SEQ_HEADER] = producerSeq.toString()
+        }
+        if (streamClosed) {
+          responseHeaders[STREAM_CLOSED_HEADER] = `true`
+        }
+        const statusCode = producerId !== undefined ? 200 : 204
+        return this.response(null, statusCode, responseHeaders)
+      }
+
+      switch (producerResult.status) {
+        case `duplicate`: {
+          const dupHeaders: Record<string, string> = {
+            [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
+            [PRODUCER_SEQ_HEADER]: producerResult.lastSeq!.toString(),
+          }
+          if (streamClosed) {
+            dupHeaders[STREAM_CLOSED_HEADER] = `true`
+          }
+          return this.response(null, 204, dupHeaders)
+        }
+
+        case `stale_epoch`:
+          return this.response(`Stale producer epoch`, 403, {
+            "content-type": `text/plain`,
+            [PRODUCER_EPOCH_HEADER]: producerResult.currentEpoch!.toString(),
+          })
+
+        case `invalid_epoch_seq`:
+          return this.response(`New epoch must start with sequence 0`, 400, {
+            "content-type": `text/plain`,
+          })
+
+        case `sequence_gap`:
+          return this.response(`Producer sequence gap`, 409, {
+            "content-type": `text/plain`,
+            [PRODUCER_EXPECTED_SEQ_HEADER]:
+              producerResult.expectedSeq!.toString(),
+            [PRODUCER_RECEIVED_SEQ_HEADER]:
+              producerResult.receivedSeq!.toString(),
+          })
+      }
+    }
+
+    const message = result as { offset: string }
+    const responseHeaders: Record<string, string> = {
+      [STREAM_OFFSET_HEADER]: message.offset,
+    }
+    if (closeStream) {
+      responseHeaders[STREAM_CLOSED_HEADER] = `true`
+    }
+    return this.response(null, 204, responseHeaders)
+  }
+
+  // ============================================================================
+  // DELETE - delete stream
+  // ============================================================================
+
+  private async handleDelete(path: string): Promise<Response> {
+    const exists = await this.store.has(path)
+    if (!exists) {
+      return this.response(`Stream not found`, 404, {
+        "content-type": `text/plain`,
+      })
+    }
+
+    await this.store.delete(path)
+
+    if (this.options.onStreamDeleted) {
+      await Promise.resolve(
+        this.options.onStreamDeleted({
+          type: `deleted`,
+          path,
+          timestamp: Date.now(),
+        })
+      )
+    }
+
+    return this.response(null, 204)
+  }
+
+  // ============================================================================
+  // Test control endpoints
+  // ============================================================================
+
+  private async handleTestInjectError(
+    method: string,
+    request: Request
+  ): Promise<Response> {
+    if (method === `POST`) {
+      const body = new Uint8Array(await request.arrayBuffer())
+      try {
+        const config = JSON.parse(new TextDecoder().decode(body)) as {
+          path: string
+          status?: number
+          count?: number
+          retryAfter?: number
+          delayMs?: number
+          dropConnection?: boolean
+          truncateBodyBytes?: number
+          probability?: number
+          method?: string
+          corruptBody?: boolean
+          jitterMs?: number
+          injectSseEvent?: {
+            eventType: string
+            data: string
+          }
+        }
+
+        if (!config.path) {
+          return this.response(`Missing required field: path`, 400, {
+            "content-type": `text/plain`,
+          })
+        }
+
+        const hasFaultType =
+          config.status !== undefined ||
+          config.delayMs !== undefined ||
+          config.dropConnection ||
+          config.truncateBodyBytes !== undefined ||
+          config.corruptBody ||
+          config.injectSseEvent !== undefined
+        if (!hasFaultType) {
+          return this.response(
+            `Must specify at least one fault type: status, delayMs, dropConnection, truncateBodyBytes, corruptBody, or injectSseEvent`,
+            400,
+            { "content-type": `text/plain` }
+          )
+        }
+
+        this.injectFault(config.path, {
+          status: config.status,
+          count: config.count ?? 1,
+          retryAfter: config.retryAfter,
+          delayMs: config.delayMs,
+          dropConnection: config.dropConnection,
+          truncateBodyBytes: config.truncateBodyBytes,
+          probability: config.probability,
+          method: config.method,
+          corruptBody: config.corruptBody,
+          jitterMs: config.jitterMs,
+          injectSseEvent: config.injectSseEvent,
+        })
+
+        return this.response(JSON.stringify({ ok: true }), 200, {
+          "content-type": `application/json`,
+        })
+      } catch {
+        return this.response(`Invalid JSON body`, 400, {
+          "content-type": `text/plain`,
+        })
+      }
+    } else if (method === `DELETE`) {
+      this.clearInjectedFaults()
+      return this.response(JSON.stringify({ ok: true }), 200, {
+        "content-type": `application/json`,
+      })
+    } else {
+      return this.response(`Method not allowed`, 405, {
+        "content-type": `text/plain`,
+      })
+    }
+  }
+}
+
+export function createFetchHandler(options: FetchHandlerOptions): {
+  handler: DurableStreamHandler
+  fetch: (request: Request) => Promise<Response>
+} {
+  const handler = new DurableStreamHandler(options)
+  return {
+    handler,
+    fetch: (request: Request) => handler.fetch(request),
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,13 +1,13 @@
-/**
- * In-memory test server for durable-stream e2e testing.
- *
- * @packageDocumentation
- */
-
 export { DurableStreamTestServer } from "./server"
-export { StreamStore } from "./store"
+export {
+  DurableStreamHandler,
+  createFetchHandler,
+  type FetchHandlerOptions,
+  type InjectedFault,
+} from "./handler"
+export { MemoryStore, MemoryStore as StreamStore } from "./storage/memory"
 export { FileBackedStreamStore } from "./file-store"
-export { encodeStreamPath, decodeStreamPath } from "./path-encoding"
+export { encodeStreamPath, decodeStreamPath } from "./path"
 export { createRegistryHooks } from "./registry-hook"
 export {
   calculateCursor,
@@ -17,6 +17,63 @@ export {
   DEFAULT_CURSOR_INTERVAL_SECONDS,
   type CursorOptions,
 } from "./cursor"
+export {
+  normalizeContentType,
+  processJsonAppend,
+  formatJsonResponse,
+  isExpired,
+  isJsonContentType,
+  validateTTL,
+  validateExpiresAt,
+  generateETag,
+  parseETag,
+  type ExpirationInfo,
+} from "./protocol"
+export {
+  initialOffset,
+  isSentinelOffset,
+  isValidOffset,
+  normalizeOffset,
+  parseOffset,
+  formatOffset,
+  compareOffsets,
+  advanceOffset,
+  incrementSeq,
+  type ParsedOffset,
+} from "./offsets"
+export {
+  STREAM_OFFSET_HEADER,
+  STREAM_CURSOR_HEADER,
+  STREAM_UP_TO_DATE_HEADER,
+  STREAM_SEQ_HEADER,
+  STREAM_TTL_HEADER,
+  STREAM_EXPIRES_AT_HEADER,
+  STREAM_SSE_DATA_ENCODING_HEADER,
+  STREAM_CLOSED_HEADER,
+  PRODUCER_ID_HEADER,
+  PRODUCER_EPOCH_HEADER,
+  PRODUCER_SEQ_HEADER,
+  PRODUCER_EXPECTED_SEQ_HEADER,
+  PRODUCER_RECEIVED_SEQ_HEADER,
+  SSE_OFFSET_FIELD,
+  SSE_CURSOR_FIELD,
+  SSE_UP_TO_DATE_FIELD,
+  SSE_CLOSED_FIELD,
+  OFFSET_QUERY_PARAM,
+  LIVE_QUERY_PARAM,
+  CURSOR_QUERY_PARAM,
+  SSE_COMPATIBLE_CONTENT_TYPES,
+} from "./constants"
+export {
+  StreamNotFoundError,
+  StreamConflictError,
+  SequenceConflictError,
+  ContentTypeMismatchError,
+  InvalidJsonError,
+  InvalidOffsetError,
+  PayloadTooLargeError,
+  type StreamError,
+} from "./errors"
 export type {
   Stream,
   StreamMessage,
@@ -24,4 +81,10 @@ export type {
   PendingLongPoll,
   StreamLifecycleEvent,
   StreamLifecycleHook,
+  DurableStreamStore,
+  AppendOptions,
+  AppendResult,
+  MaybePromise,
+  ProducerState,
+  ProducerValidationResult,
 } from "./types"

--- a/packages/server/src/offsets.ts
+++ b/packages/server/src/offsets.ts
@@ -1,0 +1,50 @@
+export type ParsedOffset = {
+  readonly seq: number
+  readonly pos: number
+}
+
+const OFFSET_REGEX = /^\d{16}_\d{16}$/
+const INITIAL_OFFSET = `0000000000000000_0000000000000000`
+const SENTINEL_OFFSET = `-1`
+
+export const initialOffset = (): string => INITIAL_OFFSET
+
+export const isSentinelOffset = (offset: string): boolean =>
+  offset === SENTINEL_OFFSET
+
+export const isValidOffset = (offset: string): boolean =>
+  offset === SENTINEL_OFFSET || OFFSET_REGEX.test(offset)
+
+export const normalizeOffset = (offset: string): string =>
+  offset === SENTINEL_OFFSET ? INITIAL_OFFSET : offset
+
+export const parseOffset = (offset: string): ParsedOffset | null => {
+  if (!OFFSET_REGEX.test(offset)) return null
+  const [seqStr, posStr] = offset.split(`_`) as [string, string]
+  return { seq: Number(seqStr), pos: Number(posStr) }
+}
+
+export const formatOffset = (seq: number, pos: number): string => {
+  return `${String(seq).padStart(16, `0`)}_${String(pos).padStart(16, `0`)}`
+}
+
+export const compareOffsets = (a: string, b: string): -1 | 0 | 1 => {
+  const parsedA = parseOffset(a)
+  const parsedB = parseOffset(b)
+  if (!(parsedA && parsedB)) return 0
+  if (parsedA.seq !== parsedB.seq) return parsedA.seq < parsedB.seq ? -1 : 1
+  if (parsedA.pos !== parsedB.pos) return parsedA.pos < parsedB.pos ? -1 : 1
+  return 0
+}
+
+export const advanceOffset = (offset: string, byteCount: number): string => {
+  const parsed = parseOffset(offset)
+  if (!parsed) return offset
+  return formatOffset(parsed.seq, parsed.pos + byteCount)
+}
+
+export const incrementSeq = (offset: string): string => {
+  const parsed = parseOffset(offset)
+  if (!parsed) return offset
+  return formatOffset(parsed.seq + 1, parsed.pos)
+}

--- a/packages/server/src/path.ts
+++ b/packages/server/src/path.ts
@@ -1,0 +1,57 @@
+const MAX_ENCODED_LENGTH = 200
+const HASH_REGEX = /^[0-9a-f]+$/
+
+const base64UrlEncode = (str: string): string => {
+  const bytes = new TextEncoder().encode(str)
+  let binary = ``
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, `-`).replace(/\//g, `_`).replace(/=/g, ``)
+}
+
+const base64UrlDecode = (encoded: string): string => {
+  const normalized = encoded.replace(/-/g, `+`).replace(/_/g, `/`)
+  const padded = normalized + `=`.repeat((4 - (normalized.length % 4)) % 4)
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return new TextDecoder().decode(bytes)
+}
+
+const sha256Hex = async (str: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(str)
+  const hashBuffer = await crypto.subtle.digest(`SHA-256`, bytes)
+  const hashArray = new Uint8Array(hashBuffer)
+  return Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, `0`))
+    .join(``)
+    .slice(0, 16)
+}
+
+export const encodeStreamPath = async (path: string): Promise<string> => {
+  const base64 = base64UrlEncode(path)
+
+  if (base64.length > MAX_ENCODED_LENGTH) {
+    const hash = await sha256Hex(path)
+    return `${base64.slice(0, 180)}~${hash}`
+  }
+
+  return base64
+}
+
+export const decodeStreamPath = (encoded: string): string => {
+  let base = encoded
+  const tildeIndex = encoded.lastIndexOf(`~`)
+
+  if (tildeIndex !== -1) {
+    const possibleHash = encoded.slice(tildeIndex + 1)
+    if (possibleHash.length === 16 && HASH_REGEX.test(possibleHash)) {
+      base = encoded.slice(0, tildeIndex)
+    }
+  }
+
+  return base64UrlDecode(base)
+}

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -1,0 +1,131 @@
+import { InvalidJsonError } from "./errors"
+
+export type ExpirationInfo = {
+  readonly ttlSeconds?: number
+  readonly expiresAt?: string
+  readonly createdAt?: number
+}
+
+export const isExpired = (info: ExpirationInfo): boolean => {
+  const now = Date.now()
+
+  if (info.expiresAt) {
+    const expiresAtMs = new Date(info.expiresAt).getTime()
+    if (!Number.isFinite(expiresAtMs) || now >= expiresAtMs) {
+      return true
+    }
+  }
+
+  if (info.ttlSeconds !== undefined && info.createdAt !== undefined) {
+    const expiresAtMs = info.createdAt + info.ttlSeconds * 1000
+    if (now >= expiresAtMs) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const TTL_REGEX = /^[1-9][0-9]*$/
+const EXPIRES_AT_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/
+
+export const normalizeContentType = (
+  contentType: string | undefined
+): string => {
+  if (!contentType) return ``
+  const semicolonIndex = contentType.indexOf(`;`)
+  if (semicolonIndex !== -1) {
+    return contentType.slice(0, semicolonIndex).trim().toLowerCase()
+  }
+  return contentType.trim().toLowerCase()
+}
+
+export const isJsonContentType = (contentType: string): boolean => {
+  const normalized = normalizeContentType(contentType)
+  return normalized === `application/json` || normalized.endsWith(`+json`)
+}
+
+export const validateTTL = (ttl: string): number | null => {
+  if (!TTL_REGEX.test(ttl)) return null
+  const parsed = parseInt(ttl, 10)
+  return isNaN(parsed) || parsed <= 0 ? null : parsed
+}
+
+export const validateExpiresAt = (value: string): Date | null => {
+  if (!EXPIRES_AT_REGEX.test(value)) return null
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? null : date
+}
+
+export const processJsonAppend = (
+  data: Uint8Array,
+  isInitialCreate = false
+): Uint8Array => {
+  const text = new TextDecoder().decode(data)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new InvalidJsonError(`Invalid JSON`)
+  }
+
+  let result: string
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) {
+      if (isInitialCreate) {
+        return new Uint8Array(0)
+      }
+      throw new InvalidJsonError(`Empty arrays are not allowed`)
+    }
+    const elements = parsed.map((item) => JSON.stringify(item))
+    result = elements.join(`,`) + `,`
+  } else {
+    result = JSON.stringify(parsed) + `,`
+  }
+
+  return new TextEncoder().encode(result)
+}
+
+export const formatJsonResponse = (data: Uint8Array): Uint8Array => {
+  if (data.length === 0) {
+    return new TextEncoder().encode(`[]`)
+  }
+
+  let text = new TextDecoder().decode(data)
+  text = text.trimEnd()
+  if (text.endsWith(`,`)) {
+    text = text.slice(0, -1)
+  }
+
+  return new TextEncoder().encode(`[${text}]`)
+}
+
+export const generateETag = (
+  path: string,
+  startOffset: string,
+  endOffset: string
+): string => {
+  const pathBase64 = btoa(path)
+  return `"${pathBase64}:${startOffset}:${endOffset}"`
+}
+
+export const parseETag = (
+  etag: string
+): { path: string; startOffset: string; endOffset: string } | null => {
+  const match = /^"([^:]+):([^:]+):([^"]+)"$/.exec(etag)
+  if (!match || match.length < 4) return null
+
+  const pathBase64 = match[1]
+  const startOffset = match[2]
+  const endOffset = match[3]
+
+  if (!(pathBase64 && startOffset && endOffset)) return null
+
+  try {
+    return { path: atob(pathBase64), startOffset, endOffset }
+  } catch {
+    return null
+  }
+}

--- a/packages/server/src/registry-hook.ts
+++ b/packages/server/src/registry-hook.ts
@@ -6,7 +6,7 @@
 import { DurableStream } from "@durable-streams/client"
 import { createStateSchema } from "@durable-streams/state"
 import type { StreamLifecycleHook } from "./types"
-import type { StreamStore } from "./store"
+import type { MemoryStore } from "./storage/memory"
 import type { FileBackedStreamStore } from "./file-store"
 
 const REGISTRY_PATH = `/v1/stream/__registry__`
@@ -59,7 +59,7 @@ const registryStateSchema = createStateSchema({
  * Any client can read this stream to discover all streams and their lifecycle events.
  */
 export function createRegistryHooks(
-  store: StreamStore | FileBackedStreamStore,
+  store: MemoryStore | FileBackedStreamStore,
   serverUrl: string
 ): {
   onStreamCreated: StreamLifecycleHook

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,86 +1,28 @@
 /**
- * HTTP server for durable streams testing.
+ * Node.js HTTP server adapter for durable streams.
+ * Wraps the runtime-agnostic fetch handler with node:http for local dev/testing.
  */
 
 import { createServer } from "node:http"
 import { deflateSync, gzipSync } from "node:zlib"
-import { StreamStore } from "./store"
+import { MemoryStore } from "./storage/memory"
 import { FileBackedStreamStore } from "./file-store"
-import { generateResponseCursor } from "./cursor"
-import type { CursorOptions } from "./cursor"
+import { DurableStreamHandler } from "./handler"
 import type { IncomingMessage, Server, ServerResponse } from "node:http"
-import type { StreamLifecycleEvent, TestServerOptions } from "./types"
+import type { TestServerOptions } from "./types"
 
-// Protocol headers (aligned with PROTOCOL.md)
-const STREAM_OFFSET_HEADER = `Stream-Next-Offset`
-const STREAM_CURSOR_HEADER = `Stream-Cursor`
-const STREAM_UP_TO_DATE_HEADER = `Stream-Up-To-Date`
-const STREAM_SEQ_HEADER = `Stream-Seq`
-const STREAM_TTL_HEADER = `Stream-TTL`
-const STREAM_EXPIRES_AT_HEADER = `Stream-Expires-At`
-const STREAM_SSE_DATA_ENCODING_HEADER = `Stream-SSE-Data-Encoding`
-
-// Idempotent producer headers
-const PRODUCER_ID_HEADER = `Producer-Id`
-const PRODUCER_EPOCH_HEADER = `Producer-Epoch`
-const PRODUCER_SEQ_HEADER = `Producer-Seq`
-const PRODUCER_EXPECTED_SEQ_HEADER = `Producer-Expected-Seq`
-const PRODUCER_RECEIVED_SEQ_HEADER = `Producer-Received-Seq`
-
-// SSE control event fields (Protocol Section 5.7)
-const SSE_OFFSET_FIELD = `streamNextOffset`
-const SSE_CURSOR_FIELD = `streamCursor`
-const SSE_UP_TO_DATE_FIELD = `upToDate`
-const SSE_CLOSED_FIELD = `streamClosed`
-
-// Stream closure header
-const STREAM_CLOSED_HEADER = `Stream-Closed`
-
-// Query params
-const OFFSET_QUERY_PARAM = `offset`
-const LIVE_QUERY_PARAM = `live`
-const CURSOR_QUERY_PARAM = `cursor`
-
-/**
- * Encode data for SSE format.
- * Per SSE spec, each line in the payload needs its own "data:" prefix.
- * Line terminators in the payload (CR, LF, or CRLF) become separate data: lines.
- * This prevents CRLF injection attacks where malicious payloads could inject
- * fake SSE events using CR-only line terminators.
- *
- * Note: We don't add a space after "data:" because clients strip exactly one
- * leading space per the SSE spec. Adding one would cause data starting with
- * spaces to lose an extra space character.
- */
-function encodeSSEData(payload: string): string {
-  // Split on all SSE-valid line terminators: CRLF, CR, or LF
-  // Order matters: \r\n must be matched before \r alone
-  const lines = payload.split(/\r\n|\r|\n/)
-  return lines.map((line) => `data:${line}`).join(`\n`) + `\n\n`
-}
-
-/**
- * Minimum response size to consider for compression.
- * Responses smaller than this won't benefit from compression.
- */
 const COMPRESSION_THRESHOLD = 1024
 
-/**
- * Determine the best compression encoding from Accept-Encoding header.
- * Returns 'gzip', 'deflate', or null if no compression should be used.
- */
 function getCompressionEncoding(
   acceptEncoding: string | undefined
 ): `gzip` | `deflate` | null {
   if (!acceptEncoding) return null
 
-  // Parse Accept-Encoding header (e.g., "gzip, deflate, br" or "gzip;q=1.0, deflate;q=0.5")
   const encodings = acceptEncoding
     .toLowerCase()
     .split(`,`)
     .map((e) => e.trim())
 
-  // Prefer gzip over deflate (better compression, wider support)
   for (const encoding of encodings) {
     const name = encoding.split(`;`)[0]?.trim()
     if (name === `gzip`) return `gzip`
@@ -93,9 +35,6 @@ function getCompressionEncoding(
   return null
 }
 
-/**
- * Compress data using the specified encoding.
- */
 function compressData(
   data: Uint8Array,
   encoding: `gzip` | `deflate`
@@ -107,98 +46,150 @@ function compressData(
   }
 }
 
-/**
- * HTTP server for testing durable streams.
- * Supports both in-memory and file-backed storage modes.
- */
-/**
- * Configuration for injected faults (for testing retry/resilience).
- * Supports various fault types beyond simple HTTP errors.
- */
-interface InjectedFault {
-  /** HTTP status code to return (if set, returns error response) */
-  status?: number
-  /** Number of times to trigger this fault (decremented on each use) */
-  count: number
-  /** Optional Retry-After header value (seconds) */
-  retryAfter?: number
-  /** Delay in milliseconds before responding */
-  delayMs?: number
-  /** Drop the connection after sending headers (simulates network failure) */
-  dropConnection?: boolean
-  /** Truncate response body to this many bytes */
-  truncateBodyBytes?: number
-  /** Probability of triggering fault (0-1, default 1.0 = always) */
-  probability?: number
-  /** Only match specific HTTP method (GET, POST, PUT, DELETE) */
-  method?: string
-  /** Corrupt the response body by flipping random bits */
-  corruptBody?: boolean
-  /** Add jitter to delay (random 0-jitterMs added to delayMs) */
-  jitterMs?: number
-  /** Inject an SSE event with custom type and data (for testing SSE parsing) */
-  injectSseEvent?: {
-    /** Event type (e.g., "unknown", "control", "data") */
-    eventType: string
-    /** Event data (will be sent as-is) */
-    data: string
+async function nodeRequestToWebRequest(
+  req: IncomingMessage,
+  baseUrl: string
+): Promise<Request> {
+  const url = new URL(req.url ?? `/`, baseUrl)
+  const method = req.method ?? `GET`
+
+  const headers = new Headers()
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === `string`) {
+      headers.set(key, value)
+    } else if (Array.isArray(value)) {
+      for (const v of value) {
+        headers.append(key, v)
+      }
+    }
   }
+
+  const hasBody = method !== `GET` && method !== `HEAD` && method !== `OPTIONS`
+  let body: ArrayBuffer | null = null
+  if (hasBody) {
+    body = await new Promise<ArrayBuffer>((resolve, reject) => {
+      const chunks: Array<Buffer> = []
+      req.on(`data`, (chunk: Buffer) => chunks.push(chunk))
+      req.on(`end`, () => {
+        const buf = Buffer.concat(chunks)
+        resolve(
+          buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+        )
+      })
+      req.on(`error`, reject)
+    })
+  }
+
+  return new Request(url.toString(), {
+    method,
+    headers,
+    body,
+    duplex: `half` as any,
+  })
+}
+
+async function writeWebResponseToNode(
+  webResponse: Response,
+  nodeRes: ServerResponse,
+  compression: boolean,
+  acceptEncoding: string | undefined
+): Promise<void> {
+  const headers: Record<string, string> = {}
+  webResponse.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+
+  const contentType = headers[`content-type`] ?? ``
+  const isSSE = contentType === `text/event-stream`
+
+  if (isSSE) {
+    nodeRes.writeHead(webResponse.status, headers)
+
+    if (webResponse.body) {
+      const reader = webResponse.body.getReader()
+      try {
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          const canContinue = nodeRes.write(value)
+          if (!canContinue) {
+            await new Promise<void>((resolve) => nodeRes.once(`drain`, resolve))
+          }
+        }
+      } catch {
+        // Connection closed
+      } finally {
+        reader.releaseLock()
+      }
+    }
+
+    nodeRes.end()
+    return
+  }
+
+  if (!webResponse.body) {
+    nodeRes.writeHead(webResponse.status, headers)
+    nodeRes.end()
+    return
+  }
+
+  let bodyData = new Uint8Array(await webResponse.arrayBuffer())
+
+  if (compression && bodyData.length >= COMPRESSION_THRESHOLD) {
+    const compressionEncoding = getCompressionEncoding(acceptEncoding)
+    if (compressionEncoding) {
+      bodyData = compressData(bodyData, compressionEncoding)
+      headers[`content-encoding`] = compressionEncoding
+      headers[`vary`] = `accept-encoding`
+    }
+  }
+
+  nodeRes.writeHead(webResponse.status, headers)
+  nodeRes.end(Buffer.from(bodyData))
 }
 
 export class DurableStreamTestServer {
-  readonly store: StreamStore | FileBackedStreamStore
+  readonly store: MemoryStore | FileBackedStreamStore
+  readonly handler: DurableStreamHandler
   private server: Server | null = null
-  private options: Required<
-    Omit<
-      TestServerOptions,
-      | `dataDir`
-      | `onStreamCreated`
-      | `onStreamDeleted`
-      | `compression`
-      | `cursorIntervalSeconds`
-      | `cursorEpoch`
-    >
-  > & {
+  private options: {
+    port: number
+    host: string
     dataDir?: string
-    onStreamCreated?: (event: StreamLifecycleEvent) => void | Promise<void>
-    onStreamDeleted?: (event: StreamLifecycleEvent) => void | Promise<void>
     compression: boolean
-    cursorOptions: CursorOptions
   }
   private _url: string | null = null
   private activeSSEResponses = new Set<ServerResponse>()
   private isShuttingDown = false
-  /** Injected faults for testing retry/resilience */
-  private injectedFaults = new Map<string, InjectedFault>()
 
   constructor(options: TestServerOptions = {}) {
-    // Choose store based on dataDir option
     if (options.dataDir) {
       this.store = new FileBackedStreamStore({
         dataDir: options.dataDir,
       })
     } else {
-      this.store = new StreamStore()
+      this.store = new MemoryStore()
     }
 
     this.options = {
       port: options.port ?? 4437,
       host: options.host ?? `127.0.0.1`,
-      longPollTimeout: options.longPollTimeout ?? 30_000,
       dataDir: options.dataDir,
+      compression: options.compression ?? true,
+    }
+
+    this.handler = new DurableStreamHandler({
+      store: this.store,
+      longPollTimeout: options.longPollTimeout ?? 30_000,
       onStreamCreated: options.onStreamCreated,
       onStreamDeleted: options.onStreamDeleted,
-      compression: options.compression ?? true,
       cursorOptions: {
         intervalSeconds: options.cursorIntervalSeconds,
         epoch: options.cursorEpoch,
       },
-    }
+    })
   }
 
-  /**
-   * Start the server.
-   */
   async start(): Promise<string> {
     if (this.server) {
       throw new Error(`Server already started`)
@@ -224,28 +215,20 @@ export class DurableStreamTestServer {
         } else if (addr) {
           this._url = `http://${this.options.host}:${addr.port}`
         }
+        this.handler.options.baseUrl = this._url!
         resolve(this._url!)
       })
     })
   }
 
-  /**
-   * Stop the server.
-   */
   async stop(): Promise<void> {
     if (!this.server) {
       return
     }
 
-    // Mark as shutting down to stop SSE handlers
     this.isShuttingDown = true
+    await this.handler.shutdown()
 
-    // Cancel all pending long-polls and SSE waits to unblock connection handlers
-    if (`cancelAllWaits` in this.store) {
-      ;(this.store as { cancelAllWaits: () => void }).cancelAllWaits()
-    }
-
-    // Force-close all active SSE connections
     for (const res of this.activeSSEResponses) {
       res.end()
     }
@@ -259,7 +242,6 @@ export class DurableStreamTestServer {
         }
 
         try {
-          // Close file-backed store if used
           if (this.store instanceof FileBackedStreamStore) {
             await this.store.close()
           }
@@ -267,6 +249,7 @@ export class DurableStreamTestServer {
           this.server = null
           this._url = null
           this.isShuttingDown = false
+          this.handler.resetShutdown()
           resolve()
         } catch (closeErr) {
           reject(closeErr)
@@ -275,9 +258,6 @@ export class DurableStreamTestServer {
     })
   }
 
-  /**
-   * Get the server URL.
-   */
   get url(): string {
     if (!this._url) {
       throw new Error(`Server not started`)
@@ -285,1339 +265,66 @@ export class DurableStreamTestServer {
     return this._url
   }
 
-  /**
-   * Clear all streams.
-   */
   clear(): void {
     this.store.clear()
   }
 
-  /**
-   * Inject an error to be returned on the next N requests to a path.
-   * Used for testing retry/resilience behavior.
-   * @deprecated Use injectFault for full fault injection capabilities
-   */
+  /** @deprecated Use injectFault for full fault injection capabilities */
   injectError(
     path: string,
     status: number,
     count: number = 1,
     retryAfter?: number
   ): void {
-    this.injectedFaults.set(path, { status, count, retryAfter })
+    this.handler.injectFault(path, { status, count, retryAfter })
   }
 
-  /**
-   * Inject a fault to be triggered on the next N requests to a path.
-   * Supports various fault types: delays, connection drops, body corruption, etc.
-   */
   injectFault(
     path: string,
-    fault: Omit<InjectedFault, `count`> & { count?: number }
+    fault: { count?: number; [key: string]: unknown }
   ): void {
-    this.injectedFaults.set(path, { count: 1, ...fault })
+    this.handler.injectFault(path, fault as any)
   }
 
-  /**
-   * Clear all injected faults.
-   */
   clearInjectedFaults(): void {
-    this.injectedFaults.clear()
+    this.handler.clearInjectedFaults()
   }
-
-  /**
-   * Check if there's an injected fault for this path/method and consume it.
-   * Returns the fault config if one should be triggered, null otherwise.
-   */
-  private consumeInjectedFault(
-    path: string,
-    method: string
-  ): InjectedFault | null {
-    const fault = this.injectedFaults.get(path)
-    if (!fault) return null
-
-    // Check method filter
-    if (fault.method && fault.method.toUpperCase() !== method.toUpperCase()) {
-      return null
-    }
-
-    // Check probability
-    if (fault.probability !== undefined && Math.random() > fault.probability) {
-      return null
-    }
-
-    fault.count--
-    if (fault.count <= 0) {
-      this.injectedFaults.delete(path)
-    }
-
-    return fault
-  }
-
-  /**
-   * Apply delay from fault config (including jitter).
-   */
-  private async applyFaultDelay(fault: InjectedFault): Promise<void> {
-    if (fault.delayMs !== undefined && fault.delayMs > 0) {
-      const jitter = fault.jitterMs ? Math.random() * fault.jitterMs : 0
-      await new Promise((resolve) =>
-        setTimeout(resolve, fault.delayMs! + jitter)
-      )
-    }
-  }
-
-  /**
-   * Apply body modifications from stored fault (truncation, corruption).
-   * Returns modified body, or original if no modifications needed.
-   */
-  private applyFaultBodyModification(
-    res: ServerResponse,
-    body: Uint8Array
-  ): Uint8Array {
-    const fault = (res as ServerResponse & { _injectedFault?: InjectedFault })
-      ._injectedFault
-    if (!fault) return body
-
-    let modified = body
-
-    // Truncate body if configured
-    if (
-      fault.truncateBodyBytes !== undefined &&
-      modified.length > fault.truncateBodyBytes
-    ) {
-      modified = modified.slice(0, fault.truncateBodyBytes)
-    }
-
-    // Corrupt body if configured - deterministically break JSON structure
-    if (fault.corruptBody && modified.length > 0) {
-      modified = new Uint8Array(modified) // Make a copy to avoid mutating original
-      // Always corrupt the first byte (breaks JSON structure - the opening [ or {)
-      // and add some random corruption for good measure
-      modified[0] = 0x58 // 'X' - makes JSON syntactically invalid
-      if (modified.length > 1) {
-        modified[1] = 0x59 // 'Y'
-      }
-      // Also corrupt some bytes in the middle to catch edge cases
-      const numCorrupt = Math.max(1, Math.floor(modified.length * 0.1))
-      for (let i = 0; i < numCorrupt; i++) {
-        const pos = Math.floor(Math.random() * modified.length)
-        modified[pos] = 0x5a // 'Z' - valid UTF-8 but breaks JSON structure
-      }
-    }
-
-    return modified
-  }
-
-  // ============================================================================
-  // Request handling
-  // ============================================================================
 
   private async handleRequest(
     req: IncomingMessage,
     res: ServerResponse
   ): Promise<void> {
-    const url = new URL(req.url ?? `/`, `http://${req.headers.host}`)
-    const path = url.pathname
-    const method = req.method?.toUpperCase()
+    const baseUrl =
+      this._url ?? `http://${this.options.host}:${this.options.port}`
+    const webRequest = await nodeRequestToWebRequest(req, baseUrl)
 
-    // CORS headers for browser testing
-    res.setHeader(`access-control-allow-origin`, `*`)
-    res.setHeader(
-      `access-control-allow-methods`,
-      `GET, POST, PUT, DELETE, HEAD, OPTIONS`
-    )
-    res.setHeader(
-      `access-control-allow-headers`,
-      `content-type, authorization, Stream-Seq, Stream-TTL, Stream-Expires-At, Stream-Closed, Producer-Id, Producer-Epoch, Producer-Seq`
-    )
-    res.setHeader(
-      `access-control-expose-headers`,
-      `Stream-Next-Offset, Stream-Cursor, Stream-Up-To-Date, Stream-Closed, Producer-Epoch, Producer-Seq, Producer-Expected-Seq, Producer-Received-Seq, etag, content-type, content-encoding, vary`
-    )
+    const isSSE =
+      webRequest.method === `GET` &&
+      new URL(webRequest.url).searchParams.get(`live`) === `sse`
 
-    // Browser security headers (Protocol Section 10.7)
-    res.setHeader(`x-content-type-options`, `nosniff`)
-    res.setHeader(`cross-origin-resource-policy`, `cross-origin`)
-
-    // Handle CORS preflight
-    if (method === `OPTIONS`) {
-      res.writeHead(204)
-      res.end()
-      return
-    }
-
-    // Handle test control endpoints (for error injection)
-    if (path === `/_test/inject-error`) {
-      await this.handleTestInjectError(method, req, res)
-      return
-    }
-
-    // Check for injected faults (for testing retry/resilience)
-    const fault = this.consumeInjectedFault(path, method ?? `GET`)
-    if (fault) {
-      // Apply delay if configured
-      await this.applyFaultDelay(fault)
-
-      // Drop connection if configured (simulates network failure)
-      if (fault.dropConnection) {
-        res.socket?.destroy()
-        return
-      }
-
-      // If status is set, return an error response
-      if (fault.status !== undefined) {
-        const headers: Record<string, string> = {
-          "content-type": `text/plain`,
-        }
-        if (fault.retryAfter !== undefined) {
-          headers[`retry-after`] = fault.retryAfter.toString()
-        }
-        res.writeHead(fault.status, headers)
-        res.end(`Injected error for testing`)
-        return
-      }
-
-      // Store fault for response modification (truncation, corruption, SSE injection)
-      if (
-        fault.truncateBodyBytes !== undefined ||
-        fault.corruptBody ||
-        fault.injectSseEvent
-      ) {
-        ;(
-          res as ServerResponse & { _injectedFault?: InjectedFault }
-        )._injectedFault = fault
-      }
-    }
-
-    try {
-      switch (method) {
-        case `PUT`:
-          await this.handleCreate(path, req, res)
-          break
-        case `HEAD`:
-          this.handleHead(path, res)
-          break
-        case `GET`:
-          await this.handleRead(path, url, req, res)
-          break
-        case `POST`:
-          await this.handleAppend(path, req, res)
-          break
-        case `DELETE`:
-          await this.handleDelete(path, res)
-          break
-        default:
-          res.writeHead(405, { "content-type": `text/plain` })
-          res.end(`Method not allowed`)
-      }
-    } catch (err) {
-      if (err instanceof Error) {
-        if (err.message.includes(`not found`)) {
-          res.writeHead(404, { "content-type": `text/plain` })
-          res.end(`Stream not found`)
-        } else if (
-          err.message.includes(`already exists with different configuration`)
-        ) {
-          res.writeHead(409, { "content-type": `text/plain` })
-          res.end(`Stream already exists with different configuration`)
-        } else if (err.message.includes(`Sequence conflict`)) {
-          res.writeHead(409, { "content-type": `text/plain` })
-          res.end(`Sequence conflict`)
-        } else if (err.message.includes(`Content-type mismatch`)) {
-          res.writeHead(409, { "content-type": `text/plain` })
-          res.end(`Content-type mismatch`)
-        } else if (err.message.includes(`Invalid JSON`)) {
-          res.writeHead(400, { "content-type": `text/plain` })
-          res.end(`Invalid JSON`)
-        } else if (err.message.includes(`Empty arrays are not allowed`)) {
-          res.writeHead(400, { "content-type": `text/plain` })
-          res.end(`Empty arrays are not allowed`)
-        } else {
-          throw err
-        }
-      } else {
-        throw err
-      }
-    }
-  }
-
-  /**
-   * Handle PUT - create stream
-   */
-  private async handleCreate(
-    path: string,
-    req: IncomingMessage,
-    res: ServerResponse
-  ): Promise<void> {
-    let contentType = req.headers[`content-type`]
-
-    // Sanitize content-type: if empty or invalid, use default
-    if (
-      !contentType ||
-      contentType.trim() === `` ||
-      !/^[\w-]+\/[\w-]+/.test(contentType)
-    ) {
-      contentType = `application/octet-stream`
-    }
-
-    const ttlHeader = req.headers[STREAM_TTL_HEADER.toLowerCase()] as
-      | string
-      | undefined
-    const expiresAtHeader = req.headers[
-      STREAM_EXPIRES_AT_HEADER.toLowerCase()
-    ] as string | undefined
-
-    // Parse Stream-Closed header
-    const closedHeader = req.headers[STREAM_CLOSED_HEADER.toLowerCase()]
-    const createClosed = closedHeader === `true`
-
-    // Validate TTL and Expires-At headers
-    if (ttlHeader && expiresAtHeader) {
-      res.writeHead(400, { "content-type": `text/plain` })
-      res.end(`Cannot specify both Stream-TTL and Stream-Expires-At`)
-      return
-    }
-
-    let ttlSeconds: number | undefined
-    if (ttlHeader) {
-      // Strict TTL validation: must be a positive integer without leading zeros,
-      // plus signs, decimals, whitespace, or non-decimal notation
-      const ttlPattern = /^(0|[1-9]\d*)$/
-      if (!ttlPattern.test(ttlHeader)) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Stream-TTL value`)
-        return
-      }
-
-      ttlSeconds = parseInt(ttlHeader, 10)
-      if (isNaN(ttlSeconds) || ttlSeconds < 0) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Stream-TTL value`)
-        return
-      }
-    }
-
-    // Validate Expires-At timestamp format (ISO 8601)
-    if (expiresAtHeader) {
-      const timestamp = new Date(expiresAtHeader)
-      if (isNaN(timestamp.getTime())) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Stream-Expires-At timestamp`)
-        return
-      }
-    }
-
-    // Read body if present
-    const body = await this.readBody(req)
-
-    const isNew = !this.store.has(path)
-
-    // Support both sync (StreamStore) and async (FileBackedStreamStore) create
-    await Promise.resolve(
-      this.store.create(path, {
-        contentType,
-        ttlSeconds,
-        expiresAt: expiresAtHeader,
-        initialData: body.length > 0 ? body : undefined,
-        closed: createClosed,
+    if (isSSE) {
+      this.activeSSEResponses.add(res)
+      res.on(`close`, () => {
+        this.activeSSEResponses.delete(res)
       })
+    }
+
+    const acceptEncoding = req.headers[`accept-encoding`]
+
+    const webResponse = await this.handler.fetch(webRequest)
+
+    // Handle dropConnection: the handler signals this with a custom header
+    // since it can't actually destroy the socket
+    if (webResponse.headers.get(`x-drop-connection`) === `true`) {
+      res.socket?.destroy()
+      return
+    }
+
+    await writeWebResponseToNode(
+      webResponse,
+      res,
+      this.options.compression,
+      acceptEncoding
     )
-
-    const stream = this.store.get(path)!
-
-    // Call lifecycle hook for new streams
-    if (isNew && this.options.onStreamCreated) {
-      await Promise.resolve(
-        this.options.onStreamCreated({
-          type: `created`,
-          path,
-          contentType,
-          timestamp: Date.now(),
-        })
-      )
-    }
-
-    // Return 201 for new streams, 200 for idempotent creates
-    const headers: Record<string, string> = {
-      "content-type": contentType,
-      [STREAM_OFFSET_HEADER]: stream.currentOffset,
-    }
-
-    // Add Location header for 201 Created responses
-    if (isNew) {
-      headers[`location`] = `${this._url}${path}`
-    }
-
-    // Include Stream-Closed header if created closed
-    if (stream.closed) {
-      headers[STREAM_CLOSED_HEADER] = `true`
-    }
-
-    res.writeHead(isNew ? 201 : 200, headers)
-    res.end()
-  }
-
-  /**
-   * Handle HEAD - get metadata
-   */
-  private handleHead(path: string, res: ServerResponse): void {
-    const stream = this.store.get(path)
-    if (!stream) {
-      res.writeHead(404, { "content-type": `text/plain` })
-      res.end()
-      return
-    }
-
-    const headers: Record<string, string> = {
-      [STREAM_OFFSET_HEADER]: stream.currentOffset,
-      // HEAD responses should not be cached to avoid stale tail offsets (Protocol Section 5.4)
-      "cache-control": `no-store`,
-    }
-
-    if (stream.contentType) {
-      headers[`content-type`] = stream.contentType
-    }
-
-    // Include Stream-Closed if stream is closed
-    if (stream.closed) {
-      headers[STREAM_CLOSED_HEADER] = `true`
-    }
-
-    // Generate ETag: {path}:-1:{offset}[:c] (includes closure status)
-    // The :c suffix ensures ETag changes when a stream is closed, even without new data
-    const closedSuffix = stream.closed ? `:c` : ``
-    headers[`etag`] =
-      `"${Buffer.from(path).toString(`base64`)}:-1:${stream.currentOffset}${closedSuffix}"`
-
-    res.writeHead(200, headers)
-    res.end()
-  }
-
-  /**
-   * Handle GET - read data
-   */
-  private async handleRead(
-    path: string,
-    url: URL,
-    req: IncomingMessage,
-    res: ServerResponse
-  ): Promise<void> {
-    const stream = this.store.get(path)
-    if (!stream) {
-      res.writeHead(404, { "content-type": `text/plain` })
-      res.end(`Stream not found`)
-      return
-    }
-
-    const offset = url.searchParams.get(OFFSET_QUERY_PARAM) ?? undefined
-    const live = url.searchParams.get(LIVE_QUERY_PARAM)
-    const cursor = url.searchParams.get(CURSOR_QUERY_PARAM) ?? undefined
-
-    // Validate offset parameter
-    if (offset !== undefined) {
-      // Reject empty offset
-      if (offset === ``) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Empty offset parameter`)
-        return
-      }
-
-      // Reject multiple offset parameters
-      const allOffsets = url.searchParams.getAll(OFFSET_QUERY_PARAM)
-      if (allOffsets.length > 1) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Multiple offset parameters not allowed`)
-        return
-      }
-
-      // Validate offset format: must be "-1", "now", or match our offset format (digits_digits)
-      // This prevents path traversal, injection attacks, and invalid characters
-      const validOffsetPattern = /^(-1|now|\d+_\d+)$/
-      if (!validOffsetPattern.test(offset)) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid offset format`)
-        return
-      }
-    }
-
-    // Require offset parameter for long-poll and SSE per protocol spec
-    if ((live === `long-poll` || live === `sse`) && !offset) {
-      res.writeHead(400, { "content-type": `text/plain` })
-      res.end(
-        `${live === `sse` ? `SSE` : `Long-poll`} requires offset parameter`
-      )
-      return
-    }
-
-    // Determine if this is a binary stream that needs base64 encoding in SSE mode
-    let useBase64 = false
-    if (live === `sse`) {
-      const ct = stream.contentType?.toLowerCase().split(`;`)[0]?.trim() ?? ``
-      const isTextCompatible =
-        ct.startsWith(`text/`) || ct === `application/json`
-      useBase64 = !isTextCompatible
-    }
-
-    // Handle SSE mode
-    if (live === `sse`) {
-      // For SSE with offset=now, convert to actual tail offset
-      const sseOffset = offset === `now` ? stream.currentOffset : offset!
-      await this.handleSSE(path, stream, sseOffset, cursor, useBase64, res)
-      return
-    }
-
-    // For offset=now, convert to actual tail offset
-    // This allows long-poll to immediately start waiting for new data
-    const effectiveOffset = offset === `now` ? stream.currentOffset : offset
-
-    // Handle catch-up mode offset=now: return empty response with tail offset
-    // For long-poll mode, we fall through to wait for new data instead
-    if (offset === `now` && live !== `long-poll`) {
-      const headers: Record<string, string> = {
-        [STREAM_OFFSET_HEADER]: stream.currentOffset,
-        [STREAM_UP_TO_DATE_HEADER]: `true`,
-        // Prevent caching - tail offset changes with each append
-        [`cache-control`]: `no-store`,
-      }
-
-      if (stream.contentType) {
-        headers[`content-type`] = stream.contentType
-      }
-
-      // Include Stream-Closed if stream is closed (client at tail, upToDate)
-      if (stream.closed) {
-        headers[STREAM_CLOSED_HEADER] = `true`
-      }
-
-      // No ETag for offset=now responses - Cache-Control: no-store makes ETag unnecessary
-      // and some CDNs may behave unexpectedly with both headers
-
-      // For JSON mode, return empty array; otherwise empty body
-      const isJsonMode = stream.contentType?.includes(`application/json`)
-      const responseBody = isJsonMode ? `[]` : ``
-
-      res.writeHead(200, headers)
-      res.end(responseBody)
-      return
-    }
-
-    // Read current messages
-    let { messages, upToDate } = this.store.read(path, effectiveOffset)
-
-    // Only wait in long-poll if:
-    // 1. long-poll mode is enabled
-    // 2. Client provided an offset (not first request) OR used offset=now
-    // 3. Client's offset matches current offset (already caught up)
-    // 4. No new messages
-    const clientIsCaughtUp =
-      (effectiveOffset && effectiveOffset === stream.currentOffset) ||
-      offset === `now`
-    if (live === `long-poll` && clientIsCaughtUp && messages.length === 0) {
-      // If stream is closed and client is at tail, return immediately (don't wait)
-      if (stream.closed) {
-        res.writeHead(204, {
-          [STREAM_OFFSET_HEADER]: stream.currentOffset,
-          [STREAM_UP_TO_DATE_HEADER]: `true`,
-          [STREAM_CLOSED_HEADER]: `true`,
-        })
-        res.end()
-        return
-      }
-
-      const result = await this.store.waitForMessages(
-        path,
-        effectiveOffset ?? stream.currentOffset,
-        this.options.longPollTimeout
-      )
-
-      // If stream was closed during wait, return immediately with Stream-Closed
-      if (result.streamClosed) {
-        const responseCursor = generateResponseCursor(
-          cursor,
-          this.options.cursorOptions
-        )
-        res.writeHead(204, {
-          [STREAM_OFFSET_HEADER]: effectiveOffset ?? stream.currentOffset,
-          [STREAM_UP_TO_DATE_HEADER]: `true`,
-          [STREAM_CURSOR_HEADER]: responseCursor,
-          [STREAM_CLOSED_HEADER]: `true`,
-        })
-        res.end()
-        return
-      }
-
-      if (result.timedOut) {
-        // Return 204 No Content on timeout (per Protocol Section 5.6)
-        // Generate cursor for CDN cache collapsing (Protocol Section 8.1)
-        const responseCursor = generateResponseCursor(
-          cursor,
-          this.options.cursorOptions
-        )
-        // Check if stream was closed during the wait
-        const currentStream = this.store.get(path)
-        const timeoutHeaders: Record<string, string> = {
-          [STREAM_OFFSET_HEADER]: effectiveOffset ?? stream.currentOffset,
-          [STREAM_UP_TO_DATE_HEADER]: `true`,
-          [STREAM_CURSOR_HEADER]: responseCursor,
-        }
-        if (currentStream?.closed) {
-          timeoutHeaders[STREAM_CLOSED_HEADER] = `true`
-        }
-        res.writeHead(204, timeoutHeaders)
-        res.end()
-        return
-      }
-
-      messages = result.messages
-      upToDate = true
-    }
-
-    // Build response
-    const headers: Record<string, string> = {}
-
-    if (stream.contentType) {
-      headers[`content-type`] = stream.contentType
-    }
-
-    // Set offset header to the last message's offset, or current if no messages
-    const lastMessage = messages[messages.length - 1]
-    const responseOffset = lastMessage?.offset ?? stream.currentOffset
-    headers[STREAM_OFFSET_HEADER] = responseOffset
-
-    // Generate cursor for live mode responses (Protocol Section 8.1)
-    if (live === `long-poll`) {
-      headers[STREAM_CURSOR_HEADER] = generateResponseCursor(
-        cursor,
-        this.options.cursorOptions
-      )
-    }
-
-    // Set up-to-date header
-    if (upToDate) {
-      headers[STREAM_UP_TO_DATE_HEADER] = `true`
-    }
-
-    // Include Stream-Closed when stream is closed AND client is at tail AND upToDate
-    // Re-fetch stream to get current state (may have been closed during request)
-    const currentStream = this.store.get(path)
-    const clientAtTail = responseOffset === currentStream?.currentOffset
-    if (currentStream?.closed && clientAtTail && upToDate) {
-      headers[STREAM_CLOSED_HEADER] = `true`
-    }
-
-    // Generate ETag: based on path, start offset, end offset, and closure status
-    // The :c suffix ensures ETag changes when a stream is closed, even without new data
-    const startOffset = offset ?? `-1`
-    const closedSuffix =
-      currentStream?.closed && clientAtTail && upToDate ? `:c` : ``
-    const etag = `"${Buffer.from(path).toString(`base64`)}:${startOffset}:${responseOffset}${closedSuffix}"`
-    headers[`etag`] = etag
-
-    // Check If-None-Match for conditional GET (Protocol Section 8.1)
-    const ifNoneMatch = req.headers[`if-none-match`]
-    if (ifNoneMatch && ifNoneMatch === etag) {
-      res.writeHead(304, { etag })
-      res.end()
-      return
-    }
-
-    // Format response (wraps JSON in array brackets)
-    const responseData = this.store.formatResponse(path, messages)
-
-    // Apply compression if enabled and response is large enough
-    let finalData: Uint8Array = responseData
-    if (
-      this.options.compression &&
-      responseData.length >= COMPRESSION_THRESHOLD
-    ) {
-      const acceptEncoding = req.headers[`accept-encoding`]
-      const compressionEncoding = getCompressionEncoding(acceptEncoding)
-      if (compressionEncoding) {
-        finalData = compressData(responseData, compressionEncoding)
-        headers[`content-encoding`] = compressionEncoding
-        // Add Vary header to indicate response varies by Accept-Encoding
-        headers[`vary`] = `accept-encoding`
-      }
-    }
-
-    // Apply fault body modifications (truncation, corruption) if configured
-    finalData = this.applyFaultBodyModification(res, finalData)
-
-    res.writeHead(200, headers)
-    res.end(Buffer.from(finalData))
-  }
-
-  /**
-   * Handle SSE (Server-Sent Events) mode
-   */
-  private async handleSSE(
-    path: string,
-    stream: ReturnType<StreamStore[`get`]>,
-    initialOffset: string,
-    cursor: string | undefined,
-    useBase64: boolean,
-    res: ServerResponse
-  ): Promise<void> {
-    // Track this SSE connection
-    this.activeSSEResponses.add(res)
-
-    // Set SSE headers (explicitly including security headers for clarity)
-    const sseHeaders: Record<string, string> = {
-      "content-type": `text/event-stream`,
-      "cache-control": `no-cache`,
-      connection: `keep-alive`,
-      "access-control-allow-origin": `*`,
-      "x-content-type-options": `nosniff`,
-      "cross-origin-resource-policy": `cross-origin`,
-    }
-
-    // Add encoding header when base64 encoding is used for binary streams
-    if (useBase64) {
-      sseHeaders[STREAM_SSE_DATA_ENCODING_HEADER] = `base64`
-    }
-
-    res.writeHead(200, sseHeaders)
-
-    // Check for injected SSE event (for testing SSE parsing)
-    const fault = (res as ServerResponse & { _injectedFault?: InjectedFault })
-      ._injectedFault
-    if (fault?.injectSseEvent) {
-      // Send the injected SSE event before normal stream
-      res.write(`event: ${fault.injectSseEvent.eventType}\n`)
-      res.write(`data: ${fault.injectSseEvent.data}\n\n`)
-    }
-
-    let currentOffset = initialOffset
-    let isConnected = true
-    const decoder = new TextDecoder()
-
-    // Handle client disconnect
-    res.on(`close`, () => {
-      isConnected = false
-      this.activeSSEResponses.delete(res)
-    })
-
-    // Get content type for formatting
-    const isJsonStream = stream?.contentType?.includes(`application/json`)
-
-    // Send initial data and then wait for more
-    // Note: isConnected and isShuttingDown can change asynchronously
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    while (isConnected && !this.isShuttingDown) {
-      // Read current messages from offset
-      const { messages, upToDate } = this.store.read(path, currentOffset)
-
-      // Send data events for each message
-      for (const message of messages) {
-        // Format data based on content type and encoding
-        let dataPayload: string
-        if (useBase64) {
-          // Base64 encode binary data (Protocol Section 5.7)
-          dataPayload = Buffer.from(message.data).toString(`base64`)
-        } else if (isJsonStream) {
-          // Use formatResponse to get properly formatted JSON (strips trailing commas)
-          const jsonBytes = this.store.formatResponse(path, [message])
-          dataPayload = decoder.decode(jsonBytes)
-        } else {
-          dataPayload = decoder.decode(message.data)
-        }
-
-        // Send data event - encode multiline payloads per SSE spec
-        // Each line in the payload needs its own "data:" prefix
-        res.write(`event: data\n`)
-        res.write(encodeSSEData(dataPayload))
-
-        currentOffset = message.offset
-      }
-
-      // Compute offset the same way as HTTP GET: last message's offset, or stream's current offset
-      // Re-fetch stream to get current state (may have been closed)
-      const currentStream = this.store.get(path)
-      const controlOffset =
-        messages[messages.length - 1]?.offset ?? currentStream!.currentOffset
-
-      // Check if stream is closed and client is at tail
-      const streamIsClosed = currentStream?.closed ?? false
-      const clientAtTail = controlOffset === currentStream!.currentOffset
-
-      // Send control event with current offset/cursor (Protocol Section 5.7)
-      // Generate cursor for CDN cache collapsing (Protocol Section 8.1)
-      const responseCursor = generateResponseCursor(
-        cursor,
-        this.options.cursorOptions
-      )
-      const controlData: Record<string, string | boolean> = {
-        [SSE_OFFSET_FIELD]: controlOffset,
-      }
-
-      if (streamIsClosed && clientAtTail) {
-        // Final control event - stream is closed
-        // streamCursor is omitted when streamClosed is true per protocol
-        // upToDate is implied by streamClosed per protocol
-        controlData[SSE_CLOSED_FIELD] = true
-      } else {
-        // Normal control event - include cursor
-        controlData[SSE_CURSOR_FIELD] = responseCursor
-        // Include upToDate flag when client has caught up to head
-        if (upToDate) {
-          controlData[SSE_UP_TO_DATE_FIELD] = true
-        }
-      }
-
-      res.write(`event: control\n`)
-      res.write(encodeSSEData(JSON.stringify(controlData)))
-
-      // Close SSE connection after sending streamClosed
-      if (streamIsClosed && clientAtTail) {
-        break // Exit loop, connection will be closed
-      }
-
-      // Update currentOffset for next iteration (use controlOffset for consistency)
-      currentOffset = controlOffset
-
-      // If caught up, wait for new messages
-      if (upToDate) {
-        // Check if stream was closed during processing (before wait)
-        if (currentStream?.closed) {
-          // Send final control event and exit
-          const finalControlData: Record<string, string | boolean> = {
-            [SSE_OFFSET_FIELD]: currentOffset,
-            [SSE_CLOSED_FIELD]: true,
-          }
-          res.write(`event: control\n`)
-          res.write(encodeSSEData(JSON.stringify(finalControlData)))
-          break
-        }
-
-        const result = await this.store.waitForMessages(
-          path,
-          currentOffset,
-          this.options.longPollTimeout
-        )
-
-        // Check if we should exit after wait returns (values can change during await)
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (this.isShuttingDown || !isConnected) break
-
-        // Check if stream was closed during wait
-        if (result.streamClosed) {
-          const finalControlData: Record<string, string | boolean> = {
-            [SSE_OFFSET_FIELD]: currentOffset,
-            [SSE_CLOSED_FIELD]: true,
-          }
-          res.write(`event: control\n`)
-          res.write(encodeSSEData(JSON.stringify(finalControlData)))
-          break
-        }
-
-        if (result.timedOut) {
-          // Send keep-alive control event on timeout (Protocol Section 5.7)
-          // Generate cursor for CDN cache collapsing (Protocol Section 8.1)
-          const keepAliveCursor = generateResponseCursor(
-            cursor,
-            this.options.cursorOptions
-          )
-
-          // Check if stream was closed during the wait
-          const streamAfterWait = this.store.get(path)
-          if (streamAfterWait?.closed) {
-            const closedControlData: Record<string, string | boolean> = {
-              [SSE_OFFSET_FIELD]: currentOffset,
-              [SSE_CLOSED_FIELD]: true,
-            }
-            res.write(`event: control\n`)
-            res.write(encodeSSEData(JSON.stringify(closedControlData)))
-            break
-          }
-
-          const keepAliveData: Record<string, string | boolean> = {
-            [SSE_OFFSET_FIELD]: currentOffset,
-            [SSE_CURSOR_FIELD]: keepAliveCursor,
-            [SSE_UP_TO_DATE_FIELD]: true, // Still caught up after timeout
-          }
-          // Single write for keep-alive control event
-          res.write(
-            `event: control\n` + encodeSSEData(JSON.stringify(keepAliveData))
-          )
-        }
-        // Loop will continue and read new messages
-      }
-    }
-
-    this.activeSSEResponses.delete(res)
-    res.end()
-  }
-
-  /**
-   * Handle POST - append data
-   */
-  private async handleAppend(
-    path: string,
-    req: IncomingMessage,
-    res: ServerResponse
-  ): Promise<void> {
-    const contentType = req.headers[`content-type`]
-    const seq = req.headers[STREAM_SEQ_HEADER.toLowerCase()] as
-      | string
-      | undefined
-
-    // Parse Stream-Closed header
-    const closedHeader = req.headers[STREAM_CLOSED_HEADER.toLowerCase()]
-    const closeStream = closedHeader === `true`
-
-    // Extract producer headers
-    const producerId = req.headers[PRODUCER_ID_HEADER.toLowerCase()] as
-      | string
-      | undefined
-    const producerEpochStr = req.headers[
-      PRODUCER_EPOCH_HEADER.toLowerCase()
-    ] as string | undefined
-    const producerSeqStr = req.headers[PRODUCER_SEQ_HEADER.toLowerCase()] as
-      | string
-      | undefined
-
-    // Validate producer headers - all three must be present together or none
-    // Also reject empty producer ID (do this before reading body)
-    const hasProducerHeaders =
-      producerId !== undefined ||
-      producerEpochStr !== undefined ||
-      producerSeqStr !== undefined
-    const hasAllProducerHeaders =
-      producerId !== undefined &&
-      producerEpochStr !== undefined &&
-      producerSeqStr !== undefined
-
-    if (hasProducerHeaders && !hasAllProducerHeaders) {
-      res.writeHead(400, { "content-type": `text/plain` })
-      res.end(
-        `All producer headers (Producer-Id, Producer-Epoch, Producer-Seq) must be provided together`
-      )
-      return
-    }
-
-    if (hasAllProducerHeaders && producerId === ``) {
-      res.writeHead(400, { "content-type": `text/plain` })
-      res.end(`Invalid Producer-Id: must not be empty`)
-      return
-    }
-
-    // Parse and validate producer epoch and seq as integers
-    // Use strict digit-only validation to reject values like "1abc" or "1e3"
-    const STRICT_INTEGER_REGEX = /^\d+$/
-    let producerEpoch: number | undefined
-    let producerSeq: number | undefined
-    if (hasAllProducerHeaders) {
-      if (!STRICT_INTEGER_REGEX.test(producerEpochStr)) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Producer-Epoch: must be a non-negative integer`)
-        return
-      }
-      producerEpoch = Number(producerEpochStr)
-      if (!Number.isSafeInteger(producerEpoch)) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Producer-Epoch: must be a non-negative integer`)
-        return
-      }
-
-      if (!STRICT_INTEGER_REGEX.test(producerSeqStr)) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Producer-Seq: must be a non-negative integer`)
-        return
-      }
-      producerSeq = Number(producerSeqStr)
-      if (!Number.isSafeInteger(producerSeq)) {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid Producer-Seq: must be a non-negative integer`)
-        return
-      }
-    }
-
-    const body = await this.readBody(req)
-
-    // Handle close-only request (empty body with Stream-Closed: true)
-    // Note: Content-Type validation is skipped for close-only requests per protocol Section 5.2
-    if (body.length === 0 && closeStream) {
-      // Close-only with producer headers participates in producer sequencing
-      if (hasAllProducerHeaders) {
-        const closeResult = await this.store.closeStreamWithProducer(path, {
-          producerId: producerId,
-          producerEpoch: producerEpoch!,
-          producerSeq: producerSeq!,
-        })
-
-        if (!closeResult) {
-          res.writeHead(404, { "content-type": `text/plain` })
-          res.end(`Stream not found`)
-          return
-        }
-
-        // Handle producer validation results
-        if (closeResult.producerResult?.status === `duplicate`) {
-          res.writeHead(204, {
-            [STREAM_OFFSET_HEADER]: closeResult.finalOffset,
-            [STREAM_CLOSED_HEADER]: `true`,
-            [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
-            [PRODUCER_SEQ_HEADER]:
-              closeResult.producerResult.lastSeq.toString(),
-          })
-          res.end()
-          return
-        }
-
-        if (closeResult.producerResult?.status === `stale_epoch`) {
-          res.writeHead(403, {
-            "content-type": `text/plain`,
-            [PRODUCER_EPOCH_HEADER]:
-              closeResult.producerResult.currentEpoch.toString(),
-          })
-          res.end(`Stale producer epoch`)
-          return
-        }
-
-        if (closeResult.producerResult?.status === `invalid_epoch_seq`) {
-          res.writeHead(400, { "content-type": `text/plain` })
-          res.end(`New epoch must start with sequence 0`)
-          return
-        }
-
-        if (closeResult.producerResult?.status === `sequence_gap`) {
-          res.writeHead(409, {
-            "content-type": `text/plain`,
-            [PRODUCER_EXPECTED_SEQ_HEADER]:
-              closeResult.producerResult.expectedSeq.toString(),
-            [PRODUCER_RECEIVED_SEQ_HEADER]:
-              closeResult.producerResult.receivedSeq.toString(),
-          })
-          res.end(`Producer sequence gap`)
-          return
-        }
-
-        // Stream already closed by a different producer - conflict
-        if (closeResult.producerResult?.status === `stream_closed`) {
-          const stream = this.store.get(path)
-          res.writeHead(409, {
-            "content-type": `text/plain`,
-            [STREAM_CLOSED_HEADER]: `true`,
-            [STREAM_OFFSET_HEADER]: stream?.currentOffset ?? ``,
-          })
-          res.end(`Stream is closed`)
-          return
-        }
-
-        res.writeHead(204, {
-          [STREAM_OFFSET_HEADER]: closeResult.finalOffset,
-          [STREAM_CLOSED_HEADER]: `true`,
-          [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
-          [PRODUCER_SEQ_HEADER]: producerSeq!.toString(),
-        })
-        res.end()
-        return
-      }
-
-      // Close-only without producer headers (simple idempotent close)
-      const closeResult = this.store.closeStream(path)
-      if (!closeResult) {
-        res.writeHead(404, { "content-type": `text/plain` })
-        res.end(`Stream not found`)
-        return
-      }
-
-      res.writeHead(204, {
-        [STREAM_OFFSET_HEADER]: closeResult.finalOffset,
-        [STREAM_CLOSED_HEADER]: `true`,
-      })
-      res.end()
-      return
-    }
-
-    // Empty body without Stream-Closed is an error
-    if (body.length === 0) {
-      res.writeHead(400, { "content-type": `text/plain` })
-      res.end(`Empty body`)
-      return
-    }
-
-    // Content-Type is required per protocol (for requests with body)
-    if (!contentType) {
-      res.writeHead(400, { "content-type": `text/plain` })
-      res.end(`Content-Type header is required`)
-      return
-    }
-
-    // Build append options (include close flag for append-and-close)
-    const appendOptions = {
-      seq,
-      contentType,
-      producerId,
-      producerEpoch,
-      producerSeq,
-      close: closeStream,
-    }
-
-    // Use appendWithProducer for serialized producer operations
-    let result
-    if (producerId !== undefined) {
-      result = await this.store.appendWithProducer(path, body, appendOptions)
-    } else {
-      result = await Promise.resolve(
-        this.store.append(path, body, appendOptions)
-      )
-    }
-
-    // Handle AppendResult with producer validation or streamClosed
-    if (result && typeof result === `object` && `message` in result) {
-      const { message, producerResult, streamClosed } = result as {
-        message: { offset: string } | null
-        producerResult?: {
-          status: string
-          lastSeq?: number
-          currentEpoch?: number
-          expectedSeq?: number
-          receivedSeq?: number
-        }
-        streamClosed?: boolean
-      }
-
-      // Handle append to closed stream
-      if (streamClosed && !message) {
-        // Check if this is an idempotent producer duplicate (matching closing tuple)
-        if (producerResult?.status === `duplicate`) {
-          const stream = this.store.get(path)
-          res.writeHead(204, {
-            [STREAM_OFFSET_HEADER]: stream?.currentOffset ?? ``,
-            [STREAM_CLOSED_HEADER]: `true`,
-            [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
-            [PRODUCER_SEQ_HEADER]: producerResult.lastSeq!.toString(),
-          })
-          res.end()
-          return
-        }
-
-        // Not a duplicate - stream was closed by different request, return 409
-        const closedStream = this.store.get(path)
-        res.writeHead(409, {
-          "content-type": `text/plain`,
-          [STREAM_CLOSED_HEADER]: `true`,
-          [STREAM_OFFSET_HEADER]: closedStream?.currentOffset ?? ``,
-        })
-        res.end(`Stream is closed`)
-        return
-      }
-
-      if (!producerResult || producerResult.status === `accepted`) {
-        // Success - return offset
-        const responseHeaders: Record<string, string> = {
-          [STREAM_OFFSET_HEADER]: message!.offset,
-        }
-        // Echo back the producer epoch and seq (highest accepted)
-        if (producerEpoch !== undefined) {
-          responseHeaders[PRODUCER_EPOCH_HEADER] = producerEpoch.toString()
-        }
-        if (producerSeq !== undefined) {
-          responseHeaders[PRODUCER_SEQ_HEADER] = producerSeq.toString()
-        }
-        // Include Stream-Closed if stream was closed with this append
-        if (streamClosed) {
-          responseHeaders[STREAM_CLOSED_HEADER] = `true`
-        }
-        // Use 200 for producer appends (with headers), 204 for non-producer appends
-        const statusCode = producerId !== undefined ? 200 : 204
-        res.writeHead(statusCode, responseHeaders)
-        res.end()
-        return
-      }
-
-      // Handle producer validation failures
-      switch (producerResult.status) {
-        case `duplicate`: {
-          // 204 No Content for duplicates (idempotent success)
-          // Return Producer-Seq as highest accepted (per PROTOCOL.md)
-          const dupHeaders: Record<string, string> = {
-            [PRODUCER_EPOCH_HEADER]: producerEpoch!.toString(),
-            [PRODUCER_SEQ_HEADER]: producerResult.lastSeq!.toString(),
-          }
-          // Include Stream-Closed if the stream is now closed
-          if (streamClosed) {
-            dupHeaders[STREAM_CLOSED_HEADER] = `true`
-          }
-          res.writeHead(204, dupHeaders)
-          res.end()
-          return
-        }
-
-        case `stale_epoch`: {
-          // 403 Forbidden for stale epochs (zombie fencing)
-          res.writeHead(403, {
-            "content-type": `text/plain`,
-            [PRODUCER_EPOCH_HEADER]: producerResult.currentEpoch!.toString(),
-          })
-          res.end(`Stale producer epoch`)
-          return
-        }
-
-        case `invalid_epoch_seq`:
-          // 400 Bad Request for epoch increase with seq != 0
-          res.writeHead(400, { "content-type": `text/plain` })
-          res.end(`New epoch must start with sequence 0`)
-          return
-
-        case `sequence_gap`:
-          // 409 Conflict for sequence gaps
-          res.writeHead(409, {
-            "content-type": `text/plain`,
-            [PRODUCER_EXPECTED_SEQ_HEADER]:
-              producerResult.expectedSeq!.toString(),
-            [PRODUCER_RECEIVED_SEQ_HEADER]:
-              producerResult.receivedSeq!.toString(),
-          })
-          res.end(`Producer sequence gap`)
-          return
-      }
-    }
-
-    // Standard append (no producer) - result is StreamMessage
-    const message = result as { offset: string }
-    const responseHeaders: Record<string, string> = {
-      [STREAM_OFFSET_HEADER]: message.offset,
-    }
-    // Include Stream-Closed if stream was closed with this append
-    if (closeStream) {
-      responseHeaders[STREAM_CLOSED_HEADER] = `true`
-    }
-    res.writeHead(204, responseHeaders)
-    res.end()
-  }
-
-  /**
-   * Handle DELETE - delete stream
-   */
-  private async handleDelete(path: string, res: ServerResponse): Promise<void> {
-    if (!this.store.has(path)) {
-      res.writeHead(404, { "content-type": `text/plain` })
-      res.end(`Stream not found`)
-      return
-    }
-
-    this.store.delete(path)
-
-    // Call lifecycle hook
-    if (this.options.onStreamDeleted) {
-      await Promise.resolve(
-        this.options.onStreamDeleted({
-          type: `deleted`,
-          path,
-          timestamp: Date.now(),
-        })
-      )
-    }
-
-    res.writeHead(204)
-    res.end()
-  }
-
-  /**
-   * Handle test control endpoints for error injection.
-   * POST /_test/inject-error - inject an error
-   * DELETE /_test/inject-error - clear all injected errors
-   */
-  private async handleTestInjectError(
-    method: string | undefined,
-    req: IncomingMessage,
-    res: ServerResponse
-  ): Promise<void> {
-    if (method === `POST`) {
-      const body = await this.readBody(req)
-      try {
-        const config = JSON.parse(new TextDecoder().decode(body)) as {
-          path: string
-          // Legacy fields (still supported)
-          status?: number
-          count?: number
-          retryAfter?: number
-          // New fault injection fields
-          delayMs?: number
-          dropConnection?: boolean
-          truncateBodyBytes?: number
-          probability?: number
-          method?: string
-          corruptBody?: boolean
-          jitterMs?: number
-          // SSE event injection (for testing SSE parsing)
-          injectSseEvent?: {
-            eventType: string
-            data: string
-          }
-        }
-
-        if (!config.path) {
-          res.writeHead(400, { "content-type": `text/plain` })
-          res.end(`Missing required field: path`)
-          return
-        }
-
-        // Must have at least one fault type specified
-        const hasFaultType =
-          config.status !== undefined ||
-          config.delayMs !== undefined ||
-          config.dropConnection ||
-          config.truncateBodyBytes !== undefined ||
-          config.corruptBody ||
-          config.injectSseEvent !== undefined
-        if (!hasFaultType) {
-          res.writeHead(400, { "content-type": `text/plain` })
-          res.end(
-            `Must specify at least one fault type: status, delayMs, dropConnection, truncateBodyBytes, corruptBody, or injectSseEvent`
-          )
-          return
-        }
-
-        this.injectFault(config.path, {
-          status: config.status,
-          count: config.count ?? 1,
-          retryAfter: config.retryAfter,
-          delayMs: config.delayMs,
-          dropConnection: config.dropConnection,
-          truncateBodyBytes: config.truncateBodyBytes,
-          probability: config.probability,
-          method: config.method,
-          corruptBody: config.corruptBody,
-          jitterMs: config.jitterMs,
-          injectSseEvent: config.injectSseEvent,
-        })
-
-        res.writeHead(200, { "content-type": `application/json` })
-        res.end(JSON.stringify({ ok: true }))
-      } catch {
-        res.writeHead(400, { "content-type": `text/plain` })
-        res.end(`Invalid JSON body`)
-      }
-    } else if (method === `DELETE`) {
-      this.clearInjectedFaults()
-      res.writeHead(200, { "content-type": `application/json` })
-      res.end(JSON.stringify({ ok: true }))
-    } else {
-      res.writeHead(405, { "content-type": `text/plain` })
-      res.end(`Method not allowed`)
-    }
-  }
-
-  // ============================================================================
-  // Helpers
-  // ============================================================================
-
-  private readBody(req: IncomingMessage): Promise<Uint8Array> {
-    return new Promise((resolve, reject) => {
-      const chunks: Array<Buffer> = []
-
-      req.on(`data`, (chunk: Buffer) => {
-        chunks.push(chunk)
-      })
-
-      req.on(`end`, () => {
-        const body = Buffer.concat(chunks)
-        resolve(new Uint8Array(body))
-      })
-
-      req.on(`error`, reject)
-    })
   }
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -244,3 +244,82 @@ export interface PendingLongPoll {
    */
   timeoutId: ReturnType<typeof setTimeout>
 }
+
+export type MaybePromise<T> = T | Promise<T>
+
+export interface AppendOptions {
+  seq?: string
+  contentType?: string
+  producerId?: string
+  producerEpoch?: number
+  producerSeq?: number
+  close?: boolean
+}
+
+export interface AppendResult {
+  message: StreamMessage | null
+  producerResult?: ProducerValidationResult
+  streamClosed?: boolean
+}
+
+export interface DurableStreamStore {
+  has: (path: string) => MaybePromise<boolean>
+  create: (
+    path: string,
+    options: {
+      contentType?: string
+      ttlSeconds?: number
+      expiresAt?: string
+      initialData?: Uint8Array
+      closed?: boolean
+    }
+  ) => MaybePromise<Stream>
+  get: (path: string) => MaybePromise<Stream | undefined>
+  read: (
+    path: string,
+    offset?: string
+  ) => MaybePromise<{ messages: Array<StreamMessage>; upToDate: boolean }>
+  formatResponse: (
+    path: string,
+    messages: Array<StreamMessage>
+  ) => MaybePromise<Uint8Array>
+  waitForMessages: (
+    path: string,
+    offset: string,
+    timeoutMs: number
+  ) => Promise<{
+    messages: Array<StreamMessage>
+    timedOut: boolean
+    streamClosed?: boolean
+  }>
+  append: (
+    path: string,
+    data: Uint8Array,
+    options?: AppendOptions
+  ) => MaybePromise<StreamMessage | AppendResult>
+  appendWithProducer: (
+    path: string,
+    data: Uint8Array,
+    options: AppendOptions
+  ) => Promise<AppendResult>
+  closeStream: (
+    path: string
+  ) => MaybePromise<{ finalOffset: string; alreadyClosed: boolean } | null>
+  closeStreamWithProducer: (
+    path: string,
+    options: {
+      producerId: string
+      producerEpoch: number
+      producerSeq: number
+    }
+  ) => Promise<{
+    finalOffset: string
+    alreadyClosed: boolean
+    producerResult?: ProducerValidationResult
+  } | null>
+  delete: (path: string) => MaybePromise<boolean>
+  clear: () => MaybePromise<void>
+  cancelAllWaits: () => MaybePromise<void>
+  getCurrentOffset: (path: string) => MaybePromise<string | undefined>
+  list: () => MaybePromise<Array<string>>
+}

--- a/packages/server/test/file-backed.test.ts
+++ b/packages/server/test/file-backed.test.ts
@@ -39,7 +39,7 @@ afterEach(async () => {
 // ============================================================================
 
 describe(`Path Encoding`, () => {
-  test(`should not misdetect hash suffix with base64url underscore`, () => {
+  test(`should not misdetect hash suffix with base64url underscore`, async () => {
     // Create a path that when base64url encoded ends with underscore + 16 chars
     // But those 16 chars are NOT a hex hash
     // Base64url uses [A-Za-z0-9_-], so we can construct a tricky case
@@ -48,17 +48,17 @@ describe(`Path Encoding`, () => {
     // where X are base64url chars (not necessarily hex)
     const trickyPath = `/stream/` + `a`.repeat(120) + `_test_value_data`
 
-    const encoded = encodeStreamPath(trickyPath)
+    const encoded = await encodeStreamPath(trickyPath)
     const decoded = decodeStreamPath(encoded)
 
     expect(decoded).toBe(trickyPath)
   })
 
-  test(`should use hash for very long paths`, () => {
+  test(`should use hash for very long paths`, async () => {
     // Create a very long path that will get hashed
     const longPath = `/stream/` + `x`.repeat(250)
 
-    const encoded = encodeStreamPath(longPath)
+    const encoded = await encodeStreamPath(longPath)
 
     // Should contain ~ separator for hash (not underscore)
     expect(encoded).toContain(`~`)

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -1,7 +1,21 @@
 import type { Options } from "tsdown"
 
 const config: Options = {
-  entry: ["src/index.ts"],
+  entry: [
+    "src/index.ts",
+    "src/handler.ts",
+    "src/types.ts",
+    "src/errors.ts",
+    "src/constants.ts",
+    "src/offsets.ts",
+    "src/cursor.ts",
+    "src/protocol.ts",
+    "src/path.ts",
+    "src/registry-hook.ts",
+    "src/storage/memory.ts",
+    "src/file-store.ts",
+    "src/server.ts",
+  ],
   format: ["esm", "cjs"],
   platform: "node",
   dts: true,


### PR DESCRIPTION
### Web API + Modular exports for @durable-streams/server

rewrote the `server` package to support Web Standard APIs (`Request`/`Response`/`ReadableStream`) so it can theoretically run on any runtime. ported over to Cloudflare Workers on my package, [durable-cf-streams](https://github.com/flbn/durable-cf-streams). related PR: https://github.com/flbn/durable-cf-streams/pull/18

but technically the same can be done on Deno, Bun, and obviously as the PR shows, Node. the node specific code (LMDB, node:fs, node:crypto, node:http) was tangled into the same entry points as some of potentially runtime agnostic handlers and protocol logic. this PR splits the package into granular, independently importable modules with a clear boundary: everything except `./storage/file` and `./node/server` is runtime-agnostic and uses only Web APIs.

What changed

Node APIs → Web APIs:

`path.ts` uses `crypto.subtle.digest` instead of `node:crypto` for stream path encoding
protocol constants were extracted from handler internals into an importable `./constants` module
offset math, cursor logic, JSON processing, expiration checks — all extracted into standalone modules with zero Node dependencies
`handler.ts` explicitly depends only on Web Standard types (`Request`, `Response`, `ReadableStream`)

Node-specific code quarantined:

`./storage/file` — `FileBackedStreamStore` (LMDB + node:fs)
`./node/server` — `DurableStreamTestServer` (node:http adapter)
everything else is safe to import from Workers, Deno, Bun, or any Web API runtime

before:
```
// one grab bag — pulls in node:crypto, types, protocol utils, store, handler
import {
  DurableStreamHandler,
  StreamStore,
  normalizeContentType,
  calculateCursor,
} from "@durable-streams/server/handler"
```

after
```
// import only what you need — all runtime-agnostic
import { DurableStreamHandler } from "@durable-streams/server/handler"
import { MemoryStore } from "@durable-streams/server/storage/memory"
import type { DurableStreamStore, Stream } from "@durable-streams/server/types"
import { normalizeContentType, processJsonAppend } from "@durable-streams/server/protocol"
import { parseOffset, advanceOffset } from "@durable-streams/server/offsets"
import { StreamNotFoundError, InvalidJsonError } from "@durable-streams/server/errors"
import { STREAM_OFFSET_HEADER } from "@durable-streams/server/constants"
import { encodeStreamPath } from "@durable-streams/server/path"
```

other changes

typed errors — handler catches by instanceof instead of string matching on err.message
`StreamStore` → `MemoryStore` — backward compat alias kept