### PR TITLE
docs: add Fork reference page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -75,6 +75,7 @@ export default defineConfig({
             collapsed: false,
           },
           { text: "JSON mode", link: "/json-mode" },
+          { text: "Fork", link: "/fork" },
           { text: "Durable Proxy", link: "/durable-proxy" },
           { text: "Durable State", link: "/durable-state" },
           { text: "StreamDB", link: "/stream-db" },

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -1,0 +1,120 @@
+---
+title: Fork
+description: >-
+  Create a new stream that branches from a source stream at a specific offset,
+  inheriting its data without copying.
+outline: [2, 3]
+---
+
+# Fork
+
+Create a new stream that branches from a source stream at a specific offset, inheriting its data without copying.
+
+A fork is created with a `PUT` to a new URL that carries the `Stream-Forked-From` header. Once created, the fork behaves as an independent stream.
+
+## What fork does
+
+A `PUT` that carries `Stream-Forked-From: <source-path>` creates a new stream that references the source's data up to `Stream-Fork-Offset`. Offsets below `Stream-Fork-Offset` resolve against the source without copying; offsets at or above resolve against the fork's own appends. `Stream-Fork-Offset` is optional and defaults to the source's current tail. The fork is independent of its source: it has its own URL, TTL, closure state, and deletion, and can outlive the source.
+
+```
+source:  [0] [1] [2] [3] [4] [5] [6] [7]
+                      │
+                      │ fork at offset 4
+                      ▼
+fork:    [0] [1] [2] [3] [4'] [5'] [6']
+         └── inherited ──┘└── fork's own ──┘
+```
+
+## Using HTTP
+
+Create a fork. `Stream-Fork-Offset` is optional and defaults to the source's current tail; `Content-Type` is optional and inherited from the source.
+
+```bash
+curl -X PUT http://localhost:4437/v1/stream/my-fork \
+  -H 'Stream-Forked-From: /v1/stream/my-source' \
+  -H 'Stream-Fork-Offset: 1024'
+```
+
+Read the fork. Reads transparently span the fork boundary — the client never needs to know the stream is a fork.
+
+```bash
+curl "http://localhost:4437/v1/stream/my-fork?offset=-1"
+```
+
+Append to the fork. Appends go only to the fork; the source is untouched.
+
+```bash
+curl -X POST http://localhost:4437/v1/stream/my-fork \
+  -H 'Content-Type: application/octet-stream' \
+  -d 'a new event only visible on the fork'
+```
+
+## Using a client library
+
+::: code-group
+
+```typescript [TypeScript]
+import { DurableStream } from "@durable-streams/client"
+
+// Create the fork — pass the fork headers via the existing headers option
+await DurableStream.create({
+  url: "http://localhost:4437/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": "1024", // optional; defaults to source tail
+  },
+})
+
+// Use a fresh handle for ongoing reads/writes
+const fork = await DurableStream.connect({
+  url: "http://localhost:4437/v1/stream/my-fork",
+})
+
+await fork.append("a new event only visible on the fork")
+```
+
+```python [Python]
+from durable_streams import DurableStream
+
+# Create the fork — pass the fork headers
+DurableStream.create(
+    "http://localhost:4437/v1/stream/my-fork",
+    headers={
+        "Stream-Forked-From": "/v1/stream/my-source",
+        "Stream-Fork-Offset": "1024",  # optional; defaults to source tail
+    },
+)
+
+# Use a fresh handle for ongoing reads/writes
+fork = DurableStream.connect("http://localhost:4437/v1/stream/my-fork")
+fork.append(b"a new event only visible on the fork")
+```
+
+:::
+
+`headers` apply to every request on a given handle — use a fresh handle after create to avoid resending fork headers on reads and appends.
+
+## TTL and expiry
+
+A fork has its own TTL and expiry. If the fork request provides `Stream-TTL` or `Stream-Expires-At`, the fork uses those values — it can outlive the source or die earlier.
+
+If the fork request omits expiry, the fork inherits from the source. A source with a TTL passes its TTL value on and the fork runs its own sliding window. A source with an `Expires-At` passes its hard deadline on, so the fork cannot be accidentally retained past the source's expiry. A source with no expiry yields a fork with no expiry.
+
+## Deletion and lifecycle
+
+- **Deleting a fork** — decrements the source's reference count and removes the fork.
+- **Deleting a source with active forks** — soft-deletes it. The source URL returns `410 Gone` for all client operations and the path is blocked from re-creation (`409 Conflict`). Fork reads keep working transparently.
+- **Cascading GC** — when the last fork of a soft-deleted source is deleted, the source is cleaned up. The cascade continues up the fork chain. Cleanup may be asynchronous.
+
+## When to use it
+
+Fork when you need a logically independent stream that shares a prefix with an existing one — without copying the prefix.
+
+- **Branching an event log at a stable point** — run a new projection, a parallel consumer, or a deterministic replay against a fixed history.
+- **Speculative or exploratory writes** — try alternative appends on a fork: AI conversation branching, scenario replay, A/B experiments.
+- **Writer handoff** — one producer transitions to another at a known offset under a new URL.
+
+## More
+
+- [PROTOCOL.md section 4.2](https://github.com/durable-streams/durable-streams/blob/main/PROTOCOL.md#42-stream-forking) — normative specification, including the full fork error table
+- [Core concepts](/concepts.md)

--- a/packages/client/skills/forking/SKILL.md
+++ b/packages/client/skills/forking/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: forking
+description: >
+  Creating and using forked streams. Fork a source stream at a specific offset
+  using Stream-Forked-From and Stream-Fork-Offset headers via
+  DurableStream.create(). Reads transparently stitch inherited and fork data.
+  Covers fork creation, fresh handle pattern, TTL/expiry inheritance,
+  content-type inheritance, and deletion lifecycle. Load when forking,
+  branching, or creating a stream variant from an existing stream.
+type: core
+library: durable-streams
+library_version: "0.2.1"
+requires:
+  - getting-started
+sources:
+  - "durable-streams/durable-streams:packages/client/src/stream.ts"
+  - "durable-streams/durable-streams:PROTOCOL.md"
+---
+
+This skill builds on durable-streams/getting-started. Read it first for setup and offset basics.
+
+# Durable Streams — Forking
+
+Fork creates a new stream that references the data of a source stream up to a
+specified offset, without copying it. The fork is independent: it has its own
+URL, TTL, closure state, and deletion lifecycle.
+
+## Setup
+
+```typescript
+import { DurableStream } from "@durable-streams/client"
+
+// Create a fork by passing fork headers via the headers option
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": "1024", // optional; defaults to source tail
+  },
+})
+
+// Use a fresh handle for ongoing reads/writes
+const fork = await DurableStream.connect({
+  url: "https://your-server.com/v1/stream/my-fork",
+})
+
+// Read — transparently returns inherited data followed by fork's own appends
+const res = await fork.stream({ json: true })
+const items = await res.json()
+
+// Write — appends go only to the fork, source is untouched
+await fork.append(JSON.stringify({ role: "user", text: "what if instead..." }))
+```
+
+## Core Patterns
+
+### Create a fork at the source's current tail
+
+```typescript
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    // Stream-Fork-Offset omitted — defaults to source's current tail
+  },
+})
+```
+
+### Create a fork at a specific offset
+
+Use a server-returned offset from a previous `HEAD`, `GET`, or `POST` response:
+
+```typescript
+const source = await DurableStream.connect({
+  url: "https://your-server.com/v1/stream/my-source",
+})
+const head = await source.head()
+
+// Fork at an offset you previously saved or received from the server
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": savedOffset,
+  },
+})
+```
+
+### Read a fork
+
+Reading a fork is identical to reading any stream. The fork transparently
+stitches inherited data from the source with the fork's own appends:
+
+```typescript
+import { stream } from "@durable-streams/client"
+
+const res = await stream({
+  url: "https://your-server.com/v1/stream/my-fork",
+  offset: "-1",
+  live: true,
+})
+
+res.subscribeJson(async (batch) => {
+  for (const item of batch.items) {
+    console.log(item) // inherited + fork's own data, in offset order
+  }
+})
+```
+
+### Write to a fork
+
+Appends work the same as any stream. Data goes only to the fork:
+
+```typescript
+const fork = await DurableStream.connect({
+  url: "https://your-server.com/v1/stream/my-fork",
+})
+
+await fork.append(JSON.stringify({ event: "branched" }))
+```
+
+### Delete a fork
+
+```typescript
+await DurableStream.delete({
+  url: "https://your-server.com/v1/stream/my-fork",
+})
+```
+
+Deleting a fork decrements the source's reference count. If the source was
+soft-deleted and this was its last fork, the source is cleaned up too.
+
+### TTL and expiry
+
+A fork has its own TTL and expiry. If the fork request provides `Stream-TTL`
+or `Stream-Expires-At`, the fork uses those values. If omitted, the fork
+inherits from the source: a source with a TTL passes its value on (the fork
+runs its own sliding window), a source with `Expires-At` passes its hard
+deadline on.
+
+```typescript
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  ttlSeconds: 3600, // fork's own TTL, independent of source
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+  },
+})
+```
+
+## Common Mistakes
+
+### CRITICAL Reusing the create handle for reads and writes
+
+Wrong:
+
+```typescript
+const fork = await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": "1024",
+  },
+})
+
+// Fork headers are resent on every request from this handle
+await fork.append(JSON.stringify({ event: "data" }))
+```
+
+Correct:
+
+```typescript
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": "1024",
+  },
+})
+
+// Fresh handle — no fork headers on subsequent requests
+const fork = await DurableStream.connect({
+  url: "https://your-server.com/v1/stream/my-fork",
+})
+await fork.append(JSON.stringify({ event: "data" }))
+```
+
+`options.headers` applies to every request on a handle. The fork headers are only meaningful on the initial `PUT`. Servers ignore them on reads and appends, but using a fresh handle keeps requests clean.
+
+Source: packages/client/src/stream.ts
+
+### CRITICAL Fabricating offset values for Stream-Fork-Offset
+
+Wrong:
+
+```typescript
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": "100", // made-up value
+  },
+})
+```
+
+Correct:
+
+```typescript
+// Use a server-returned offset
+const source = await DurableStream.connect({
+  url: "https://your-server.com/v1/stream/my-source",
+})
+const head = await source.head()
+
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+    "Stream-Fork-Offset": head.offset!, // server-returned offset
+  },
+})
+```
+
+Offsets are opaque tokens. Fabricated values may return `400 Bad Request`. Always use an offset from a previous `HEAD`, `GET`, or `POST` response.
+
+Source: PROTOCOL.md section 6 (Offsets), section 4.2 (Stream forking)
+
+### HIGH Mismatched Content-Type on fork creation
+
+Wrong:
+
+```typescript
+// Source is application/json
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  contentType: "text/plain", // 409 Conflict!
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+  },
+})
+```
+
+Correct:
+
+```typescript
+// Omit Content-Type to inherit from source
+await DurableStream.create({
+  url: "https://your-server.com/v1/stream/my-fork",
+  headers: {
+    "Stream-Forked-From": "/v1/stream/my-source",
+  },
+})
+```
+
+When forking, omit `Content-Type` to inherit it from the source. If provided, it must match the source's content type exactly or the server returns `409 Conflict`.
+
+Source: PROTOCOL.md section 4.2 (Stream forking)
+
+### MEDIUM Not handling 410 Gone for soft-deleted sources
+
+Wrong:
+
+```typescript
+try {
+  const res = await stream({ url: sourceUrl, offset: "-1", live: false })
+  const data = await res.json()
+} catch (err) {
+  // Only checks for 404
+  if (err.statusCode === 404) console.log("Not found")
+}
+```
+
+Correct:
+
+```typescript
+try {
+  const res = await stream({ url: sourceUrl, offset: "-1", live: false })
+  const data = await res.json()
+} catch (err) {
+  if (err.statusCode === 404) console.log("Not found")
+  if (err.statusCode === 410) console.log("Soft-deleted — has active forks")
+}
+```
+
+When a source stream with active forks is deleted, it returns `410 Gone` for all client operations. The source's data is retained internally for fork reads, but the source URL is no longer directly accessible.
+
+Source: PROTOCOL.md section 4.2 (Soft-delete and lifecycle)
+
+## See also
+
+- [getting-started](../getting-started/SKILL.md) — Stream creation and offset basics
+- [writing-data](../writing-data/SKILL.md) — IdempotentProducer for writes to forked streams
+- [reading-streams](../reading-streams/SKILL.md) — Reading patterns (works identically on forks)
+
+## Version
+
+Targets @durable-streams/client v0.2.1.


### PR DESCRIPTION
## Summary

- Adds `docs/fork.md`, a canonical reference for the stream forking feature introduced in #312.
- Explains the mechanism in terms of the `Stream-Forked-From` and `Stream-Fork-Offset` headers, with HTTP and client library examples (TypeScript and Python), TTL/expiry inheritance rules, deletion and cascading GC semantics, and common use cases.
- Adds the page to the "Usage" sidebar between "JSON mode" and "Durable Proxy".
- No client library changes were needed — the existing `headers` option on `DurableStream.create` already supports passing fork headers.

The page is organized to match the shape of `json-mode.md`: short intro, a technical "What fork does" paragraph that references the headers directly, combined HTTP examples, a code-group with TypeScript and Python, then TTL/expiry, deletion, and "when to use it" at the bottom.

## Test plan

- [ ] Preview locally with `pnpm --filter @durable-streams/docs dev` and walk through each section
- [ ] Run the `curl` examples against a local reference server (`pnpm dev`)
- [ ] Verify the TypeScript and Python client snippets work end-to-end against the reference server
- [ ] Confirm the "Fork" sidebar entry renders in the Usage section

🤖 Generated with [Claude Code](https://claude.com/claude-code)