### PR TITLE
Add proxy protocol spec v0.1

### DIFF
--- a/packages/proxy/PROXY_PROTOCOL.md
+++ b/packages/proxy/PROXY_PROTOCOL.md
@@ -506,10 +506,10 @@ The specific CORS policy (allowed origins, max age, etc.) is implementation-defi
 
 ## 11. Error Codes
 
-The proxy protocol defines the following error codes. Servers **SHOULD** return errors as JSON objects with `error` and `message` fields:
+The proxy protocol defines the following error codes. Servers **SHOULD** return errors as JSON objects with a nested `error` object containing `code` and `message` fields:
 
 ```json
-{ "error": "ERROR_CODE", "message": "Human-readable description" }
+{ "error": { "code": "ERROR_CODE", "message": "Human-readable description" } }
 ```
 
 ### 11.1. Request Validation Errors
@@ -526,7 +526,8 @@ The proxy protocol defines the following error codes. Servers **SHOULD** return 
 
 | HTTP Status | Error Code          | Description                                    |
 | ----------- | ------------------- | ---------------------------------------------- |
-| 401         | `UNAUTHORIZED`      | Missing or invalid service authentication      |
+| 401         | `MISSING_SECRET`    | No service authentication provided             |
+| 401         | `INVALID_SECRET`    | Service authentication credentials are invalid |
 | 401         | `SIGNATURE_EXPIRED` | Pre-signed URL has expired                     |
 | 401         | `SIGNATURE_INVALID` | Pre-signed URL signature verification failed   |
 | 401         | `MISSING_SIGNATURE` | Pre-signed URL parameters required but missing |
@@ -542,13 +543,15 @@ The proxy protocol defines the following error codes. Servers **SHOULD** return 
 | HTTP Status | Error Code         | Description                                                                  |
 | ----------- | ------------------ | ---------------------------------------------------------------------------- |
 | 502         | `UPSTREAM_ERROR`   | Upstream returned a non-2xx, non-3xx response (see `Upstream-Status` header) |
+| 502         | `STORAGE_ERROR`    | Failed to create or write to the durable stream backend                      |
 | 504         | `UPSTREAM_TIMEOUT` | Upstream did not respond within the header resolution timeout                |
 
 ### 11.5. Standard Errors
 
-| HTTP Status | Error Code  | Description                    |
-| ----------- | ----------- | ------------------------------ |
-| 404         | `NOT_FOUND` | Stream or route does not exist |
+| HTTP Status | Error Code         | Description                         |
+| ----------- | ------------------ | ----------------------------------- |
+| 404         | `NOT_FOUND`        | Route does not exist                |
+| 404         | `STREAM_NOT_FOUND` | The specified stream does not exist |
 
 ## 12. Security Considerations
 


### PR DESCRIPTION
## Summary

- Adds `PROXY_PROTOCOL.md` — the protocol specification for the Durable Streams Proxy extension, defining the HTTP interface for forwarding requests to upstream services and persisting their streaming responses to durable streams.

## Detail

The proxy package README references `PROXY_PROTOCOL.md` but the document didn't exist. This PR adds the initial draft (v0.1) of the protocol specification.

The spec defines the proxy as a pure superset of the base Durable Streams Protocol, covering:

- **HTTP operations**: POST (create), GET (read), HEAD (metadata), PATCH (abort), DELETE
- **Header handling**: `Upstream-URL`, `Upstream-Method`, `Upstream-Authorization` semantics and hop-by-hop filtering
- **Pre-signed URLs**: Capability URLs for per-stream read and abort access
- **Upstream URL allowlist**: SSRF prevention via allowlist validation and redirect blocking
- **Upstream fetch lifecycle**: Timeouts, response piping, chunk batching, abort behavior
- **Authentication model**: Service auth (implementation-defined) and stream auth (pre-signed URLs)
- **Error codes**: Standardised error codes and response format
- **Security considerations**: SSRF, pre-signed URL security, TLS

The spec is deliberately minimal for a v0.1 baseline — several areas are left implementation-defined (authentication mechanism, allowlist syntax, signing scheme) and abort/error stream closure semantics are explicitly deferred to a future revision.

The spec was reviewed against the reference implementation in `packages/proxy` to ensure conformance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change introducing a new protocol spec file; no runtime behavior or security-sensitive code paths are modified.
> 
> **Overview**
> Adds a new `packages/proxy/PROXY_PROTOCOL.md` draft specification describing the **Durable Streams Proxy Protocol** extension, defining how a proxy can forward an upstream HTTP request and persist the streaming response into a durable stream for resumable reads.
> 
> The doc standardizes the proxy’s HTTP surface (create/read/head/abort/delete), header forwarding/filtering rules, pre-signed URL capability model, upstream allowlist + redirect blocking guidance, lifecycle/timeouts, error codes, and security considerations (SSRF, signature handling, TLS).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a0fb6bc5ba3d2e61ca2398d0826744942301e1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->