### PR TITLE
feat: make @durable-streams/proxy backend-configurable

### DIFF
--- a/.changeset/backend-configurable.md
+++ b/.changeset/backend-configurable.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/proxy": patch
+---
+
+Add `streamPath` and `backendHeaders` options to `ProxyServerOptions` for configurable backend URL paths and authentication headers

--- a/packages/proxy/src/__tests__/backend-config.test.ts
+++ b/packages/proxy/src/__tests__/backend-config.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Tests for backend configuration options (streamPath and backendHeaders).
+ *
+ * Verifies that the proxy correctly applies custom URL paths and headers
+ * when communicating with the durable-streams backend.
+ */
+
+import { createServer } from "node:http"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createProxyServer } from "../server"
+import { createAIStreamingResponse, createMockUpstream } from "./harness"
+import type { MockUpstreamServer } from "./harness"
+import type { ProxyServer } from "../server"
+import type { IncomingMessage, Server, ServerResponse } from "node:http"
+
+/**
+ * A recording backend that captures all requests and proxies them
+ * to a real durable-streams server (or returns canned responses).
+ */
+interface RecordedRequest {
+  method: string
+  url: string
+  headers: Record<string, string>
+}
+
+interface RecordingBackend {
+  url: string
+  requests: Array<RecordedRequest>
+  stop: () => Promise<void>
+  clear: () => void
+}
+
+/**
+ * Create a backend that records requests, then proxies them to the real
+ * durable-streams server so the full flow works end-to-end.
+ */
+async function createRecordingBackend(
+  realBackendUrl: string
+): Promise<RecordingBackend> {
+  const requests: Array<RecordedRequest> = []
+
+  const server: Server = createServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      // Record the request
+      requests.push({
+        method: req.method ?? `GET`,
+        url: req.url ?? `/`,
+        headers: Object.fromEntries(
+          Object.entries(req.headers).map(([k, v]) => [
+            k,
+            Array.isArray(v) ? v.join(`, `) : (v ?? ``),
+          ])
+        ),
+      })
+
+      // Collect request body
+      const chunks: Array<Buffer> = []
+      for await (const chunk of req) {
+        chunks.push(chunk as Buffer)
+      }
+      const body = Buffer.concat(chunks)
+
+      // Proxy to real backend
+      const targetUrl = new URL(req.url ?? `/`, realBackendUrl)
+      const proxyHeaders: Record<string, string> = {}
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (key !== `host` && key !== `connection`) {
+          proxyHeaders[key] = Array.isArray(value)
+            ? value.join(`, `)
+            : (value ?? ``)
+        }
+      }
+
+      try {
+        const proxyRes = await fetch(targetUrl.toString(), {
+          method: req.method ?? `GET`,
+          headers: proxyHeaders,
+          body: body.length > 0 ? (body as unknown as BodyInit) : undefined,
+        })
+
+        const responseHeaders: Record<string, string> = {}
+        proxyRes.headers.forEach((value, key) => {
+          responseHeaders[key] = value
+        })
+
+        res.writeHead(proxyRes.status, responseHeaders)
+
+        if (proxyRes.body) {
+          const reader = proxyRes.body.getReader()
+          try {
+            for (;;) {
+              const { done, value } = await reader.read()
+              if (done) break
+              res.write(value)
+            }
+          } finally {
+            reader.releaseLock()
+          }
+        }
+        res.end()
+      } catch {
+        res.writeHead(502)
+        res.end(`Backend proxy error`)
+      }
+    }
+  )
+
+  const port = 10000 + Math.floor(Math.random() * 50000)
+
+  await new Promise<void>((resolve, reject) => {
+    server.on(`error`, reject)
+    server.listen(port, `localhost`, () => {
+      server.removeListener(`error`, reject)
+      resolve()
+    })
+  })
+
+  return {
+    url: `http://localhost:${port}`,
+    requests,
+    clear: () => {
+      requests.length = 0
+    },
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = `test-secret-key-for-development`
+
+let upstream: MockUpstreamServer
+let realBackend: { url: string; stop: () => Promise<void> }
+let recordingBackend: RecordingBackend
+
+// Proxy instances – created per describe block
+let defaultProxy: ProxyServer
+let customPathProxy: ProxyServer
+let staticHeadersProxy: ProxyServer
+let fnHeadersProxy: ProxyServer
+let asyncHeadersProxy: ProxyServer
+
+beforeAll(async () => {
+  // 1. Start mock upstream (simulates the AI provider)
+  const basePort = 10000 + Math.floor(Math.random() * 50000)
+  upstream = await createMockUpstream({ port: basePort, host: `localhost` })
+
+  // 2. Start real durable-streams server
+  const { DurableStreamTestServer } = await import(`@durable-streams/server`)
+  const ds = new DurableStreamTestServer({
+    port: basePort + 1,
+    host: `localhost`,
+  })
+  const dsUrl = await ds.start()
+  realBackend = { url: dsUrl, stop: () => ds.stop() }
+
+  // 3. Start recording backend (sits between proxy and real backend)
+  recordingBackend = await createRecordingBackend(dsUrl)
+
+  // 4. Start proxy variants
+  const allowlist = [`http://localhost:*/**`]
+
+  defaultProxy = await createProxyServer({
+    port: basePort + 3,
+    host: `localhost`,
+    durableStreamsUrl: recordingBackend.url,
+    allowlist,
+    jwtSecret: JWT_SECRET,
+  })
+
+  customPathProxy = await createProxyServer({
+    port: basePort + 4,
+    host: `localhost`,
+    durableStreamsUrl: recordingBackend.url,
+    allowlist,
+    jwtSecret: JWT_SECRET,
+    streamPath: (id) => `/v1/myproject/stream/${id}`,
+  })
+
+  staticHeadersProxy = await createProxyServer({
+    port: basePort + 5,
+    host: `localhost`,
+    durableStreamsUrl: recordingBackend.url,
+    allowlist,
+    jwtSecret: JWT_SECRET,
+    backendHeaders: {
+      "X-Custom": `static-value`,
+      Authorization: `Bearer static-token`,
+    },
+  })
+
+  fnHeadersProxy = await createProxyServer({
+    port: basePort + 6,
+    host: `localhost`,
+    durableStreamsUrl: recordingBackend.url,
+    allowlist,
+    jwtSecret: JWT_SECRET,
+    backendHeaders: ({ streamId, method }) => ({
+      "X-Stream-Id": streamId,
+      "X-Method": method,
+    }),
+  })
+
+  asyncHeadersProxy = await createProxyServer({
+    port: basePort + 7,
+    host: `localhost`,
+    durableStreamsUrl: recordingBackend.url,
+    allowlist,
+    jwtSecret: JWT_SECRET,
+    backendHeaders: async ({ streamId }) => {
+      // Simulate async token minting
+      await new Promise((r) => setTimeout(r, 5))
+      return { Authorization: `Bearer async-jwt-for-${streamId}` }
+    },
+  })
+})
+
+afterAll(async () => {
+  await Promise.all([
+    defaultProxy.stop(),
+    customPathProxy.stop(),
+    staticHeadersProxy.stop(),
+    fnHeadersProxy.stop(),
+    asyncHeadersProxy.stop(),
+  ])
+  await recordingBackend.stop()
+  await realBackend.stop()
+  await upstream.stop()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createStreamVia(
+  proxyUrl: string,
+  upstreamUrl: string
+): Promise<{ streamId: string; streamUrl: string }> {
+  const url = new URL(`/v1/proxy`, proxyUrl)
+  url.searchParams.set(`secret`, JWT_SECRET)
+
+  const response = await fetch(url.toString(), {
+    method: `POST`,
+    headers: {
+      "Upstream-URL": upstreamUrl,
+      "Upstream-Method": `POST`,
+      "Content-Type": `application/json`,
+    },
+    body: JSON.stringify({ prompt: `test` }),
+  })
+
+  expect(response.status).toBe(201)
+
+  const location = response.headers.get(`Location`)!
+  const streamUrl = new URL(location, proxyUrl).toString()
+  const match = new URL(streamUrl).pathname.match(/\/v1\/proxy\/([^/]+)\/?$/)
+  const streamId = decodeURIComponent(match![1]!)
+
+  return { streamId, streamUrl }
+}
+
+async function headStreamVia(
+  proxyUrl: string,
+  streamId: string
+): Promise<number> {
+  const url = new URL(`/v1/proxy/${streamId}`, proxyUrl)
+  url.searchParams.set(`secret`, JWT_SECRET)
+  const res = await fetch(url.toString(), { method: `HEAD` })
+  return res.status
+}
+
+async function waitForReady(proxyUrl: string, streamId: string): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < 5000) {
+    if ((await headStreamVia(proxyUrl, streamId)) === 200) return
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  throw new Error(`Timed out waiting for stream ${streamId}`)
+}
+
+async function deleteStreamVia(
+  proxyUrl: string,
+  streamId: string
+): Promise<number> {
+  const url = new URL(`/v1/proxy/${streamId}`, proxyUrl)
+  url.searchParams.set(`secret`, JWT_SECRET)
+  const res = await fetch(url.toString(), { method: `DELETE` })
+  return res.status
+}
+
+async function readStreamVia(
+  streamUrl: string
+): Promise<{ status: number; body: string }> {
+  const url = new URL(streamUrl)
+  url.searchParams.set(`offset`, `-1`)
+  const res = await fetch(url.toString())
+  return { status: res.status, body: await res.text() }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe(`default behavior (no streamPath or backendHeaders)`, () => {
+  it(`uses /v1/streams/:id path by default`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`default`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      defaultProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(defaultProxy.url, streamId)
+
+    // The recording backend should have received requests with /v1/streams/<id>
+    const backendRequests = recordingBackend.requests.filter((r) =>
+      r.url.includes(streamId)
+    )
+    expect(backendRequests.length).toBeGreaterThan(0)
+
+    for (const req of backendRequests) {
+      expect(req.url).toMatch(new RegExp(`^/v1/streams/${streamId}`))
+    }
+  })
+
+  it(`sends no extra headers by default`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`default`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      defaultProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(defaultProxy.url, streamId)
+
+    const backendRequests = recordingBackend.requests.filter((r) =>
+      r.url.includes(streamId)
+    )
+    expect(backendRequests.length).toBeGreaterThan(0)
+
+    // Should NOT have custom headers
+    for (const req of backendRequests) {
+      expect(req.headers[`x-custom`]).toBeUndefined()
+      expect(req.headers[`x-stream-id`]).toBeUndefined()
+    }
+  })
+})
+
+describe(`custom streamPath`, () => {
+  it(`produces correct backend URLs`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`custom-path`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      customPathProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    // The recording backend sees /v1/myproject/stream/<id> but the real
+    // backend behind it expects /v1/streams/<id>, so the create will fail.
+    // That's expected — we're testing the URL that was *sent*.
+
+    // Wait a bit for the PUT to be recorded
+    await new Promise((r) => setTimeout(r, 200))
+
+    const backendRequests = recordingBackend.requests.filter((r) =>
+      r.url.includes(streamId)
+    )
+    expect(backendRequests.length).toBeGreaterThan(0)
+
+    for (const req of backendRequests) {
+      expect(req.url).toMatch(new RegExp(`^/v1/myproject/stream/${streamId}`))
+      // Verify the old default path is NOT used
+      expect(req.url).not.toContain(`/v1/streams/`)
+    }
+  })
+})
+
+describe(`static backendHeaders`, () => {
+  it(`includes static headers on all backend requests`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`static-hdrs`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      staticHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(staticHeadersProxy.url, streamId)
+
+    const backendRequests = recordingBackend.requests.filter((r) =>
+      r.url.includes(streamId)
+    )
+    expect(backendRequests.length).toBeGreaterThan(0)
+
+    for (const req of backendRequests) {
+      expect(req.headers[`x-custom`]).toBe(`static-value`)
+      expect(req.headers[`authorization`]).toBe(`Bearer static-token`)
+    }
+  })
+
+  it(`includes static headers on HEAD requests`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`head-hdrs`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      staticHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(staticHeadersProxy.url, streamId)
+
+    // Now do a HEAD
+    recordingBackend.clear()
+    await headStreamVia(staticHeadersProxy.url, streamId)
+
+    const headRequests = recordingBackend.requests.filter(
+      (r) => r.method === `HEAD`
+    )
+    expect(headRequests.length).toBe(1)
+    expect(headRequests[0]!.headers[`x-custom`]).toBe(`static-value`)
+    expect(headRequests[0]!.headers[`authorization`]).toBe(
+      `Bearer static-token`
+    )
+  })
+
+  it(`includes static headers on DELETE requests`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`delete-hdrs`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      staticHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(staticHeadersProxy.url, streamId)
+
+    recordingBackend.clear()
+    await deleteStreamVia(staticHeadersProxy.url, streamId)
+
+    const deleteRequests = recordingBackend.requests.filter(
+      (r) => r.method === `DELETE`
+    )
+    expect(deleteRequests.length).toBe(1)
+    expect(deleteRequests[0]!.headers[`x-custom`]).toBe(`static-value`)
+    expect(deleteRequests[0]!.headers[`authorization`]).toBe(
+      `Bearer static-token`
+    )
+  })
+
+  it(`includes static headers on GET (read) requests`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`read-hdrs`]))
+    recordingBackend.clear()
+
+    const { streamId, streamUrl } = await createStreamVia(
+      staticHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(staticHeadersProxy.url, streamId)
+
+    recordingBackend.clear()
+    await readStreamVia(streamUrl)
+
+    const getRequests = recordingBackend.requests.filter(
+      (r) => r.method === `GET`
+    )
+    expect(getRequests.length).toBe(1)
+    expect(getRequests[0]!.headers[`x-custom`]).toBe(`static-value`)
+    expect(getRequests[0]!.headers[`authorization`]).toBe(`Bearer static-token`)
+  })
+})
+
+describe(`function backendHeaders`, () => {
+  it(`calls function with correct { streamId, method } context`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`fn-hdrs`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      fnHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(fnHeadersProxy.url, streamId)
+
+    const backendRequests = recordingBackend.requests.filter((r) =>
+      r.url.includes(streamId)
+    )
+    expect(backendRequests.length).toBeGreaterThan(0)
+
+    // Check that the function was called with the correct streamId
+    for (const req of backendRequests) {
+      expect(req.headers[`x-stream-id`]).toBe(streamId)
+      expect(req.headers[`x-method`]).toBe(req.method)
+    }
+  })
+
+  it(`receives PUT method on stream creation`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`fn-put`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      fnHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    // Wait a bit for the PUT to be recorded
+    await new Promise((r) => setTimeout(r, 200))
+
+    const putRequests = recordingBackend.requests.filter(
+      (r) => r.method === `PUT` && r.url.includes(streamId)
+    )
+    expect(putRequests.length).toBe(1)
+    expect(putRequests[0]!.headers[`x-method`]).toBe(`PUT`)
+    expect(putRequests[0]!.headers[`x-stream-id`]).toBe(streamId)
+  })
+})
+
+describe(`async backendHeaders`, () => {
+  it(`resolves async function and includes headers`, async () => {
+    upstream.setResponse(createAIStreamingResponse([`async-hdrs`]))
+    recordingBackend.clear()
+
+    const { streamId } = await createStreamVia(
+      asyncHeadersProxy.url,
+      upstream.url + `/v1/chat`
+    )
+
+    await waitForReady(asyncHeadersProxy.url, streamId)
+
+    const backendRequests = recordingBackend.requests.filter((r) =>
+      r.url.includes(streamId)
+    )
+    expect(backendRequests.length).toBeGreaterThan(0)
+
+    for (const req of backendRequests) {
+      expect(req.headers[`authorization`]).toBe(
+        `Bearer async-jwt-for-${streamId}`
+      )
+    }
+  })
+})

--- a/packages/proxy/src/__tests__/harness/server-orchestrator.ts
+++ b/packages/proxy/src/__tests__/harness/server-orchestrator.ts
@@ -20,7 +20,7 @@
 import { DurableStreamTestServer } from "@durable-streams/server"
 import { createProxyServer } from "../../server"
 import { createMockUpstream } from "./mock-upstream"
-import type { ProxyServer } from "../../server"
+import type { ProxyServer, ProxyServerOptions } from "../../server"
 import type { MockUpstreamServer } from "./mock-upstream"
 
 /**
@@ -37,6 +37,8 @@ export interface OrchestratorOptions {
   allowlist?: Array<string>
   /** Skip starting the proxy server (use PROXY_CONFORMANCE_URL instead) */
   useExternalProxy?: boolean
+  /** Extra options to pass to createProxyServer */
+  proxyOptions?: Partial<ProxyServerOptions>
 }
 
 /**
@@ -135,6 +137,7 @@ export async function startTestServers(
     allowlist,
     jwtSecret: `test-secret-key-for-development`,
     streamTtlSeconds: 3600, // 1 hour for tests
+    ...options.proxyOptions,
   })
 
   return {

--- a/packages/proxy/src/server/backend.ts
+++ b/packages/proxy/src/server/backend.ts
@@ -1,0 +1,52 @@
+/**
+ * Backend URL and header helpers for the durable-streams proxy.
+ *
+ * Centralises how the proxy builds URLs and resolves headers for
+ * all requests to the underlying durable-streams server.
+ */
+
+import type { ProxyServerOptions } from "./types"
+
+/**
+ * Build the full backend URL for a stream.
+ *
+ * Uses `options.streamPath` if provided, otherwise defaults to
+ * `/v1/streams/${streamId}`.
+ *
+ * @param options - Proxy server options (needs `durableStreamsUrl` and optionally `streamPath`)
+ * @param streamId - The stream ID
+ * @returns Full URL string
+ */
+export function buildBackendUrl(
+  options: Pick<ProxyServerOptions, `durableStreamsUrl` | `streamPath`>,
+  streamId: string
+): string {
+  const path = options.streamPath
+    ? options.streamPath(streamId)
+    : `/v1/streams/${streamId}`
+  return new URL(path, options.durableStreamsUrl).toString()
+}
+
+/**
+ * Resolve backend headers for a request.
+ *
+ * If `options.backendHeaders` is a function, calls it with context.
+ * If it's a static object, returns it directly.
+ * If undefined, returns an empty object.
+ *
+ * @param options - Proxy server options (needs optionally `backendHeaders`)
+ * @param ctx - Request context
+ * @returns Headers to include on the backend request
+ */
+export async function resolveBackendHeaders(
+  options: Pick<ProxyServerOptions, `backendHeaders`>,
+  ctx: { streamId: string; method: string }
+): Promise<Record<string, string>> {
+  if (!options.backendHeaders) {
+    return {}
+  }
+  if (typeof options.backendHeaders === `function`) {
+    return options.backendHeaders(ctx)
+  }
+  return options.backendHeaders
+}

--- a/packages/proxy/src/server/head-stream.ts
+++ b/packages/proxy/src/server/head-stream.ts
@@ -7,6 +7,7 @@
  */
 
 import { validateServiceJwt } from "./tokens"
+import { buildBackendUrl, resolveBackendHeaders } from "./backend"
 import { sendError } from "./response"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { ProxyServerOptions } from "./types"
@@ -50,12 +51,17 @@ export async function handleHeadStream(
   }
 
   // Get metadata from underlying durable stream
-  const dsUrl = new URL(`/v1/streams/${streamId}`, options.durableStreamsUrl)
+  const dsUrl = buildBackendUrl(options, streamId)
 
   try {
     // Use HEAD request to underlying server
-    const dsResponse = await fetch(dsUrl.toString(), {
+    const extra = await resolveBackendHeaders(options, {
+      streamId,
       method: `HEAD`,
+    })
+    const dsResponse = await fetch(dsUrl, {
+      method: `HEAD`,
+      headers: extra,
     })
 
     if (dsResponse.status === 404) {

--- a/packages/proxy/src/server/index.ts
+++ b/packages/proxy/src/server/index.ts
@@ -118,3 +118,4 @@ export {
   HOP_BY_HOP_HEADERS,
 } from "./allowlist"
 export { sendError, sendJson } from "./response"
+export { buildBackendUrl, resolveBackendHeaders } from "./backend"

--- a/packages/proxy/src/server/types.ts
+++ b/packages/proxy/src/server/types.ts
@@ -22,6 +22,16 @@ export interface ProxyServerOptions {
   urlExpirationSeconds?: number
   /** Maximum response size in bytes (default: 100MB) */
   maxResponseBytes?: number
+  /** Build the backend URL path for a stream. Default: (id) => `/v1/streams/${id}` */
+  streamPath?: (streamId: string) => string
+  /** Headers to include on all requests to the durable-streams backend.
+   *  Static object or async function for per-request headers (e.g., short-lived JWTs). */
+  backendHeaders?:
+    | Record<string, string>
+    | ((ctx: {
+        streamId: string
+        method: string
+      }) => Record<string, string> | Promise<Record<string, string>>)
 }
 
 /**


### PR DESCRIPTION
Hi! I really appreciate all your work on this whole project! I made a cloudflare implementation of [durable-streams](https://github.com/commoncurriculum/durable-streams-cloudflare) and I'd love to use the proxy but I can't given the hardcoded choices in it. Here's a PR that let's you customize the headers and the path -- it's pretty minimal.

Let me know if it needs any changes!

## Summary

- Adds `streamPath` option to `ProxyServerOptions` — custom function to build backend URL paths (default: `/v1/streams/:id`)
- Adds `backendHeaders` option — static object or async function for per-request headers to the durable-streams backend (e.g., short-lived JWTs)
- All 6 backend fetch call sites (PUT, POST×2, GET, HEAD, DELETE) now use shared `buildBackendUrl()` and `resolveBackendHeaders()` helpers
- Default behavior is unchanged when neither option is provided

### Example usage

```typescript
const server = await createProxyServer({
  durableStreamsUrl: "https://ds.example.com",
  jwtSecret: process.env.JWT_SECRET,
  allowlist: ["https://api.openai.com/**"],

  // Custom URL convention
  streamPath: (id) => `/v1/myproject/stream/${id}`,

  // JWT auth for backend
  backendHeaders: ({ streamId }) => ({
    Authorization: `Bearer ${mintJwt({ sub: "myproject", scope: "write" })}`,
  }),
})
```

## Tests completed:

- [x] All 96 existing tests pass unchanged (default behavior preserved)
- [x] 10 new tests in `backend-config.test.ts` covering:
  - Default path (`/v1/streams/:id`) when `streamPath` not provided
  - No extra headers when `backendHeaders` not provided
  - Custom `streamPath` produces correct backend URLs
  - Static `backendHeaders` object included on PUT, POST, HEAD, GET, DELETE
  - Function `backendHeaders` called with correct `{ streamId, method }` context
  - Async `backendHeaders` (returning a Promise) resolves correctly

[Claude Code](https://claude.com/claude-code) and I worked on this together quite a bit. 