### PR TITLE
fix file-backed stream tail races on concurrent appends

### DIFF
--- a/.changeset/fix-file-store-append-race.md
+++ b/.changeset/fix-file-store-append-race.md
@@ -1,0 +1,7 @@
+---
+"@durable-streams/server": patch
+---
+
+fix(server): serialize file-backed appends per stream
+
+File-backed streams could lose track of the latest logical tail when two append requests hit the same stream at the same time without producer headers. The bytes were written to disk, but stale metadata could leave `currentOffset` behind the real file tail, which caused live readers to treat newer updates as already caught up until a restart or recovery reconciled the offsets.

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -45,6 +45,12 @@ interface StreamMetadata {
   ttlSeconds?: number
   expiresAt?: string
   createdAt: number
+  /**
+   * Timestamp of the last read or write (for TTL renewal).
+   * Optional for backward-compatible deserialization from LMDB (old records won't have it).
+   * Falls back to createdAt when missing.
+   */
+  lastAccessedAt?: number
   segmentCount: number
   totalBytes: number
   /**
@@ -413,7 +419,7 @@ export class FileBackedStreamStore {
       ttlSeconds: meta.ttlSeconds,
       expiresAt: meta.expiresAt,
       createdAt: meta.createdAt,
-      lastAccessedAt: meta.createdAt,
+      lastAccessedAt: meta.lastAccessedAt ?? meta.createdAt,
       producers,
       closed: meta.closed,
       closedBy: meta.closedBy,
@@ -568,6 +574,21 @@ export class FileBackedStreamStore {
   }
 
   /**
+   * Update lastAccessedAt to now. Called on reads and appends (not HEAD).
+   */
+  touchAccess(streamPath: string): void {
+    const key = `stream:${streamPath}`
+    const meta = this.db.get(key) as StreamMetadata | undefined
+    if (meta) {
+      const updatedMeta: StreamMetadata = {
+        ...meta,
+        lastAccessedAt: Date.now(),
+      }
+      this.db.putSync(key, updatedMeta)
+    }
+  }
+
+  /**
    * Check if a stream is expired based on TTL or Expires-At.
    */
   private isExpired(meta: StreamMetadata): boolean {
@@ -582,9 +603,10 @@ export class FileBackedStreamStore {
       }
     }
 
-    // Check TTL (relative to creation time)
+    // Check TTL (sliding window from last access)
     if (meta.ttlSeconds !== undefined) {
-      const expiryTime = meta.createdAt + meta.ttlSeconds * 1000
+      const lastAccessed = meta.lastAccessedAt ?? meta.createdAt
+      const expiryTime = lastAccessed + meta.ttlSeconds * 1000
       if (now >= expiryTime) {
         return true
       }
@@ -622,43 +644,33 @@ export class FileBackedStreamStore {
   }
 
   /**
-   * Compute the effective expiry for a fork stream, capped at the source's expiry.
+   * Resolve fork expiry per the decision table.
+   * Forks have independent lifetimes — no capping at source expiry.
    */
-  private computeForkExpiry(
+  private resolveForkExpiry(
     opts: { ttlSeconds?: number; expiresAt?: string },
     sourceMeta: StreamMetadata
-  ): string | undefined {
-    // Resolve source's absolute expiry
-    let sourceExpiryMs: number | undefined
-    if (sourceMeta.expiresAt) {
-      sourceExpiryMs = new Date(sourceMeta.expiresAt).getTime()
-    } else if (sourceMeta.ttlSeconds !== undefined) {
-      sourceExpiryMs = sourceMeta.createdAt + sourceMeta.ttlSeconds * 1000
+  ): { ttlSeconds?: number; expiresAt?: string } {
+    // Fork explicitly requests TTL — use it
+    if (opts.ttlSeconds !== undefined) {
+      return { ttlSeconds: opts.ttlSeconds }
     }
 
-    // Resolve fork's requested expiry
-    let forkExpiryMs: number | undefined
+    // Fork explicitly requests Expires-At — use it
     if (opts.expiresAt) {
-      forkExpiryMs = new Date(opts.expiresAt).getTime()
-    } else if (opts.ttlSeconds !== undefined) {
-      forkExpiryMs = Date.now() + opts.ttlSeconds * 1000
-    } else {
-      forkExpiryMs = sourceExpiryMs // Inherit source expiry
+      return { expiresAt: opts.expiresAt }
     }
 
-    // Cap at source expiry
-    if (
-      sourceExpiryMs !== undefined &&
-      forkExpiryMs !== undefined &&
-      forkExpiryMs > sourceExpiryMs
-    ) {
-      forkExpiryMs = sourceExpiryMs
+    // No expiry requested — inherit from source
+    if (sourceMeta.ttlSeconds !== undefined) {
+      return { ttlSeconds: sourceMeta.ttlSeconds }
+    }
+    if (sourceMeta.expiresAt) {
+      return { expiresAt: sourceMeta.expiresAt }
     }
 
-    if (forkExpiryMs !== undefined) {
-      return new Date(forkExpiryMs).toISOString()
-    }
-    return undefined
+    // Source has no expiry either
+    return {}
   }
 
   /**
@@ -801,8 +813,9 @@ export class FileBackedStreamStore {
     let effectiveExpiresAt = options.expiresAt
     let effectiveTtlSeconds = options.ttlSeconds
     if (isFork) {
-      effectiveExpiresAt = this.computeForkExpiry(options, sourceMeta!)
-      effectiveTtlSeconds = undefined // Forks store expiresAt, not TTL
+      const resolved = this.resolveForkExpiry(options, sourceMeta!)
+      effectiveExpiresAt = resolved.expiresAt
+      effectiveTtlSeconds = resolved.ttlSeconds
     }
 
     // Define key for LMDB operations
@@ -819,6 +832,7 @@ export class FileBackedStreamStore {
       ttlSeconds: effectiveTtlSeconds,
       expiresAt: effectiveExpiresAt,
       createdAt: Date.now(),
+      lastAccessedAt: Date.now(),
       segmentCount: 1,
       totalBytes: 0,
       directoryName: generateUniqueDirectoryName(streamPath),
@@ -1766,6 +1780,7 @@ export class FileBackedStreamStore {
 
   private notifyLongPolls(streamPath: string): void {
     const toNotify = this.pendingLongPolls.filter((p) => p.path === streamPath)
+
     for (const pending of toNotify) {
       const { messages } = this.read(streamPath, pending.offset)
       if (messages.length > 0) {

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -45,12 +45,6 @@ interface StreamMetadata {
   ttlSeconds?: number
   expiresAt?: string
   createdAt: number
-  /**
-   * Timestamp of the last read or write (for TTL renewal).
-   * Optional for backward-compatible deserialization from LMDB (old records won't have it).
-   * Falls back to createdAt when missing.
-   */
-  lastAccessedAt?: number
   segmentCount: number
   totalBytes: number
   /**
@@ -227,6 +221,11 @@ export class FileBackedStreamStore {
   private fileHandlePool: FileHandlePool
   private pendingLongPolls: Array<PendingLongPoll> = []
   private dataDir: string
+  /**
+   * Per-stream locks for serializing append operations.
+   * Key: "{streamPath}"
+   */
+  private streamLocks = new Map<string, Promise<unknown>>()
   /**
    * Per-producer locks for serializing validation+append operations.
    * Key: "{streamPath}:{producerId}"
@@ -414,7 +413,7 @@ export class FileBackedStreamStore {
       ttlSeconds: meta.ttlSeconds,
       expiresAt: meta.expiresAt,
       createdAt: meta.createdAt,
-      lastAccessedAt: meta.lastAccessedAt ?? meta.createdAt,
+      lastAccessedAt: meta.createdAt,
       producers,
       closed: meta.closed,
       closedBy: meta.closedBy,
@@ -536,6 +535,27 @@ export class FileBackedStreamStore {
   }
 
   /**
+   * Acquire a lock for serialized stream append operations.
+   * Returns a release function.
+   */
+  private async acquireStreamLock(streamPath: string): Promise<() => void> {
+    while (this.streamLocks.has(streamPath)) {
+      await this.streamLocks.get(streamPath)
+    }
+
+    let releaseLock: () => void
+    const lockPromise = new Promise<void>((resolve) => {
+      releaseLock = resolve
+    })
+    this.streamLocks.set(streamPath, lockPromise)
+
+    return () => {
+      this.streamLocks.delete(streamPath)
+      releaseLock!()
+    }
+  }
+
+  /**
    * Get the current epoch for a producer on a stream.
    * Returns undefined if the producer doesn't exist or stream not found.
    */
@@ -545,21 +565,6 @@ export class FileBackedStreamStore {
       return undefined
     }
     return meta.producers[producerId]?.epoch
-  }
-
-  /**
-   * Update lastAccessedAt to now. Called on reads and appends (not HEAD).
-   */
-  touchAccess(streamPath: string): void {
-    const key = `stream:${streamPath}`
-    const meta = this.db.get(key) as StreamMetadata | undefined
-    if (meta) {
-      const updatedMeta: StreamMetadata = {
-        ...meta,
-        lastAccessedAt: Date.now(),
-      }
-      this.db.putSync(key, updatedMeta)
-    }
   }
 
   /**
@@ -577,10 +582,9 @@ export class FileBackedStreamStore {
       }
     }
 
-    // Check TTL (sliding window from last access)
+    // Check TTL (relative to creation time)
     if (meta.ttlSeconds !== undefined) {
-      const lastAccessed = meta.lastAccessedAt ?? meta.createdAt
-      const expiryTime = lastAccessed + meta.ttlSeconds * 1000
+      const expiryTime = meta.createdAt + meta.ttlSeconds * 1000
       if (now >= expiryTime) {
         return true
       }
@@ -618,33 +622,43 @@ export class FileBackedStreamStore {
   }
 
   /**
-   * Resolve fork expiry per the decision table.
-   * Forks have independent lifetimes — no capping at source expiry.
+   * Compute the effective expiry for a fork stream, capped at the source's expiry.
    */
-  private resolveForkExpiry(
+  private computeForkExpiry(
     opts: { ttlSeconds?: number; expiresAt?: string },
     sourceMeta: StreamMetadata
-  ): { ttlSeconds?: number; expiresAt?: string } {
-    // Fork explicitly requests TTL — use it
-    if (opts.ttlSeconds !== undefined) {
-      return { ttlSeconds: opts.ttlSeconds }
-    }
-
-    // Fork explicitly requests Expires-At — use it
-    if (opts.expiresAt) {
-      return { expiresAt: opts.expiresAt }
-    }
-
-    // No expiry requested — inherit from source
-    if (sourceMeta.ttlSeconds !== undefined) {
-      return { ttlSeconds: sourceMeta.ttlSeconds }
-    }
+  ): string | undefined {
+    // Resolve source's absolute expiry
+    let sourceExpiryMs: number | undefined
     if (sourceMeta.expiresAt) {
-      return { expiresAt: sourceMeta.expiresAt }
+      sourceExpiryMs = new Date(sourceMeta.expiresAt).getTime()
+    } else if (sourceMeta.ttlSeconds !== undefined) {
+      sourceExpiryMs = sourceMeta.createdAt + sourceMeta.ttlSeconds * 1000
     }
 
-    // Source has no expiry either
-    return {}
+    // Resolve fork's requested expiry
+    let forkExpiryMs: number | undefined
+    if (opts.expiresAt) {
+      forkExpiryMs = new Date(opts.expiresAt).getTime()
+    } else if (opts.ttlSeconds !== undefined) {
+      forkExpiryMs = Date.now() + opts.ttlSeconds * 1000
+    } else {
+      forkExpiryMs = sourceExpiryMs // Inherit source expiry
+    }
+
+    // Cap at source expiry
+    if (
+      sourceExpiryMs !== undefined &&
+      forkExpiryMs !== undefined &&
+      forkExpiryMs > sourceExpiryMs
+    ) {
+      forkExpiryMs = sourceExpiryMs
+    }
+
+    if (forkExpiryMs !== undefined) {
+      return new Date(forkExpiryMs).toISOString()
+    }
+    return undefined
   }
 
   /**
@@ -787,9 +801,8 @@ export class FileBackedStreamStore {
     let effectiveExpiresAt = options.expiresAt
     let effectiveTtlSeconds = options.ttlSeconds
     if (isFork) {
-      const resolved = this.resolveForkExpiry(options, sourceMeta!)
-      effectiveExpiresAt = resolved.expiresAt
-      effectiveTtlSeconds = resolved.ttlSeconds
+      effectiveExpiresAt = this.computeForkExpiry(options, sourceMeta!)
+      effectiveTtlSeconds = undefined // Forks store expiresAt, not TTL
     }
 
     // Define key for LMDB operations
@@ -806,7 +819,6 @@ export class FileBackedStreamStore {
       ttlSeconds: effectiveTtlSeconds,
       expiresAt: effectiveExpiresAt,
       createdAt: Date.now(),
-      lastAccessedAt: Date.now(),
       segmentCount: 1,
       totalBytes: 0,
       directoryName: generateUniqueDirectoryName(streamPath),
@@ -986,6 +998,19 @@ export class FileBackedStreamStore {
   }
 
   async append(
+    streamPath: string,
+    data: Uint8Array,
+    options: AppendOptions & { isInitialCreate?: boolean } = {}
+  ): Promise<StreamMessage | AppendResult | null> {
+    const releaseLock = await this.acquireStreamLock(streamPath)
+    try {
+      return await this.appendUnlocked(streamPath, data, options)
+    } finally {
+      releaseLock()
+    }
+  }
+
+  private async appendUnlocked(
     streamPath: string,
     data: Uint8Array,
     options: AppendOptions & { isInitialCreate?: boolean } = {}
@@ -1741,7 +1766,6 @@ export class FileBackedStreamStore {
 
   private notifyLongPolls(streamPath: string): void {
     const toNotify = this.pendingLongPolls.filter((p) => p.path === streamPath)
-
     for (const pending of toNotify) {
       const { messages } = this.read(streamPath, pending.offset)
       if (messages.length > 0) {

--- a/packages/server/test/file-backed.test.ts
+++ b/packages/server/test/file-backed.test.ts
@@ -71,6 +71,59 @@ describe(`Path Encoding`, () => {
   })
 })
 
+describe(`Concurrent appends`, () => {
+  test(`should serialize append metadata updates per stream without producer headers`, async () => {
+    server.store.create(`/test`, { contentType: `text/plain` })
+
+    const store = server.store as any
+    const fileHandlePool = store.fileHandlePool
+    const originalFsyncFile = fileHandlePool.fsyncFile.bind(fileHandlePool)
+
+    let signalFirstFsyncReached: (() => void) | undefined
+    const firstFsyncReached = new Promise<void>((resolve) => {
+      signalFirstFsyncReached = resolve
+    })
+
+    let releaseFirstFsync: (() => void) | undefined
+    const unblockFirstFsync = new Promise<void>((resolve) => {
+      releaseFirstFsync = resolve
+    })
+
+    let fsyncCallCount = 0
+    fileHandlePool.fsyncFile = async (segmentPath: string) => {
+      fsyncCallCount += 1
+      if (fsyncCallCount === 1) {
+        signalFirstFsyncReached?.()
+        await unblockFirstFsync
+      }
+      return originalFsyncFile(segmentPath)
+    }
+
+    try {
+      const firstAppend = server.store.append(`/test`, encode(`abc`))
+      await firstFsyncReached
+
+      const secondAppend = server.store.append(`/test`, encode(`def`))
+      releaseFirstFsync?.()
+
+      await Promise.all([firstAppend, secondAppend])
+
+      expect(server.store.getCurrentOffset(`/test`)).toBe(
+        `0000000000000000_0000000000000006`
+      )
+
+      const { messages } = server.store.read(`/test`)
+      expect(messages).toHaveLength(2)
+      expect(messages.map((message) => decode(message.data))).toEqual([
+        `abc`,
+        `def`,
+      ])
+    } finally {
+      fileHandlePool.fsyncFile = originalFsyncFile
+    }
+  })
+})
+
 // ============================================================================
 // Server Close Tests (Server Implementation Detail)
 // ============================================================================


### PR DESCRIPTION
## Summary
This fixes a race in the file-backed reference server where two append requests could hit the same stream at the same time without producer headers.

In that case, both requests could read the same pre-append `currentOffset`, both write their bytes to disk successfully, and then race when writing LMDB metadata. The loser could overwrite the newer tail with a stale `currentOffset`, leaving metadata behind the real on-disk stream tail. When that happened, live readers and long-polls would compare against the stale metadata, conclude they were already up to date, and miss the newest bytes until restart or recovery reconciled the file tail.

This PR:
- serializes file-backed appends per stream, even for requests that do not use producer headers
- adds a regression test that forces two untagged appends to overlap and verifies the stored tail still advances from `...0003` to `...0006`
- adds a changeset for the `@durable-streams/server` patch release
- preserves the current `main` branch expiry and fork-lifetime behavior while applying the concurrency fix

## Test plan
- [x] Add regression test in `packages/server/test/file-backed.test.ts`
- [x] Run the new test on `main` without the fix and confirm it fails (`currentOffset` stays at `...0003` instead of `...0006`)
- [x] Re-run `pnpm exec vitest run packages/server/test/file-backed.test.ts` with the fix and confirm it passes
- [x] Run `pnpm build` in `packages/server`

Made with [Cursor](https://cursor.com)