### PR TITLE
fix: live: true should default to SSE instead of long-poll

### DIFF
--- a/packages/client/src/response.ts
+++ b/packages/client/src/response.ts
@@ -10,6 +10,7 @@ import {
   STREAM_CLOSED_HEADER,
   STREAM_CURSOR_HEADER,
   STREAM_OFFSET_HEADER,
+  STREAM_SSE_DATA_ENCODING_HEADER,
   STREAM_UP_TO_DATE_HEADER,
 } from "./constants"
 import { DurableStreamError } from "./error"
@@ -478,6 +479,12 @@ export class StreamResponseImpl<
       this.#requestAbortController.signal
     )
     if (newSSEResponse.body) {
+      if (!this.#encoding) {
+        const enc = newSSEResponse.headers.get(STREAM_SSE_DATA_ENCODING_HEADER)
+        if (enc === `base64`) {
+          this.#encoding = `base64`
+        }
+      }
       return parseSSEStream(
         newSSEResponse.body,
         this.#requestAbortController.signal
@@ -778,6 +785,29 @@ export class StreamResponseImpl<
               this.#requestAbortController.signal,
               resumingFromPause
             )
+
+            // Check if fetchNext returned an SSE response (live: true sends live=sse)
+            const isSSEResponse =
+              response.headers
+                .get(`content-type`)
+                ?.includes(`text/event-stream`) ?? false
+
+            if (isSSEResponse && response.body) {
+              this.#markSSEConnectionStart()
+              if (!this.#encoding) {
+                const enc = response.headers.get(
+                  STREAM_SSE_DATA_ENCODING_HEADER
+                )
+                if (enc === `base64`) {
+                  this.#encoding = `base64`
+                }
+              }
+              sseEventIterator = parseSSEStream(
+                response.body,
+                this.#requestAbortController.signal
+              )
+              return
+            }
 
             this.#updateStateFromResponse(response)
             controller.enqueue(response)

--- a/packages/client/src/stream-api.ts
+++ b/packages/client/src/stream-api.ts
@@ -220,9 +220,9 @@ async function streamInternal<TJson = unknown>(
     // For subsequent requests, set live mode unless resuming from pause
     // (resuming from pause needs immediate response for UI status)
     if (!resumingFromPause) {
-      if (live === `sse`) {
+      if (live === `sse` || live === true) {
         nextUrl.searchParams.set(LIVE_QUERY_PARAM, `sse`)
-      } else if (live === true || live === `long-poll`) {
+      } else if (live === `long-poll`) {
         nextUrl.searchParams.set(LIVE_QUERY_PARAM, `long-poll`)
       }
     }
@@ -254,7 +254,7 @@ async function streamInternal<TJson = unknown>(
 
   // Create SSE start function (for SSE mode reconnection)
   const startSSE =
-    live === `sse`
+    live !== false && live !== `long-poll`
       ? async (
           offset: Offset,
           cursor: string | undefined,

--- a/packages/client/test/transition.test.ts
+++ b/packages/client/test/transition.test.ts
@@ -1,10 +1,10 @@
 /**
- * Test to verify the automatic transition from catch-up to live polling.
+ * Test to verify the automatic transition from catch-up to live SSE.
  * This specifically tests the stream() with live: true behavior.
  *
- * Default mode always uses long-poll after catch-up (SSE is only used when
- * explicitly requested with live: "sse") because SSE is harder to scale
- * with HTTP proxies.
+ * When live: true is used, the client defaults to SSE for subsequent
+ * requests after catch-up, since the server supports SSE for all content
+ * types (binary gets base64-encoded).
  */
 
 import { describe, expect, vi } from "vitest"
@@ -12,9 +12,9 @@ import { DurableStream } from "../src"
 import { testWithStream, testWithTextStream } from "./support/test-context"
 import { decode, encode } from "./support/test-helpers"
 
-describe(`Catchup to Live Polling Transition`, () => {
+describe(`Catchup to Live SSE Transition`, () => {
   testWithStream(
-    `should automatically transition from catchup to long-poll for binary streams`,
+    `should automatically transition from catchup to SSE for binary streams`,
     async ({ streamUrl, store, streamPath, aborter }) => {
       const capturedUrls: Array<string> = []
 
@@ -35,7 +35,7 @@ describe(`Catchup to Live Polling Transition`, () => {
 
       const receivedData: Array<string> = []
 
-      // Start reading with live: true mode (auto transition to long-poll)
+      // Start reading with live: true mode (auto transition to SSE)
       const readPromise = (async () => {
         const response = await handle.stream({
           signal: aborter.signal,
@@ -64,10 +64,7 @@ describe(`Catchup to Live Polling Transition`, () => {
         expect(capturedUrls.length).toBeGreaterThanOrEqual(1)
       )
 
-      // Verify first request was catch-up (no live param or auto mode)
-      // The new API sends live=auto in the query params
-
-      // Append data while client should be in live polling mode
+      // Append data while client should be in SSE mode
       store.append(streamPath, encode(`live-data-1`))
 
       // Wait for first live data to be received
@@ -85,7 +82,7 @@ describe(`Catchup to Live Polling Transition`, () => {
   )
 
   testWithTextStream(
-    `should automatically transition from catchup to long-poll for text streams (not SSE)`,
+    `should automatically transition from catchup to SSE for text streams`,
     async ({ streamUrl, store, streamPath, aborter }) => {
       const capturedUrls: Array<string> = []
 
@@ -135,7 +132,7 @@ describe(`Catchup to Live Polling Transition`, () => {
         expect(capturedUrls.length).toBeGreaterThanOrEqual(1)
       )
 
-      // Append data while client should be in long-poll mode
+      // Append data while client should be in SSE mode
       store.append(streamPath, encode(`live-data-1`))
 
       await readPromise
@@ -143,9 +140,9 @@ describe(`Catchup to Live Polling Transition`, () => {
       // Verify we received the live data
       expect(receivedData).toContain(`live-data-1`)
 
-      // Verify we didn't see SSE requests - SSE is only used when explicitly requested
+      // Verify SSE requests ARE made - live: true now defaults to SSE
       const sawSSERequest = capturedUrls.some((url) => url.includes(`live=sse`))
-      expect(sawSSERequest).toBe(false)
+      expect(sawSSERequest).toBe(true)
     }
   )
 })


### PR DESCRIPTION
fixes #250 

## Summary
- live: true was documented as "auto-select best mode" but always fell through to long-poll because a refactor replaced the "auto" string literal with true without implementing the actual auto-selection logic
- In stream-api.ts, group live === true with sse in fetchNext so subsequent requests send live=sse, and create startSSE for any live mode that isn't false or long-poll
- In response.ts, detect text/event-stream content-type after fetchNext returns in the long-poll continuation path and transition inline to SSE processing (avoids OOM in mock tests vs. a separate transition block). Add encoding detection from SSE response headers in #trySSEReconnect for reconnections where encoding wasn't set initially
- Update transition.test.ts to expect SSE behavior instead of long-poll when using live: true

## Test plan
- [ ] Verify `pnpm --filter @durable-streams/client` builds cleanly
- [ ] Verify `pnpm vitest run --project client` succeeds
- [ ] Verify `pnpm vitest run --project server` succeeds