### PR TITLE
chore: add missing changeset for y-durable-streams

### DIFF
--- a/.changeset/y-durable-streams-docs-fix.md
+++ b/.changeset/y-durable-streams-docs-fix.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/y-durable-streams": patch
+---
+
+Fix stale skill and README API docs, add intent CLI bin entry


### PR DESCRIPTION
## Summary
- Adds a missing `patch` changeset for `@durable-streams/y-durable-streams` to trigger a release
- Covers changes from #326 (stale skill and README API docs fix, intent CLI bin entry)

## Test plan
- [ ] Verify changeset is picked up by the version workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)