### PR TITLE
Remove verbose debug logging from StreamDB

### DIFF
--- a/.changeset/remove-streamdb-debug-logs.md
+++ b/.changeset/remove-streamdb-debug-logs.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/state": patch
+---
+
+Remove verbose debug logging from StreamDB stream consumer

--- a/packages/state/src/stream-db.ts
+++ b/packages/state/src/stream-db.ts
@@ -790,13 +790,6 @@ export function createStreamDB<
       gcTime: 0,
     })
 
-    console.log(`[StreamDB] Created collection "${name}":`, {
-      type: typeof collection,
-      constructor: collection.constructor.name,
-      isCollection: collection instanceof Object,
-      hasSize: `size` in collection,
-    })
-
     collectionInstances[name] = collection
   }
 
@@ -818,22 +811,9 @@ export function createStreamDB<
       signal: abortController.signal,
     })
 
-    // Track batch processing for debugging
-    let batchCount = 0
-    let lastBatchTime = Date.now()
-
     // Process events as they come in
     streamResponse.subscribeJson((batch) => {
       try {
-        batchCount++
-        lastBatchTime = Date.now()
-
-        if (batch.items.length > 0) {
-          console.log(
-            `[StreamDB] Processing batch #${batchCount}: ${batch.items.length} items, upToDate=${batch.upToDate}`
-          )
-        }
-
         for (const event of batch.items) {
           if (isChangeEvent(event)) {
             dispatcher.dispatchChange(event)
@@ -844,15 +824,7 @@ export function createStreamDB<
 
         // Check batch-level up-to-date signal
         if (batch.upToDate) {
-          console.log(
-            `[StreamDB] Marking up-to-date after batch #${batchCount}`
-          )
           dispatcher.markUpToDate()
-          console.log(`[StreamDB] Successfully marked up-to-date`)
-        }
-
-        if (batch.items.length > 0) {
-          console.log(`[StreamDB] Successfully processed batch #${batchCount}`)
         }
       } catch (error) {
         console.error(`[StreamDB] Error processing batch:`, error)
@@ -864,20 +836,6 @@ export function createStreamDB<
         // Don't rethrow - we've already rejected the promise
       }
       return Promise.resolve()
-    })
-
-    // Health check to detect silent stalls
-    const healthCheck = setInterval(() => {
-      const timeSinceLastBatch = Date.now() - lastBatchTime
-      console.log(
-        `[StreamDB] Health: ${batchCount} batches processed, last batch ${(timeSinceLastBatch / 1000).toFixed(1)}s ago`
-      )
-    }, 15000)
-
-    // Clean up health check on abort
-    abortController.signal.addEventListener(`abort`, () => {
-      clearInterval(healthCheck)
-      console.log(`[StreamDB] Aborted - cleaning up health check`)
     })
   }
 
@@ -900,16 +858,10 @@ export function createStreamDB<
   }
 
   // Combine collections with methods
-  console.log(
-    `[StreamDB] Creating db object with collections:`,
-    Object.keys(collectionInstances)
-  )
   const db = {
     collections: collectionInstances,
     ...dbMethods,
   } as unknown as StreamDB<TDef>
-  console.log(`[StreamDB] db.collections:`, Object.keys(db.collections))
-  console.log(`[StreamDB] db.collections.events:`, db.collections.events)
 
   // If actions factory is provided, wrap actions and return db with actions
   if (actionsFactory) {


### PR DESCRIPTION
## Summary

StreamDB's stream consumer was flooding the browser console with `[StreamDB]` log lines on every batch, every 15 seconds (health check), and at initialization. This removes all `console.log` calls, keeping only `console.error`/`console.warn` that fire on actual problems.

## Approach

Pure deletion — removed 11 `console.log` call sites and their supporting variables (`batchCount`, `lastBatchTime`, health-check interval). No behavioral changes.

**What was removed:**
- Batch processing logs (fired on every batch, including empty keep-alive batches)
- 15-second health-check interval timer and its log
- Collection creation debug dump (type, constructor, hasSize)
- DB object creation logs

**What was kept:**
- `console.error` for batch processing failures (with batch context)
- `console.error` for handler.write() / handler.commit() failures
- `console.warn` for the known TanStack DB groupBy bug workaround

## Key invariants

- Error-path logging is untouched — failures are still visible in the console
- No runtime behavior changes — the health-check interval was only used for logging

## Non-goals

- Adding a configurable log-level system (not needed yet; can revisit if debug logging becomes useful again)

## Verification

```bash
# Build the state package
cd packages/state && pnpm build

# Run any example that uses StreamDB and confirm the console is quiet
# during normal operation, and errors still surface on failures
```

## Files changed

| File | Change |
|------|--------|
| `packages/state/src/stream-db.ts` | Remove 11 `console.log` calls, health-check interval, and associated tracking variables |

🤖 Generated with [Claude Code](https://claude.com/claude-code)