### PR TITLE
docs(stream-db): fix useLiveQuery list query pattern

### DIFF
--- a/.changeset/fix-stream-db-skill.md
+++ b/.changeset/fix-stream-db-skill.md
@@ -1,0 +1,7 @@
+---
+"@durable-streams/state": patch
+---
+
+docs(stream-db): show list query pattern for useLiveQuery
+
+Added list query example with `{ data }` destructuring and default empty array alongside the existing findOne pattern. Prevents agents from writing `allSessions.map(...)` instead of `const { data: allSessions = [] } = useLiveQuery(...)`.

--- a/.changeset/fix-tanstack-ai-skill.md
+++ b/.changeset/fix-tanstack-ai-skill.md
@@ -1,0 +1,7 @@
+---
+"@durable-streams/tanstack-ai-transport": patch
+---
+
+docs(tanstack-ai): show anthropicText adapter, warn against raw SDK usage
+
+Updated the skill to use `anthropicText` from `@tanstack/ai-anthropic` as the primary example instead of `openaiText`. Added explicit warning against calling LLM SDKs directly — agents were bypassing the adapter and getting 400 errors from message format mismatches.

--- a/packages/state/skills/stream-db/SKILL.md
+++ b/packages/state/skills/stream-db/SKILL.md
@@ -77,22 +77,34 @@ const messages = db.collections.messages
 
 ### Reactive queries with TanStack DB
 
-StreamDB collections are TanStack DB collections. Use framework adapters for reactive queries:
+StreamDB collections are TanStack DB collections. Use framework adapters for reactive queries.
+
+**IMPORTANT**: `useLiveQuery` returns `{ data }`, NOT the array directly. Always destructure with a default:
 
 ```typescript
 import { useLiveQuery } from "@tanstack/react-db"
 import { eq } from "@durable-streams/state"
 
+// List query — destructure { data } with a default empty array
+function UserList() {
+  const { data: users = [] } = useLiveQuery((q) =>
+    q.from({ users: db.collections.users })
+  )
+
+  return users.map(u => <div key={u.id}>{u.name}</div>)
+}
+
+// Single item query — use findOne(), data is T | undefined
 function UserProfile({ userId }: { userId: string }) {
-  const userQuery = useLiveQuery((q) =>
+  const { data: user } = useLiveQuery((q) =>
     q
       .from({ users: db.collections.users })
       .where(({ users }) => eq(users.id, userId))
       .findOne()
   )
 
-  if (!userQuery.data) return null
-  return <div>{userQuery.data.name}</div>
+  if (!user) return null
+  return <div>{user.name}</div>
 }
 ```
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -55,9 +55,11 @@ function Chat({ id, initialMessages, resumeOffset }) {
 
 ### Server — POST /api/chat
 
+Use `chat()` from `@tanstack/ai` with the appropriate adapter. **Do NOT call LLM SDKs (Anthropic, OpenAI) directly** — the adapter handles message format conversion, streaming chunks, and error mapping.
+
 ```typescript
 import { chat } from "@tanstack/ai"
-import { openaiText } from "@tanstack/ai-openai"
+import { anthropicText } from "@tanstack/ai-anthropic"
 import { toDurableChatSessionResponse } from "@durable-streams/tanstack-ai-transport"
 
 export async function POST(request: Request) {
@@ -65,7 +67,7 @@ export async function POST(request: Request) {
   const latestUserMessage = messages.findLast((m) => m.role === "user")
 
   const responseStream = chat({
-    adapter: openaiText("gpt-4o-mini"),
+    adapter: anthropicText("claude-sonnet-4-6"),
     messages,
   })
 
@@ -79,6 +81,13 @@ export async function POST(request: Request) {
   })
 }
 ```
+
+**Available adapters:**
+
+- `anthropicText("claude-sonnet-4-6")` from `@tanstack/ai-anthropic` — Anthropic Claude models
+- `openaiText("gpt-4o-mini")` from `@tanstack/ai-openai` — OpenAI models
+
+The adapter reads credentials from standard env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). Do NOT pass API keys from the client.
 
 `mode: "immediate"` (default) returns `202` immediately; writes continue in background. Use `mode: "await"` when the runtime needs an active request to keep running.
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -117,6 +117,26 @@ Always proxy reads through an app route so write credentials stay server-side. S
 
 ## Common Mistakes
 
+### CRITICAL Not awaiting toDurableChatSessionResponse
+
+Wrong — returns a Promise object, causing header conflicts (500):
+
+```typescript
+return toDurableChatSessionResponse({ stream, newMessages, responseStream })
+```
+
+Correct — await the response:
+
+```typescript
+return await toDurableChatSessionResponse({
+  stream,
+  newMessages,
+  responseStream,
+})
+```
+
+In TanStack Start server handlers, returning an unresolved Promise causes Node to serialize it incorrectly, producing both `Content-Length` and `Transfer-Encoding: chunked` headers simultaneously — which HTTP/1.1 forbids.
+
 ### CRITICAL Sending full message history as newMessages
 
 Wrong: `newMessages: messages` — echoes the entire conversation again.


### PR DESCRIPTION
## Summary
- Add list query example with `{ data }` destructuring and default empty array to stream-db skill
- Agents were writing `allSessions.map(...)` instead of `const { data: allSessions = [] } = useLiveQuery(...)`, causing "map is not a function" runtime errors
- Show both list and findOne patterns side by side

## Test plan
- [ ] Verify skill renders correctly in intent list
- [ ] Run an agent session with a plan using StreamDB — confirm no `.map is not a function` errors

Generated with [Claude Code](https://claude.com/claude-code)