### PR TITLE
Proxy protocol and RFC v0.2

### DIFF
--- a/packages/proxy/PROXY_PROTOCOL.md
+++ b/packages/proxy/PROXY_PROTOCOL.md
@@ -467,9 +467,20 @@ Authenticates via pre-signed URL parameters (`expires` and `signature`) or via s
 
 The response body contains framed binary data (see Section 5). Clients **MUST** parse the frame format to extract individual upstream responses. The byte offset semantics from the base protocol apply — clients can resume reading from any byte offset, including mid-frame. Client implementations **MUST** handle partial frames when resuming from a non-zero offset that falls within a frame.
 
+When `live=sse`, framed bytes are transported via SSE `event: data` events (base protocol Section 5.7):
+
+- If the server includes `Stream-SSE-Data-Encoding: base64`, each SSE data event payload is an independently base64-encoded byte chunk.
+- Clients **MUST** decode each SSE data event payload independently before feeding bytes into the frame parser.
+- If `Stream-SSE-Data-Encoding` is absent, SSE data event payloads are already UTF-8-compatible and can be consumed as-is.
+- SSE `event: control` messages carry stream metadata (`streamNextOffset`, `streamCursor`, `upToDate`, `streamClosed`) per the base protocol.
+
 #### Response Headers
 
 All standard `Stream-*` response headers from the base protocol.
+
+For `live=sse`, servers **MAY** include:
+
+- `Stream-SSE-Data-Encoding: base64` — indicates SSE `event: data` payloads are base64-encoded and must be decoded before frame parsing.
 
 #### Response Codes
 


### PR DESCRIPTION
To either merge into or replace #238

See https://github.com/durable-streams/durable-streams/commit/c4fccb9e4cb5381200060ecf6c12641eb3a4505b for the changes to the RFC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/spec-only change with no executable code, but it codifies breaking protocol semantics that downstream implementations must follow.
> 
> **Overview**
> Adds an accepted design RFC (`docs/rfcs/0001-proxy-stream-reuse.md`) describing **named stream reuse**, a **connect** operation for signed-URL refresh (optionally via an auth endpoint), client-side `requestId` → `responseId` idempotency, and a **binary framing** format for multiplexing multiple upstream responses onto one durable stream.
> 
> Updates `packages/proxy/PROXY_PROTOCOL.md` to **v0.2**, formalizing URL-based dispatch (`POST {proxy-url}`, `POST {proxy-url}/{stream-id}`, `POST ...?action=connect`), new/changed headers (`Stream-Response-Id`, `Stream-Signed-URL-TTL`, optional `Stream-SSE-Data-Encoding`), structured `SIGNATURE_EXPIRED` errors including `streamId`, revised abort semantics (optional `response=`), and a fully specified framing format (S/D/C/A/E) plus updated auth/CORS/error-code sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e56c6dd718e4fdbd6c4871a080a552746d7666a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->