### PR TITLE
chore: add missing changeset for AI transport packages

### DIFF
--- a/.changeset/ai-transport-skills.md
+++ b/.changeset/ai-transport-skills.md
@@ -1,0 +1,6 @@
+---
+"@durable-streams/aisdk-transport": patch
+"@durable-streams/tanstack-ai-transport": patch
+---
+
+Add AI agent skills and intent CLI bin entry


### PR DESCRIPTION
## Summary
- Adds a missing `patch` changeset for `@durable-streams/aisdk-transport` and `@durable-streams/tanstack-ai-transport` to trigger releases
- Covers changes from #327 (skills, intent CLI bin entry, devDependency additions)

## Test plan
- [ ] Verify changeset is picked up by the version workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)