### PR TITLE
docs(tanstack-ai): headers on connection + full read proxy pattern

### DIFF
--- a/.changeset/fix-aisdk-skill-v2.md
+++ b/.changeset/fix-aisdk-skill-v2.md
@@ -1,0 +1,12 @@
+---
+"@durable-streams/aisdk-transport": patch
+---
+
+docs(vercel-ai-sdk): inline read proxy, remove broken examples/ refs
+
+- Inline the full read proxy implementation (hop-by-hop header stripping,
+  query-param forwarding, Authorization header injection) so agents don't
+  need to follow `examples/chat-aisdk/...` references that don't ship in
+  the npm package
+- Drop prose "Source: examples/chat-aisdk/..." lines that pointed at files
+  only present in the monorepo, not in the published skill

--- a/.changeset/fix-transport-skill-v2.md
+++ b/.changeset/fix-transport-skill-v2.md
@@ -1,0 +1,11 @@
+---
+"@durable-streams/tanstack-ai-transport": patch
+---
+
+docs(tanstack-ai): headers on connection, full read proxy, auth separation
+
+- Document that custom headers (API keys) go on `durableStreamConnection`, not `useChat`
+- Add full inline read proxy implementation (was "see examples/" which agents can't access)
+- Separate DS auth from AI auth with clear table
+- Add user-supplied API key pattern for apps with settings UI
+- Recommend query params over dynamic route segments for chat id

--- a/.changeset/fix-yjs-skills-v2.md
+++ b/.changeset/fix-yjs-skills-v2.md
@@ -1,0 +1,16 @@
+---
+"@durable-streams/y-durable-streams": patch
+---
+
+docs(yjs): inline example snippets, remove broken examples/ refs
+
+- `yjs-editors`: add an inlined "Sharing doc/awareness via Context" section
+  showing the full `YjsRoomProvider` pattern (provider with `connect: false`,
+  listeners before connect, `status` + `synced` + `error` events, Strict
+  Mode-safe awareness re-seeding via ref, merge-not-overwrite `setUsername`).
+  Previously this pattern pointed at `examples/yjs-demo/...` which doesn't
+  ship in the npm package.
+- `yjs-server`: add an inlined "Single-origin dev server" section showing
+  how to spawn Caddy alongside `YjsServer` and the matching dev Caddyfile
+  (DS route, Yjs route with `flush_interval -1`, Vite reverse proxy). Drops
+  prose "Source: examples/yjs-demo/Caddyfile" pointers.

--- a/packages/aisdk-transport/skills/vercel-ai-sdk/SKILL.md
+++ b/packages/aisdk-transport/skills/vercel-ai-sdk/SKILL.md
@@ -108,7 +108,55 @@ The transport defaults to `${api}/${chatId}/stream`. Pass `reconnectApi` to over
 
 ### Read proxy
 
-Always proxy reads through an app route so write credentials stay server-side. Pass the proxy URL as `readUrl` in `toDurableStreamResponse()`. The proxy should forward query params (offset, live) to the upstream DS URL and strip hop-by-hop headers (`connection`, `transfer-encoding`, `content-encoding`, `content-length`) from the response.
+Always proxy reads through an app route so write credentials stay server-side. Pass the proxy URL as `readUrl` in `toDurableStreamResponse()`.
+
+```typescript
+// app/api/chat-stream/route.ts (Next.js) or equivalent server route
+function copyHeaders(response: Response): Headers {
+  const headers = new Headers()
+  for (const [key, value] of response.headers.entries()) {
+    const k = key.toLowerCase()
+    if (
+      k === "connection" ||
+      k === "transfer-encoding" ||
+      k === "content-encoding" ||
+      k === "content-length"
+    )
+      continue
+    headers.set(key, value)
+  }
+  headers.set("Cache-Control", "no-store")
+  return headers
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const streamPath = url.searchParams.get("path")
+  if (!streamPath)
+    return Response.json({ error: "Missing stream path" }, { status: 400 })
+
+  const upstreamUrl = new URL(buildReadStreamUrl(streamPath))
+  for (const [key, value] of url.searchParams) {
+    if (key === "path") continue
+    upstreamUrl.searchParams.append(key, value)
+  }
+
+  const response = await fetch(upstreamUrl, {
+    headers: {
+      Authorization: `Bearer ${process.env.DS_SECRET}`,
+      ...(request.headers.get("accept")
+        ? { Accept: request.headers.get("accept")! }
+        : {}),
+    },
+  })
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: copyHeaders(response),
+  })
+}
+```
 
 ## Common Mistakes
 

--- a/packages/aisdk-transport/skills/vercel-ai-sdk/SKILL.md
+++ b/packages/aisdk-transport/skills/vercel-ai-sdk/SKILL.md
@@ -108,15 +108,13 @@ The transport defaults to `${api}/${chatId}/stream`. Pass `reconnectApi` to over
 
 ### Read proxy
 
-Always proxy reads through an app route so write credentials stay server-side. See `examples/chat-aisdk/app/api/chat-stream/route.ts` for the full implementation. Pass the proxy URL as `readUrl` in `toDurableStreamResponse()`.
+Always proxy reads through an app route so write credentials stay server-side. Pass the proxy URL as `readUrl` in `toDurableStreamResponse()`. The proxy should forward query params (offset, live) to the upstream DS URL and strip hop-by-hop headers (`connection`, `transfer-encoding`, `content-encoding`, `content-length`) from the response.
 
 ## Common Mistakes
 
 ### CRITICAL Not persisting activeStreamId for resume
 
 Save the active stream path before returning and clear it in `onFinish`. Without it, the reconnect endpoint has nothing to return and `resume: true` silently fails. See the server setup above for the correct pattern.
-
-Source: examples/chat-aisdk/app/api/chat/route.ts
 
 ### CRITICAL Exposing write URLs to the client
 
@@ -136,8 +134,6 @@ Source: packages/aisdk-transport/src/server.ts
 ### HIGH Not clearing activeStreamId on finish
 
 A stale `activeStreamId` causes the reconnect endpoint to return a completed stream. Always clear it in `onFinish`. See the server setup above.
-
-Source: examples/chat-aisdk/app/api/chat/route.ts
 
 ### MEDIUM Missing reconnect endpoint
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -261,6 +261,66 @@ newMessages: latestUserMessage ? [latestUserMessage] : []
 
 Setting `readUrl` on the server stream config to the durable stream's write URL leaks the secret in the `Location` header. Always use a read proxy route for `readUrl`.
 
+### CRITICAL First assistant response invisible until refresh — dead subscription
+
+`durableStreamConnection` opens its live SSE read on mount. If the stream doesn't exist yet (new conversation), the read fails with `STREAM_NOT_FOUND` and **the subscription terminates — it does NOT retry on 404**. When the user's first POST then creates the stream and the server streams chunks, nothing is listening. After a refresh, the subscription is re-opened against an existing stream and everything works — which is exactly what the user describes when they say "the first response only shows after refresh".
+
+**Fix**: create the stream eagerly when you create the conversation row, so the client's subscription has something to attach to. PUT is idempotent — catch `CONFLICT_EXISTS` / `CONFLICT_SEQ` and treat as success.
+
+```ts
+// src/routes/api/conversations.ts — after inserting the conversation row
+import { DurableStream, DurableStreamError } from "@durable-streams/client"
+
+async function ensureChatStream(streamId: string): Promise<void> {
+  try {
+    const stream = new DurableStream({
+      url: `${DS_BASE}/chat-${streamId}`,
+      headers: DS_AUTH,
+      contentType: "application/json",
+    })
+    await stream.create({ contentType: "application/json" })
+  } catch (err) {
+    if (
+      err instanceof DurableStreamError &&
+      err.status === 409 &&
+      (err.code === "CONFLICT_EXISTS" || err.code === "CONFLICT_SEQ")
+    ) {
+      return // already exists — fine
+    }
+    throw err
+  }
+}
+```
+
+Do NOT rely on `toDurableChatSessionResponse`'s `createIfMissing` to cover this case. That handler runs during the first POST, which is AFTER the client's read subscription has already died.
+
+### CRITICAL Switching conversations shows stale data — missing useLiveQuery deps + missing component key
+
+Two separate React pitfalls compound into the same symptom (header/messages don't update when the user clicks a different conversation):
+
+1. `useLiveQuery` needs explicit deps — without them, the query closure captures the initial id and never re-runs:
+
+   ```ts
+   // WRONG — no deps, closure captures initial conversationId forever
+   const { data } = useLiveQuery((q) =>
+     q.from({ conv }).where(({ conv }) => eq(conv.id, conversationId))
+   )
+
+   // RIGHT — deps array pins re-evaluation to the param
+   const { data } = useLiveQuery(
+     (q) => q.from({ conv }).where(({ conv }) => eq(conv.id, conversationId)),
+     [conversationId]
+   )
+   ```
+
+2. `useChat`'s internal `ChatClient` is memoized per-hook and keeps previous messages in a ref even when the `id` prop changes. Force a full remount by keying the component on the stream id:
+
+   ```tsx
+   return (
+     <ChatInner key={streamId} streamId={streamId} connection={connection} />
+   )
+   ```
+
 ### CRITICAL Wrong field on UIMessage parts — empty bubbles
 
 TanStack AI's `UIMessage` has `parts: Array<MessagePart>`. The `TextPart` interface puts the text in `.content` — **not** `.text`, **not** `message.content`. Reading the wrong field renders empty strings silently (no error), so bubbles just show "…" or blank.

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -337,21 +337,23 @@ Use the chat id as a **query parameter** (`/api/chat-stream?id=...`), not a dyna
 
 ## Common Mistakes
 
-### CRITICAL Returning toDurableChatSessionResponse without stripping headers
+### CRITICAL Node 22 Parse Error with Content-Length + Transfer-Encoding
 
-The upstream DS service sends both `Content-Length` and `Transfer-Encoding` headers. Node rejects this with `Parse Error: Content-Length can't be present with Transfer-Encoding`.
+The Electric Cloud DS service may send responses with both `Content-Length` and `Transfer-Encoding` headers. Node 22 rejects this at the socket level with `Parse Error: Content-Length can't be present with Transfer-Encoding` — this crashes **inside** `toDurableChatSessionResponse` before your code can strip headers.
 
-Wrong:
+**Workaround:** Start the app with `--insecure-http-parser` to relax Node's strict HTTP parsing:
 
-```typescript
-return await toDurableChatSessionResponse({
-  stream,
-  newMessages,
-  responseStream,
-})
+```json
+// package.json scripts
+{
+  "dev:start": "NODE_OPTIONS='--insecure-http-parser' pnpm dev:start",
+  "dev": "NODE_OPTIONS='--insecure-http-parser' vinxi dev"
+}
 ```
 
-Correct — always reconstruct the response:
+Or set it in the Vite config's server options. This is a known issue with the upstream DS service and will be fixed in a future release.
+
+Even with this workaround, always reconstruct the response from `toDurableChatSessionResponse` to strip headers before returning:
 
 ```typescript
 const dsResponse = await toDurableChatSessionResponse({

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -18,159 +18,103 @@ sources:
   - "durable-streams/durable-streams:packages/tanstack-ai-transport/src/types.ts"
 ---
 
-This skill builds on durable-streams/getting-started. Read it first for setup and offset basics.
-
 # Durable Streams — TanStack AI
 
 Connection adapter for TanStack AI's `useChat()`. Uses one stream per chat session: user messages are echoed into the stream alongside model responses, making it a complete transcript that supports multi-client sync and SSR hydration.
 
-## Prerequisites: Durable Streams Service
+## The two auth layers — keep them separate
 
-Before writing any code, you need a running Durable Streams service. Two options:
+| Auth                | What                                   | Where                                                   | How                                                         |
+| ------------------- | -------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------- |
+| **Durable Streams** | `DS_SECRET`                            | Server-only — POST `/api/chat` + GET `/api/chat-stream` | `Authorization: Bearer <DS_SECRET>` on upstream DS requests |
+| **AI model**        | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | Server-only (read by the adapter)                       | `process.env.ANTHROPIC_API_KEY` is picked up automatically  |
 
-### Option A: Self-hosted
+NEVER mix these. The DS secret authenticates your server to the DS service. The AI key authenticates your server to Anthropic/OpenAI. The client NEVER sees either.
 
-Run the Caddy-based server locally or on your own infrastructure. See `node_modules/@durable-streams/client/skills/server-deployment/SKILL.md` for the full setup (dev server, production Caddyfile, persistence).
+For apps that let users supply their own AI key, see "User-supplied AI key" below.
 
-Set these env vars to point at your server:
+## Prerequisites
 
-```bash
-DS_URL=http://localhost:4437/v1/stream    # your server's stream endpoint
-DS_SECRET=                                 # empty for local dev, or your auth token
-```
-
-### Option B: Electric Cloud (hosted)
-
-Provision a managed Durable Streams service via the Electric CLI:
+Install the DS client + this package:
 
 ```bash
-npx @electric-sql/cli services create streams --environment <env-id> --name chat-streams
-npx @electric-sql/cli services get-secret <service-id>
+pnpm add @durable-streams/client @durable-streams/tanstack-ai-transport @tanstack/ai-react @tanstack/ai-anthropic
 ```
 
-This returns a `service_id` and `secret`. Store them:
+Set env vars. You need a running Durable Streams service — self-hosted (see `server-deployment` skill) or Electric Cloud (see blog post for setup).
 
 ```bash
-echo "DS_SERVICE_ID=<service_id>" >> .env
-echo "DS_SECRET=<secret>" >> .env
-echo "ELECTRIC_URL=https://api.electric-sql.cloud" >> .env
+ELECTRIC_URL=          # e.g. https://api.electric-sql.cloud (root API URL)
+DS_SERVICE_ID=         # Durable Streams service id, e.g. svc-abc-123
+DS_SECRET=             # Bearer token for DS auth
+ANTHROPIC_API_KEY=     # AI model auth (OR let user supply their own, see below)
 ```
 
-If you're inside the Electric Studio agent sandbox, use `set_secret` to persist them for other agents:
+Build the stream base URL from `ELECTRIC_URL + DS_SERVICE_ID` rather than trusting a single `DS_URL` env var — different environments populate it differently, and a mismatch silently 404s your PUT.
 
-```
-set_secret(key: "DS_SERVICE_ID", value: "<service_id>")
-set_secret(key: "DS_SECRET", value: "<secret>")
-```
-
-### URL construction helper
-
-Use this in your server routes. It works with both self-hosted (`DS_URL` set directly) and Electric Cloud (`DS_SERVICE_ID` + `ELECTRIC_URL`):
-
-```typescript
-function buildStreamUrl(streamPath: string): string {
-  const base =
-    process.env.DS_URL ??
-    `${process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"}/v1/stream/${process.env.DS_SERVICE_ID}`
-  // Use URL constructor to avoid double-slash from trailing slash in base
-  return new URL(streamPath, base.replace(/\/+$/, "") + "/").toString()
-}
-
-function dsAuthHeaders(): Record<string, string> {
-  const secret = process.env.DS_SECRET
-  return secret ? { Authorization: `Bearer ${secret}` } : {}
-}
+```ts
+// src/lib/ds-stream.ts
+const electricUrl = process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"
+const serviceId = process.env.DS_SERVICE_ID
+if (!serviceId) throw new Error("DS_SERVICE_ID is required")
+export const DS_BASE = `${electricUrl.replace(/\/+$/, "")}/v1/stream/${serviceId}`
+export const DS_AUTH = { Authorization: `Bearer ${process.env.DS_SECRET}` }
 ```
 
-Without `DS_SECRET`, requests go unauthenticated (fine for local dev). On Electric Cloud, every DS operation requires the secret or returns 401.
+## Client
 
-## Setup
-
-### Client
-
-```typescript
+```tsx
 import { useMemo } from "react"
 import { useChat } from "@tanstack/ai-react"
 import { durableStreamConnection } from "@durable-streams/tanstack-ai-transport"
 
-function Chat({ id, initialMessages, resumeOffset }) {
+function Chat({
+  id,
+  initialMessages,
+  resumeOffset,
+}: {
+  id: string
+  initialMessages?: Array<any>
+  resumeOffset?: string
+}) {
   const connection = useMemo(
     () =>
       durableStreamConnection({
         sendUrl: `/api/chat?id=${encodeURIComponent(id)}`,
         readUrl: `/api/chat-stream?id=${encodeURIComponent(id)}`,
-        initialOffset: resumeOffset, // from SSR loader, prevents replay
+        initialOffset: resumeOffset, // from SSR loader, skips replay
       }),
     [id, resumeOffset]
   )
 
-  const { messages, sendMessage, isLoading } = useChat({
+  const { messages, sendMessage } = useChat({
     id,
     initialMessages,
     connection,
-    live: true, // keep subscription open for multi-client sync
+    live: true, // keeps read subscription open for multi-client sync
   })
 
-  // Render messages — TanStack AI uses `parts` array, NOT `content` string
-  return messages.map((msg) => (
-    <div key={msg.id}>
-      {msg.parts
-        .filter((p) => p.type === "text")
-        .map((p, i) => <p key={i}>{p.text}</p>)}
-    </div>
-  ))
+  // TanStack AI UIMessage has `parts: Array<MessagePart>`. TextPart uses
+  // `.content` (NOT `.text` — that silently renders empty strings).
+  return (
+    <>
+      {messages.map((m) => (
+        <div key={m.id}>
+          {m.parts
+            .filter((p) => p.type === "text")
+            .map((p, i) => (
+              <span key={i}>{p.content}</span>
+            ))}
+        </div>
+      ))}
+    </>
+  )
 }
 ```
 
-**CRITICAL: Share apiKey state via Context, not per-hook useState.** If multiple components read the API key from settings, each `useState`-based hook has isolated state. When the user saves the key in Settings, only that component sees it — other components still have `""`. Requests go out with `x-api-key: ""` and the server returns 401.
+## Server — POST /api/chat
 
-```typescript
-// WRONG — each useSettings() call has isolated state
-export function useSettings() {
-  const [apiKey, setApiKey] = useState("")
-  useEffect(() => { setApiKey(localStorage.getItem("api-key") ?? "") }, [])
-  return { apiKey, setApiKey }
-}
-
-// RIGHT — use Context so all components see the same value
-const SettingsContext = createContext<{ apiKey: string; setApiKey: (k: string) => void }>(...)
-export function SettingsProvider({ children }) {
-  const [apiKey, setApiKey] = useState(() => localStorage.getItem("api-key") ?? "")
-  const save = useCallback((k: string) => { localStorage.setItem("api-key", k); setApiKey(k) }, [])
-  return <SettingsContext.Provider value={{ apiKey, setApiKey: save }}>{children}</SettingsContext.Provider>
-}
-export const useSettings = () => useContext(SettingsContext)
-```
-
-Wrap your root layout in `<SettingsProvider>` so both the `SettingsDialog` (writer) and the `durableStreamConnection` consumer see the same value.
-
-**CRITICAL: TanStack AI message format.** `useChat()` returns `UIMessage` objects with a `parts` array, NOT a `content` string:
-
-```typescript
-// WRONG — crashes with "Cannot read properties of undefined (reading 'slice')"
-message.content
-
-// RIGHT — TanStack AI UIMessage uses parts array
-function getTextContent(message: {
-  parts: Array<{ type: string; text?: string }>
-}): string {
-  return message.parts
-    .filter((p) => p.type === "text")
-    .map((p) => p.text ?? "")
-    .join("")
-}
-
-// Use it for rendering, titles, etc.
-const title = getTextContent(messages[0]).slice(0, 50)
-```
-
-````
-
-### Server — POST /api/chat
-
-Use `chat()` from `@tanstack/ai` with the appropriate adapter. **Do NOT call LLM SDKs (Anthropic, OpenAI) directly** — the adapter handles message format conversion, streaming chunks, and error mapping.
-
-```typescript
+```ts
 import { chat } from "@tanstack/ai"
 import { anthropicText } from "@tanstack/ai-anthropic"
 import { toDurableChatSessionResponse } from "@durable-streams/tanstack-ai-transport"
@@ -178,253 +122,201 @@ import { toDurableChatSessionResponse } from "@durable-streams/tanstack-ai-trans
 export async function POST(request: Request) {
   const url = new URL(request.url)
   const body = await request.json()
-  const messages = body.messages
-  // id comes from the query string (sendUrl) or body — check both
   const id = url.searchParams.get("id") ?? body.id
   if (!id) return Response.json({ error: "Missing chat id" }, { status: 400 })
 
-  const latestUserMessage = messages.findLast((m) => m.role === "user")
+  const latestUserMessage = body.messages.findLast(
+    (m: any) => m.role === "user"
+  )
 
   const responseStream = chat({
     adapter: anthropicText("claude-sonnet-4-6"),
-    messages,
+    messages: body.messages,
   })
 
-  const dsResponse = await toDurableChatSessionResponse({
+  return await toDurableChatSessionResponse({
     stream: {
-      writeUrl: buildStreamUrl(`chat/${id}`),
-      headers: { ...dsAuthHeaders(), "Content-Type": "application/json" },
+      writeUrl: `${DS_BASE}/chat-${id}`,
+      headers: DS_AUTH,
       createIfMissing: true,
     },
     newMessages: latestUserMessage ? [latestUserMessage] : [],
     responseStream,
   })
-
-  // CRITICAL: reconstruct the response — the upstream DS service may send
-  // both Content-Length and Transfer-Encoding headers, which Node rejects
-  // with "Parse Error: Content-Length can't be present with Transfer-Encoding"
-  const headers = new Headers(dsResponse.headers)
-  headers.delete("content-length")
-  headers.delete("content-encoding")
-  return new Response(dsResponse.body, { status: dsResponse.status, headers })
 }
-````
+```
 
 **Available adapters:**
 
-- `anthropicText("claude-sonnet-4-6")` from `@tanstack/ai-anthropic` — Anthropic Claude models
-- `openaiText("gpt-4o-mini")` from `@tanstack/ai-openai` — OpenAI models
+- `anthropicText("claude-sonnet-4-6")` from `@tanstack/ai-anthropic`
+- `openaiText("gpt-4o-mini")` from `@tanstack/ai-openai`
 
-`mode: "immediate"` (default) returns `202` immediately; writes continue in background. Use `mode: "await"` when the runtime needs an active request to keep running.
+Both read credentials from their standard env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`).
 
-### Auth: two separate concerns
+## Server — GET /api/chat-stream (read proxy)
 
-There are two independent auth layers. Keep them distinct:
+Never expose the DS write URL to the client. Proxy reads through your server so the DS secret stays server-side.
 
-| Auth                | What                     | Where                                                               | How                                                                                                                              |
-| ------------------- | ------------------------ | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Durable Streams** | `DS_SECRET`              | Server-side only — both POST `/api/chat` and GET `/api/chat-stream` | Read from `process.env.DS_SECRET`, inject as `Authorization: Bearer` header on upstream DS requests. NEVER expose to the client. |
-| **AI model**        | `ANTHROPIC_API_KEY` etc. | Server-side only                                                    | Read from `process.env`. The adapter picks it up automatically.                                                                  |
+```ts
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const id = url.searchParams.get("id")
+  if (!id) return Response.json({ error: "Missing id" }, { status: 400 })
 
-**Default pattern (recommended):** API keys are server-side env vars. The client sends only the chat message — no secrets in the browser.
+  const upstream = new URL(`${DS_BASE}/chat-${id}`)
+  // Forward offset/live/sse params from the browser's DS client
+  for (const [k, v] of url.searchParams) {
+    if (k !== "id") upstream.searchParams.set(k, v)
+  }
 
-**User-supplied API key pattern:** If the app lets users enter their own AI key in a settings UI (stored in localStorage), the client must send it to the server on every request. In this case:
+  const response = await fetch(upstream, {
+    headers: {
+      ...DS_AUTH,
+      ...(request.headers.get("accept") && {
+        Accept: request.headers.get("accept")!,
+      }),
+    },
+  })
 
-Client — pass the key via `headers` on `durableStreamConnection` (NOT on `useChat` — those headers are not forwarded):
+  // Strip hop-by-hop headers before forwarding
+  const headers = new Headers()
+  for (const [k, v] of response.headers) {
+    const lk = k.toLowerCase()
+    if (
+      lk === "connection" ||
+      lk === "transfer-encoding" ||
+      lk === "content-length" ||
+      lk === "content-encoding"
+    )
+      continue
+    headers.set(k, v)
+  }
+  return new Response(response.body, { status: response.status, headers })
+}
+```
 
-```typescript
+Use the chat id as a **query parameter** — not a dynamic route segment. Segments like `/api/chat-stream/$id` break when the stream path contains slashes.
+
+## SSR hydration + resume
+
+In your route loader, materialize the snapshot server-side and pass the offset down:
+
+```ts
+import { materializeSnapshotFromDurableStream } from "@durable-streams/tanstack-ai-transport"
+
+export const loader = async ({ params }: { params: { id: string } }) => {
+  const snapshot = await materializeSnapshotFromDurableStream({
+    readUrl: `${DS_BASE}/chat-${params.id}`,
+    headers: DS_AUTH,
+  })
+  return { messages: snapshot.messages, resumeOffset: snapshot.offset }
+}
+```
+
+Pass `resumeOffset` to `durableStreamConnection` — this skips replaying the history on first subscribe.
+
+## User-supplied AI key
+
+If users enter their own AI key in a settings UI:
+
+1. Store the key in a shared store (Context, Zustand, Jotai) — NOT per-hook `useState`, otherwise different components see different values.
+2. Pass it via `headers` on `durableStreamConnection` (NOT on `useChat` — those headers aren't forwarded):
+
+```tsx
+const { apiKey } = useSettings() // from Context/store, shared across components
 const connection = useMemo(
   () =>
     durableStreamConnection({
       sendUrl: `/api/chat?id=${encodeURIComponent(id)}`,
       readUrl: `/api/chat-stream?id=${encodeURIComponent(id)}`,
-      headers: { "x-api-key": apiKey }, // sent on every POST to sendUrl
+      headers: { "x-api-key": apiKey },
     }),
   [id, apiKey]
 )
-
-const { messages, sendMessage } = useChat({ id, connection, live: true })
 ```
 
-Server — read the key from the request header and set it for the adapter:
+Server reads the header and sets it for the adapter:
 
-```typescript
-export async function POST({ request }) {
-  const apiKey = request.headers.get("x-api-key")
-  if (!apiKey)
-    return Response.json({ error: "Missing API key" }, { status: 401 })
-
-  // Set for the adapter (adapter reads process.env.ANTHROPIC_API_KEY)
-  process.env.ANTHROPIC_API_KEY = apiKey
-
-  const { messages, id } = await request.json()
-  // ... rest of handler same as above
-}
+```ts
+const apiKey = request.headers.get("x-api-key")
+if (!apiKey) return Response.json({ error: "Missing API key" }, { status: 401 })
+process.env.ANTHROPIC_API_KEY = apiKey
+// ... rest of handler
 ```
-
-Note: setting `process.env` per-request is a quick hack for single-user apps. For multi-user apps, pass the key via the adapter's constructor options instead.
-
-### SSR hydration
-
-Use `materializeSnapshotFromDurableStream()` in your server loader to build initial state and capture a resume offset:
-
-```typescript
-import { materializeSnapshotFromDurableStream } from "@durable-streams/tanstack-ai-transport"
-
-export async function loader({ params }) {
-  const snapshot = await materializeSnapshotFromDurableStream({
-    readUrl: buildReadStreamUrl(`chat/${params.id}`),
-    headers: READ_HEADERS,
-  })
-
-  return {
-    messages: snapshot.messages,
-    resumeOffset: snapshot.offset, // pass as initialOffset to skip replay
-  }
-}
-```
-
-### Read proxy — GET /api/chat-stream
-
-Always proxy reads through an app route so credentials stay server-side. The `readUrl` in `durableStreamConnection` points here.
-
-```typescript
-// Build the upstream DS URL from env vars
-function buildReadStreamUrl(streamPath: string): string {
-  const dsServiceId = process.env.DS_SERVICE_ID
-  const electricUrl =
-    process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"
-  return `${electricUrl}/v1/stream/${dsServiceId}/${streamPath}`
-}
-
-export async function GET({ request }: { request: Request }) {
-  const url = new URL(request.url)
-  const chatId = url.searchParams.get("id")
-  if (!chatId)
-    return Response.json({ error: "Missing chat id" }, { status: 400 })
-
-  const streamPath = `chat/${chatId}`
-  const upstream = new URL(buildStreamUrl(streamPath))
-
-  // Forward query params (offset, live, etc.) from the browser's DS client
-  for (const [key, value] of url.searchParams) {
-    if (key === "id") continue
-    upstream.searchParams.set(key, value)
-  }
-
-  const response = await fetch(upstream, {
-    headers: {
-      ...dsAuthHeaders(),
-      ...(request.headers.get("accept")
-        ? { Accept: request.headers.get("accept")! }
-        : {}),
-    },
-  })
-
-  // Stream doesn't exist yet (created on first message send).
-  // Forward the 404 as-is — the DS client handles retries internally.
-  // Do NOT return a fake 200 with empty SSE body, as the client will
-  // treat it as "stream closed" and reconnect in a tight loop.
-  if (response.status === 404) {
-    return Response.json(
-      { error: "Stream not found", code: "STREAM_NOT_FOUND" },
-      { status: 404 }
-    )
-  }
-
-  // Strip hop-by-hop headers, always drop content-length + content-encoding
-  const headers = new Headers()
-  for (const [key, value] of response.headers) {
-    const k = key.toLowerCase()
-    if (
-      k === "connection" ||
-      k === "transfer-encoding" ||
-      k === "content-encoding" ||
-      k === "content-length"
-    )
-      continue
-    headers.set(key, value)
-  }
-  headers.set("Cache-Control", "no-store")
-
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  })
-}
-```
-
-Use the chat id as a **query parameter** (`/api/chat-stream?id=...`), not a dynamic route segment. Dynamic segments like `/api/ds-stream/$streamId` cause issues with TanStack Router when the stream path contains slashes.
 
 ## Common Mistakes
 
-### CRITICAL Node 22 Parse Error with Content-Length + Transfer-Encoding
-
-The Electric Cloud DS service may send responses with both `Content-Length` and `Transfer-Encoding` headers. Node 22 rejects this at the socket level with `Parse Error: Content-Length can't be present with Transfer-Encoding` — this crashes **inside** `toDurableChatSessionResponse` before your code can strip headers.
-
-**Workaround:** Start the app with `--insecure-http-parser` to relax Node's strict HTTP parsing:
-
-```json
-// package.json scripts
-{
-  "dev:start": "NODE_OPTIONS='--insecure-http-parser' pnpm dev:start",
-  "dev": "NODE_OPTIONS='--insecure-http-parser' vinxi dev"
-}
-```
-
-Or set it in the Vite config's server options. This is a known issue with the upstream DS service and will be fixed in a future release.
-
-Even with this workaround, always reconstruct the response from `toDurableChatSessionResponse` to strip headers before returning:
-
-```typescript
-const dsResponse = await toDurableChatSessionResponse({
-  stream,
-  newMessages,
-  responseStream,
-})
-const headers = new Headers(dsResponse.headers)
-headers.delete("content-length")
-headers.delete("content-encoding")
-return new Response(dsResponse.body, { status: dsResponse.status, headers })
-```
-
 ### CRITICAL Sending full message history as newMessages
 
-Wrong: `newMessages: messages` — echoes the entire conversation again.
-Fix: only pass messages that are new since the last request:
+Wrong: `newMessages: messages` — echoes the entire conversation every request.
 
-```typescript
+Correct: only pass what's new since the last request:
+
+```ts
 const latestUserMessage = messages.findLast((m) => m.role === "user")
 newMessages: latestUserMessage ? [latestUserMessage] : []
 ```
 
-### CRITICAL Exposing write URLs to the client
+### CRITICAL Exposing the DS write URL to the client
 
-Wrong: setting `readUrl` to the durable stream write URL with credentials.
-Fix: always use a read proxy route for `readUrl` in the connection options.
+Setting `readUrl` on the server stream config to the durable stream's write URL leaks the secret in the `Location` header. Always use a read proxy route for `readUrl`.
 
-Source: packages/tanstack-ai-transport/src/client.ts
+### CRITICAL Wrong field on UIMessage parts — empty bubbles
 
-### HIGH Not passing initialOffset for SSR hydration
+TanStack AI's `UIMessage` has `parts: Array<MessagePart>`. The `TextPart` interface puts the text in `.content` — **not** `.text`, **not** `message.content`. Reading the wrong field renders empty strings silently (no error), so bubbles just show "…" or blank.
 
-Without `initialOffset`, the subscriber replays the entire stream history on first subscribe and materializes a `MESSAGES_SNAPSHOT` from scratch. For long conversations this wastes bandwidth and processing. Pass the offset from `materializeSnapshotFromDurableStream()`.
+```ts
+// WRONG — message.content does not exist on UIMessage
+message.content.slice(0, 50)
 
-Source: packages/tanstack-ai-transport/src/client.ts
+// WRONG — p.text is undefined on TextPart (silently empty)
+message.parts
+  .filter((p) => p.type === "text")
+  .map((p) => p.text)
+  .join("")
 
-### HIGH Not using waitUntil on serverless runtimes
+// RIGHT
+const text = message.parts
+  .filter((p) => p.type === "text")
+  .map((p) => p.content)
+  .join("")
+```
 
-In `immediate` mode, the response returns before writes finish. Without `waitUntil`, serverless runtimes may kill the process and drop chunks.
+Reference: `@tanstack/ai` `TextPart { type: "text"; content: string }` in `src/types.ts`.
 
-Fix: pass `waitUntil: ctx.waitUntil.bind(ctx)` to `toDurableChatSessionResponse()`.
+### HIGH useChat headers are not forwarded
 
-Source: packages/tanstack-ai-transport/src/server.ts
+`headers` on `useChat({ headers })` are NOT sent by `durableStreamConnection`. Put them on the connection:
 
-### MEDIUM Using readUrl as sendUrl
+```ts
+durableStreamConnection({ sendUrl, readUrl, headers: { "x-api-key": key } })
+```
 
-`sendUrl` is the POST endpoint that triggers model generation. `readUrl` is the GET/SSE endpoint for subscribing. These are different routes. Swapping them causes silent failures.
+### HIGH Missing initialOffset for SSR
 
-Source: packages/tanstack-ai-transport/src/client.ts
+Without `initialOffset`, the client replays the entire stream history on first subscribe and re-materializes a `MESSAGES_SNAPSHOT`. For long conversations this wastes bandwidth. Always pass the offset from `materializeSnapshotFromDurableStream()` to the connection.
+
+### HIGH Missing waitUntil on serverless
+
+In `immediate` mode (default), the response returns before background writes finish. Without `waitUntil`, serverless runtimes kill the process and drop chunks:
+
+```ts
+return await toDurableChatSessionResponse({
+  stream,
+  newMessages,
+  responseStream,
+  waitUntil: ctx.waitUntil.bind(ctx),
+})
+```
+
+### MEDIUM Swapping readUrl and sendUrl
+
+`sendUrl` is the POST endpoint that triggers model generation. `readUrl` is the GET/SSE endpoint for subscribing. Different routes — swapping causes silent failures.
+
+## Response contract
+
+- `toDurableChatSessionResponse({ mode: "immediate" })` (default) → `202`, empty body, writes continue in background
+- `toDurableChatSessionResponse({ mode: "await" })` → `200`, empty body, returns after writes finish
 
 ## See also
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -250,8 +250,6 @@ const latestUserMessage = messages.findLast((m) => m.role === "user")
 newMessages: latestUserMessage ? [latestUserMessage] : []
 ```
 
-Source: examples/chat-tanstack/src/routes/api/chat.ts
-
 ### CRITICAL Exposing write URLs to the client
 
 Wrong: setting `readUrl` to the durable stream write URL with credentials.

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -168,7 +168,7 @@ export async function POST(request: Request) {
     messages,
   })
 
-  return await toDurableChatSessionResponse({
+  const dsResponse = await toDurableChatSessionResponse({
     stream: {
       writeUrl: buildStreamUrl(`chat/${id}`),
       headers: { ...dsAuthHeaders(), "Content-Type": "application/json" },
@@ -177,6 +177,14 @@ export async function POST(request: Request) {
     newMessages: latestUserMessage ? [latestUserMessage] : [],
     responseStream,
   })
+
+  // CRITICAL: reconstruct the response — the upstream DS service may send
+  // both Content-Length and Transfer-Encoding headers, which Node rejects
+  // with "Parse Error: Content-Length can't be present with Transfer-Encoding"
+  const headers = new Headers(dsResponse.headers)
+  headers.delete("content-length")
+  headers.delete("content-encoding")
+  return new Response(dsResponse.body, { status: dsResponse.status, headers })
 }
 ````
 
@@ -329,15 +337,11 @@ Use the chat id as a **query parameter** (`/api/chat-stream?id=...`), not a dyna
 
 ## Common Mistakes
 
-### HIGH Not awaiting toDurableChatSessionResponse
+### CRITICAL Returning toDurableChatSessionResponse without stripping headers
 
-Wrong — returns a Promise, not a Response:
+The upstream DS service sends both `Content-Length` and `Transfer-Encoding` headers. Node rejects this with `Parse Error: Content-Length can't be present with Transfer-Encoding`.
 
-```typescript
-return toDurableChatSessionResponse({ stream, newMessages, responseStream })
-```
-
-Correct:
+Wrong:
 
 ```typescript
 return await toDurableChatSessionResponse({
@@ -347,7 +351,19 @@ return await toDurableChatSessionResponse({
 })
 ```
 
-Note: `toDurableChatSessionResponse` currently returns a null-body `202` (immediate mode) or `200` (await mode), so `Content-Length`/`Transfer-Encoding` conflicts don't occur. If you use `toDurableStreamResponse` (the generic variant for Vercel AI SDK), that function returns a JSON body — in that case you may need to strip `content-length` from the response headers.
+Correct — always reconstruct the response:
+
+```typescript
+const dsResponse = await toDurableChatSessionResponse({
+  stream,
+  newMessages,
+  responseStream,
+})
+const headers = new Headers(dsResponse.headers)
+headers.delete("content-length")
+headers.delete("content-encoding")
+return new Response(dsResponse.body, { status: dsResponse.status, headers })
+```
 
 ### CRITICAL Sending full message history as newMessages
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -69,22 +69,20 @@ Use this in your server routes. It works with both self-hosted (`DS_URL` set dir
 
 ```typescript
 function buildStreamUrl(streamPath: string): string {
-  if (process.env.DS_URL) {
-    return `${process.env.DS_URL}/${streamPath}`
-  }
-  const dsServiceId = process.env.DS_SERVICE_ID
-  const electricUrl =
-    process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"
-  return `${electricUrl}/v1/stream/${dsServiceId}/${streamPath}`
+  const base =
+    process.env.DS_URL ??
+    `${process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"}/v1/stream/${process.env.DS_SERVICE_ID}`
+  // Use URL constructor to avoid double-slash from trailing slash in base
+  return new URL(streamPath, base.replace(/\/+$/, "") + "/").toString()
 }
 
-const DS_HEADERS = {
-  Authorization: `Bearer ${process.env.DS_SECRET}`,
-  "Content-Type": "application/json",
+function dsAuthHeaders(): Record<string, string> {
+  const secret = process.env.DS_SECRET
+  return secret ? { Authorization: `Bearer ${secret}` } : {}
 }
 ```
 
-Without these env vars, every DS operation returns 401.
+Without `DS_SECRET`, requests go unauthenticated (fine for local dev). On Electric Cloud, every DS operation requires the secret or returns 401.
 
 ## Setup
 
@@ -139,24 +137,14 @@ export async function POST(request: Request) {
     messages,
   })
 
-  const dsResponse = await toDurableChatSessionResponse({
+  return await toDurableChatSessionResponse({
     stream: {
-      writeUrl: buildWriteStreamUrl(`chat/${id}`),
-      headers: DS_WRITE_HEADERS, // Durable Streams auth — server-side only
+      writeUrl: buildStreamUrl(`chat/${id}`),
+      headers: { ...dsAuthHeaders(), "Content-Type": "application/json" },
       createIfMissing: true,
     },
     newMessages: latestUserMessage ? [latestUserMessage] : [],
     responseStream,
-  })
-
-  // Reconstruct response — strip content-length to avoid conflicts
-  // with transfer-encoding (Node rejects responses with both)
-  const headers = new Headers(dsResponse.headers)
-  headers.delete("content-length")
-  headers.delete("content-encoding")
-  return new Response(dsResponse.body, {
-    status: dsResponse.status,
-    headers,
   })
 }
 ```
@@ -255,7 +243,7 @@ export async function GET({ request }: { request: Request }) {
     return Response.json({ error: "Missing chat id" }, { status: 400 })
 
   const streamPath = `chat/${chatId}`
-  const upstream = new URL(buildReadStreamUrl(streamPath))
+  const upstream = new URL(buildStreamUrl(streamPath))
 
   // Forward query params (offset, live, etc.) from the browser's DS client
   for (const [key, value] of url.searchParams) {
@@ -265,7 +253,7 @@ export async function GET({ request }: { request: Request }) {
 
   const response = await fetch(upstream, {
     headers: {
-      Authorization: `Bearer ${process.env.DS_SECRET}`,
+      ...dsAuthHeaders(),
       ...(request.headers.get("accept")
         ? { Accept: request.headers.get("accept")! }
         : {}),
@@ -310,11 +298,15 @@ Use the chat id as a **query parameter** (`/api/chat-stream?id=...`), not a dyna
 
 ## Common Mistakes
 
-### CRITICAL Returning toDurableChatSessionResponse directly
+### HIGH Not awaiting toDurableChatSessionResponse
 
-The response from `toDurableChatSessionResponse` may contain both `Content-Length` and `Transfer-Encoding` headers from the upstream DS service. Node's HTTP layer rejects this combination — you'll see `Parse Error: Content-Length can't be present with Transfer-Encoding`.
+Wrong — returns a Promise, not a Response:
 
-Wrong:
+```typescript
+return toDurableChatSessionResponse({ stream, newMessages, responseStream })
+```
+
+Correct:
 
 ```typescript
 return await toDurableChatSessionResponse({
@@ -324,19 +316,7 @@ return await toDurableChatSessionResponse({
 })
 ```
 
-Correct — reconstruct the response, stripping content-length:
-
-```typescript
-const dsResponse = await toDurableChatSessionResponse({
-  stream,
-  newMessages,
-  responseStream,
-})
-const headers = new Headers(dsResponse.headers)
-headers.delete("content-length")
-headers.delete("content-encoding")
-return new Response(dsResponse.body, { status: dsResponse.status, headers })
-```
+Note: `toDurableChatSessionResponse` currently returns a null-body `202` (immediate mode) or `200` (await mode), so `Content-Length`/`Transfer-Encoding` conflicts don't occur. If you use `toDurableStreamResponse` (the generic variant for Vercel AI SDK), that function returns a JSON body — in that case you may need to strip `content-length` from the response headers.
 
 ### CRITICAL Sending full message history as newMessages
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -53,6 +53,27 @@ function Chat({ id, initialMessages, resumeOffset }) {
 }
 ```
 
+**Custom headers** (e.g. API keys from the client) go on `durableStreamConnection`, NOT on `useChat`:
+
+```typescript
+// WRONG — useChat headers are NOT forwarded by the connection
+const { messages } = useChat({
+  connection,
+  headers: { "x-api-key": apiKey }, // ❌ not sent to sendUrl
+})
+
+// RIGHT — headers on the connection are sent with every sendUrl POST
+const connection = useMemo(
+  () =>
+    durableStreamConnection({
+      sendUrl: `/api/chat?id=${encodeURIComponent(id)}`,
+      readUrl: `/api/chat-stream?id=${encodeURIComponent(id)}`,
+      headers: { "x-api-key": apiKey }, // ✅ sent on every request
+    }),
+  [id, apiKey]
+)
+```
+
 ### Server — POST /api/chat
 
 Use `chat()` from `@tanstack/ai` with the appropriate adapter. **Do NOT call LLM SDKs (Anthropic, OpenAI) directly** — the adapter handles message format conversion, streaming chunks, and error mapping.
@@ -111,9 +132,67 @@ export async function loader({ params }) {
 }
 ```
 
-### Read proxy
+### Read proxy — GET /api/chat-stream
 
-Always proxy reads through an app route so write credentials stay server-side. See `examples/chat-tanstack/src/routes/api/chat-stream.ts` for the full implementation.
+Always proxy reads through an app route so credentials stay server-side. The `readUrl` in `durableStreamConnection` points here.
+
+```typescript
+// Build the upstream DS URL from env vars
+function buildReadStreamUrl(streamPath: string): string {
+  const dsServiceId = process.env.DS_SERVICE_ID
+  const electricUrl =
+    process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"
+  return `${electricUrl}/v1/stream/${dsServiceId}/${streamPath}`
+}
+
+export async function GET({ request }: { request: Request }) {
+  const url = new URL(request.url)
+  const chatId = url.searchParams.get("id")
+  if (!chatId)
+    return Response.json({ error: "Missing chat id" }, { status: 400 })
+
+  const streamPath = `chat/${chatId}`
+  const upstream = new URL(buildReadStreamUrl(streamPath))
+
+  // Forward query params (offset, live, etc.) from the browser's DS client
+  for (const [key, value] of url.searchParams) {
+    if (key === "id") continue
+    upstream.searchParams.set(key, value)
+  }
+
+  const response = await fetch(upstream, {
+    headers: {
+      Authorization: `Bearer ${process.env.DS_SECRET}`,
+      ...(request.headers.get("accept")
+        ? { Accept: request.headers.get("accept")! }
+        : {}),
+    },
+  })
+
+  // Strip hop-by-hop headers, always drop content-length + content-encoding
+  const headers = new Headers()
+  for (const [key, value] of response.headers) {
+    const k = key.toLowerCase()
+    if (
+      k === "connection" ||
+      k === "transfer-encoding" ||
+      k === "content-encoding" ||
+      k === "content-length"
+    )
+      continue
+    headers.set(key, value)
+  }
+  headers.set("Cache-Control", "no-store")
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+```
+
+Use the chat id as a **query parameter** (`/api/chat-stream?id=...`), not a dynamic route segment. Dynamic segments like `/api/ds-stream/$streamId` cause issues with TanStack Router when the stream path contains slashes.
 
 ## Common Mistakes
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -26,24 +26,29 @@ Connection adapter for TanStack AI's `useChat()`. Uses one stream per chat sessi
 
 ## Prerequisites: Durable Streams Service
 
-Before writing any code, you need a Durable Streams service. On Electric Cloud:
+Before writing any code, you need a running Durable Streams service. Two options:
 
-1. **Provision the service** using the Electric CLI (the token should already be in your secrets):
+### Option A: Self-hosted
+
+Run the Caddy-based server locally or on your own infrastructure. See `node_modules/@durable-streams/client/skills/server-deployment/SKILL.md` for the full setup (dev server, production Caddyfile, persistence).
+
+Set these env vars to point at your server:
 
 ```bash
-export ELECTRIC_CLI_TOKEN=$(get_secret ELECTRIC_CLI_TOKEN)
+DS_URL=http://localhost:4437/v1/stream    # your server's stream endpoint
+DS_SECRET=                                 # empty for local dev, or your auth token
+```
+
+### Option B: Electric Cloud (hosted)
+
+Provision a managed Durable Streams service via the Electric CLI:
+
+```bash
 npx @electric-sql/cli services create streams --environment <env-id> --name chat-streams
 npx @electric-sql/cli services get-secret <service-id>
 ```
 
-2. **Store the credentials** via `set_secret`:
-
-```
-set_secret(key: "DS_SERVICE_ID", value: "<service_id from CLI>")
-set_secret(key: "DS_SECRET", value: "<secret from CLI>")
-```
-
-3. **Write them to `.env`** so server routes can read them:
+This returns a `service_id` and `secret`. Store them:
 
 ```bash
 echo "DS_SERVICE_ID=<service_id>" >> .env
@@ -51,23 +56,35 @@ echo "DS_SECRET=<secret>" >> .env
 echo "ELECTRIC_URL=https://api.electric-sql.cloud" >> .env
 ```
 
-The server routes below read these env vars to construct stream URLs and auth headers. Without them, every DS operation returns 401.
+If you're inside the Electric Studio agent sandbox, use `set_secret` to persist them for other agents:
 
-**URL construction pattern** — use this helper in your server routes:
+```
+set_secret(key: "DS_SERVICE_ID", value: "<service_id>")
+set_secret(key: "DS_SECRET", value: "<secret>")
+```
+
+### URL construction helper
+
+Use this in your server routes. It works with both self-hosted (`DS_URL` set directly) and Electric Cloud (`DS_SERVICE_ID` + `ELECTRIC_URL`):
 
 ```typescript
 function buildStreamUrl(streamPath: string): string {
+  if (process.env.DS_URL) {
+    return `${process.env.DS_URL}/${streamPath}`
+  }
   const dsServiceId = process.env.DS_SERVICE_ID
   const electricUrl =
     process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"
   return `${electricUrl}/v1/stream/${dsServiceId}/${streamPath}`
 }
 
-const DS_WRITE_HEADERS = {
+const DS_HEADERS = {
   Authorization: `Bearer ${process.env.DS_SECRET}`,
   "Content-Type": "application/json",
 }
 ```
+
+Without these env vars, every DS operation returns 401.
 
 ## Setup
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -122,6 +122,28 @@ function Chat({ id, initialMessages, resumeOffset }) {
 }
 ```
 
+**CRITICAL: Share apiKey state via Context, not per-hook useState.** If multiple components read the API key from settings, each `useState`-based hook has isolated state. When the user saves the key in Settings, only that component sees it — other components still have `""`. Requests go out with `x-api-key: ""` and the server returns 401.
+
+```typescript
+// WRONG — each useSettings() call has isolated state
+export function useSettings() {
+  const [apiKey, setApiKey] = useState("")
+  useEffect(() => { setApiKey(localStorage.getItem("api-key") ?? "") }, [])
+  return { apiKey, setApiKey }
+}
+
+// RIGHT — use Context so all components see the same value
+const SettingsContext = createContext<{ apiKey: string; setApiKey: (k: string) => void }>(...)
+export function SettingsProvider({ children }) {
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem("api-key") ?? "")
+  const save = useCallback((k: string) => { localStorage.setItem("api-key", k); setApiKey(k) }, [])
+  return <SettingsContext.Provider value={{ apiKey, setApiKey: save }}>{children}</SettingsContext.Provider>
+}
+export const useSettings = () => useContext(SettingsContext)
+```
+
+Wrap your root layout in `<SettingsProvider>` so both the `SettingsDialog` (writer) and the `durableStreamConnection` consumer see the same value.
+
 **CRITICAL: TanStack AI message format.** `useChat()` returns `UIMessage` objects with a `parts` array, NOT a `content` string:
 
 ```typescript

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -24,6 +24,51 @@ This skill builds on durable-streams/getting-started. Read it first for setup an
 
 Connection adapter for TanStack AI's `useChat()`. Uses one stream per chat session: user messages are echoed into the stream alongside model responses, making it a complete transcript that supports multi-client sync and SSR hydration.
 
+## Prerequisites: Durable Streams Service
+
+Before writing any code, you need a Durable Streams service. On Electric Cloud:
+
+1. **Provision the service** using the Electric CLI (the token should already be in your secrets):
+
+```bash
+export ELECTRIC_CLI_TOKEN=$(get_secret ELECTRIC_CLI_TOKEN)
+npx @electric-sql/cli services create streams --environment <env-id> --name chat-streams
+npx @electric-sql/cli services get-secret <service-id>
+```
+
+2. **Store the credentials** via `set_secret`:
+
+```
+set_secret(key: "DS_SERVICE_ID", value: "<service_id from CLI>")
+set_secret(key: "DS_SECRET", value: "<secret from CLI>")
+```
+
+3. **Write them to `.env`** so server routes can read them:
+
+```bash
+echo "DS_SERVICE_ID=<service_id>" >> .env
+echo "DS_SECRET=<secret>" >> .env
+echo "ELECTRIC_URL=https://api.electric-sql.cloud" >> .env
+```
+
+The server routes below read these env vars to construct stream URLs and auth headers. Without them, every DS operation returns 401.
+
+**URL construction pattern** — use this helper in your server routes:
+
+```typescript
+function buildStreamUrl(streamPath: string): string {
+  const dsServiceId = process.env.DS_SERVICE_ID
+  const electricUrl =
+    process.env.ELECTRIC_URL || "https://api.electric-sql.cloud"
+  return `${electricUrl}/v1/stream/${dsServiceId}/${streamPath}`
+}
+
+const DS_WRITE_HEADERS = {
+  Authorization: `Bearer ${process.env.DS_SECRET}`,
+  "Content-Type": "application/json",
+}
+```
+
 ## Setup
 
 ### Client

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -273,15 +273,14 @@ export async function GET({ request }: { request: Request }) {
   })
 
   // Stream doesn't exist yet (created on first message send).
-  // Return empty SSE so the client doesn't show a console error.
+  // Forward the 404 as-is — the DS client handles retries internally.
+  // Do NOT return a fake 200 with empty SSE body, as the client will
+  // treat it as "stream closed" and reconnect in a tight loop.
   if (response.status === 404) {
-    return new Response("", {
-      status: 200,
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache, no-store, must-revalidate",
-      },
-    })
+    return Response.json(
+      { error: "Stream not found", code: "STREAM_NOT_FOUND" },
+      { status: 404 }
+    )
   }
 
   // Strip hop-by-hop headers, always drop content-length + content-encoding

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -125,7 +125,13 @@ import { anthropicText } from "@tanstack/ai-anthropic"
 import { toDurableChatSessionResponse } from "@durable-streams/tanstack-ai-transport"
 
 export async function POST(request: Request) {
-  const { messages, id } = await request.json()
+  const url = new URL(request.url)
+  const body = await request.json()
+  const messages = body.messages
+  // id comes from the query string (sendUrl) or body — check both
+  const id = url.searchParams.get("id") ?? body.id
+  if (!id) return Response.json({ error: "Missing chat id" }, { status: 400 })
+
   const latestUserMessage = messages.findLast((m) => m.role === "user")
 
   const responseStream = chat({

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -133,13 +133,24 @@ export async function POST(request: Request) {
     messages,
   })
 
-  return await toDurableChatSessionResponse({
+  const dsResponse = await toDurableChatSessionResponse({
     stream: {
       writeUrl: buildWriteStreamUrl(`chat/${id}`),
       headers: DS_WRITE_HEADERS, // Durable Streams auth — server-side only
+      createIfMissing: true,
     },
     newMessages: latestUserMessage ? [latestUserMessage] : [],
     responseStream,
+  })
+
+  // Reconstruct response — strip content-length to avoid conflicts
+  // with transfer-encoding (Node rejects responses with both)
+  const headers = new Headers(dsResponse.headers)
+  headers.delete("content-length")
+  headers.delete("content-encoding")
+  return new Response(dsResponse.body, {
+    status: dsResponse.status,
+    headers,
   })
 }
 ```
@@ -282,15 +293,11 @@ Use the chat id as a **query parameter** (`/api/chat-stream?id=...`), not a dyna
 
 ## Common Mistakes
 
-### CRITICAL Not awaiting toDurableChatSessionResponse
+### CRITICAL Returning toDurableChatSessionResponse directly
 
-Wrong — returns a Promise object, causing header conflicts (500):
+The response from `toDurableChatSessionResponse` may contain both `Content-Length` and `Transfer-Encoding` headers from the upstream DS service. Node's HTTP layer rejects this combination — you'll see `Parse Error: Content-Length can't be present with Transfer-Encoding`.
 
-```typescript
-return toDurableChatSessionResponse({ stream, newMessages, responseStream })
-```
-
-Correct — await the response:
+Wrong:
 
 ```typescript
 return await toDurableChatSessionResponse({
@@ -300,7 +307,19 @@ return await toDurableChatSessionResponse({
 })
 ```
 
-In TanStack Start server handlers, returning an unresolved Promise causes Node to serialize it incorrectly, producing both `Content-Length` and `Transfer-Encoding: chunked` headers simultaneously — which HTTP/1.1 forbids.
+Correct — reconstruct the response, stripping content-length:
+
+```typescript
+const dsResponse = await toDurableChatSessionResponse({
+  stream,
+  newMessages,
+  responseStream,
+})
+const headers = new Headers(dsResponse.headers)
+headers.delete("content-length")
+headers.delete("content-encoding")
+return new Response(dsResponse.body, { status: dsResponse.status, headers })
+```
 
 ### CRITICAL Sending full message history as newMessages
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -321,6 +321,30 @@ Two separate React pitfalls compound into the same symptom (header/messages don'
    )
    ```
 
+### CRITICAL sendMessage signature — crash on submit
+
+`useChat().sendMessage` takes either a string **or** `{ content: Array<ContentPart>, id? }` (for multimodal). The intuitive-looking `{ text: "hi" }` form is NOT supported — it normalizes to `{ content: undefined }` and crashes inside `StreamProcessor.addUserMessage` with:
+
+```
+TypeError: Cannot read properties of undefined (reading 'map')
+```
+
+```ts
+// WRONG — passes { text } which is neither a string nor a valid object shape
+sendMessage({ text: input.trim() })
+
+// RIGHT — pass the string directly
+sendMessage(input.trim())
+
+// RIGHT — multimodal (explicit content parts)
+sendMessage({
+  content: [
+    { type: "text", content: input.trim() },
+    { type: "image", source: { type: "url", value: imageUrl } },
+  ],
+})
+```
+
 ### CRITICAL Wrong field on UIMessage parts — empty bubbles
 
 TanStack AI's `UIMessage` has `parts: Array<MessagePart>`. The `TextPart` interface puts the text in `.content` — **not** `.text`, **not** `message.content`. Reading the wrong field renders empty strings silently (no error), so bubbles just show "…" or blank.

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -110,8 +110,39 @@ function Chat({ id, initialMessages, resumeOffset }) {
     connection,
     live: true, // keep subscription open for multi-client sync
   })
+
+  // Render messages — TanStack AI uses `parts` array, NOT `content` string
+  return messages.map((msg) => (
+    <div key={msg.id}>
+      {msg.parts
+        .filter((p) => p.type === "text")
+        .map((p, i) => <p key={i}>{p.text}</p>)}
+    </div>
+  ))
 }
 ```
+
+**CRITICAL: TanStack AI message format.** `useChat()` returns `UIMessage` objects with a `parts` array, NOT a `content` string:
+
+```typescript
+// WRONG — crashes with "Cannot read properties of undefined (reading 'slice')"
+message.content
+
+// RIGHT — TanStack AI UIMessage uses parts array
+function getTextContent(message: {
+  parts: Array<{ type: string; text?: string }>
+}): string {
+  return message.parts
+    .filter((p) => p.type === "text")
+    .map((p) => p.text ?? "")
+    .join("")
+}
+
+// Use it for rendering, titles, etc.
+const title = getTextContent(messages[0]).slice(0, 50)
+```
+
+````
 
 ### Server — POST /api/chat
 
@@ -147,7 +178,7 @@ export async function POST(request: Request) {
     responseStream,
   })
 }
-```
+````
 
 **Available adapters:**
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -53,27 +53,6 @@ function Chat({ id, initialMessages, resumeOffset }) {
 }
 ```
 
-**Custom headers** (e.g. API keys from the client) go on `durableStreamConnection`, NOT on `useChat`:
-
-```typescript
-// WRONG — useChat headers are NOT forwarded by the connection
-const { messages } = useChat({
-  connection,
-  headers: { "x-api-key": apiKey }, // ❌ not sent to sendUrl
-})
-
-// RIGHT — headers on the connection are sent with every sendUrl POST
-const connection = useMemo(
-  () =>
-    durableStreamConnection({
-      sendUrl: `/api/chat?id=${encodeURIComponent(id)}`,
-      readUrl: `/api/chat-stream?id=${encodeURIComponent(id)}`,
-      headers: { "x-api-key": apiKey }, // ✅ sent on every request
-    }),
-  [id, apiKey]
-)
-```
-
 ### Server — POST /api/chat
 
 Use `chat()` from `@tanstack/ai` with the appropriate adapter. **Do NOT call LLM SDKs (Anthropic, OpenAI) directly** — the adapter handles message format conversion, streaming chunks, and error mapping.
@@ -92,10 +71,10 @@ export async function POST(request: Request) {
     messages,
   })
 
-  return toDurableChatSessionResponse({
+  return await toDurableChatSessionResponse({
     stream: {
       writeUrl: buildWriteStreamUrl(`chat/${id}`),
-      headers: WRITE_HEADERS,
+      headers: DS_WRITE_HEADERS, // Durable Streams auth — server-side only
     },
     newMessages: latestUserMessage ? [latestUserMessage] : [],
     responseStream,
@@ -108,9 +87,54 @@ export async function POST(request: Request) {
 - `anthropicText("claude-sonnet-4-6")` from `@tanstack/ai-anthropic` — Anthropic Claude models
 - `openaiText("gpt-4o-mini")` from `@tanstack/ai-openai` — OpenAI models
 
-The adapter reads credentials from standard env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). Do NOT pass API keys from the client.
-
 `mode: "immediate"` (default) returns `202` immediately; writes continue in background. Use `mode: "await"` when the runtime needs an active request to keep running.
+
+### Auth: two separate concerns
+
+There are two independent auth layers. Keep them distinct:
+
+| Auth                | What                     | Where                                                               | How                                                                                                                              |
+| ------------------- | ------------------------ | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Durable Streams** | `DS_SECRET`              | Server-side only — both POST `/api/chat` and GET `/api/chat-stream` | Read from `process.env.DS_SECRET`, inject as `Authorization: Bearer` header on upstream DS requests. NEVER expose to the client. |
+| **AI model**        | `ANTHROPIC_API_KEY` etc. | Server-side only                                                    | Read from `process.env`. The adapter picks it up automatically.                                                                  |
+
+**Default pattern (recommended):** API keys are server-side env vars. The client sends only the chat message — no secrets in the browser.
+
+**User-supplied API key pattern:** If the app lets users enter their own AI key in a settings UI (stored in localStorage), the client must send it to the server on every request. In this case:
+
+Client — pass the key via `headers` on `durableStreamConnection` (NOT on `useChat` — those headers are not forwarded):
+
+```typescript
+const connection = useMemo(
+  () =>
+    durableStreamConnection({
+      sendUrl: `/api/chat?id=${encodeURIComponent(id)}`,
+      readUrl: `/api/chat-stream?id=${encodeURIComponent(id)}`,
+      headers: { "x-api-key": apiKey }, // sent on every POST to sendUrl
+    }),
+  [id, apiKey]
+)
+
+const { messages, sendMessage } = useChat({ id, connection, live: true })
+```
+
+Server — read the key from the request header and set it for the adapter:
+
+```typescript
+export async function POST({ request }) {
+  const apiKey = request.headers.get("x-api-key")
+  if (!apiKey)
+    return Response.json({ error: "Missing API key" }, { status: 401 })
+
+  // Set for the adapter (adapter reads process.env.ANTHROPIC_API_KEY)
+  process.env.ANTHROPIC_API_KEY = apiKey
+
+  const { messages, id } = await request.json()
+  // ... rest of handler same as above
+}
+```
+
+Note: setting `process.env` per-request is a quick hack for single-user apps. For multi-user apps, pass the key via the adapter's constructor options instead.
 
 ### SSR hydration
 

--- a/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
+++ b/packages/tanstack-ai-transport/skills/tanstack-ai/SKILL.md
@@ -266,6 +266,18 @@ export async function GET({ request }: { request: Request }) {
     },
   })
 
+  // Stream doesn't exist yet (created on first message send).
+  // Return empty SSE so the client doesn't show a console error.
+  if (response.status === 404) {
+    return new Response("", {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+      },
+    })
+  }
+
   // Strip hop-by-hop headers, always drop content-length + content-encoding
   const headers = new Headers()
   for (const [key, value] of response.headers) {

--- a/packages/y-durable-streams/skills/yjs-editors/SKILL.md
+++ b/packages/y-durable-streams/skills/yjs-editors/SKILL.md
@@ -171,6 +171,161 @@ export const Route = createFileRoute("/doc/$docId")({
 })
 ```
 
+### Sharing doc/awareness via Context (multi-consumer apps)
+
+When several sibling components need the same doc and awareness (an editor,
+a presence list, a save button), wrap them in a Context Provider instead of
+prop-drilling. The Provider owns the lifecycle; children consume via a hook.
+
+```tsx
+import { createContext, useContext, useEffect, useRef, useState } from "react"
+import type { ReactNode } from "react"
+import * as Y from "yjs"
+import { Awareness } from "y-protocols/awareness"
+import { YjsProvider } from "@durable-streams/y-durable-streams"
+import type { YjsProviderStatus } from "@durable-streams/y-durable-streams"
+
+interface YjsRoomContextValue {
+  doc: Y.Doc
+  awareness: Awareness
+  roomId: string
+  isLoading: boolean
+  isSynced: boolean
+  error: Error | null
+  setUsername: (name: string) => void
+  username: string
+}
+
+const YjsRoomContext = createContext<YjsRoomContextValue | null>(null)
+
+export function useYjsRoom(): YjsRoomContextValue {
+  const ctx = useContext(YjsRoomContext)
+  if (!ctx) throw new Error("useYjsRoom must be used inside YjsRoomProvider")
+  return ctx
+}
+
+export function YjsRoomProvider({
+  roomId,
+  baseUrl,
+  initialUser,
+  children,
+}: {
+  roomId: string
+  baseUrl: string
+  initialUser: { name: string; color: string; colorLight: string }
+  children: ReactNode
+}) {
+  const [username, setUsernameState] = useState(initialUser.name)
+  const usernameRef = useRef(username)
+  usernameRef.current = username
+
+  // Doc + awareness: stable across renders, with initial local state so the
+  // first awareness broadcast already has the user info (no null-state flash).
+  const [{ doc, awareness }] = useState(() => {
+    const d = new Y.Doc()
+    const a = new Awareness(d)
+    a.setLocalState({ user: initialUser })
+    return { doc: d, awareness: a }
+  })
+
+  // Destroy doc + awareness on unmount
+  useEffect(
+    () => () => {
+      awareness.destroy()
+      doc.destroy()
+    },
+    [doc, awareness]
+  )
+
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSynced, setIsSynced] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Mutation path for username — merge into existing awareness state so
+  // other fields (cursor, selection) aren't clobbered.
+  const setUsername = (name: string) => {
+    setUsernameState(name)
+    const current = awareness.getLocalState() || {}
+    awareness.setLocalState({
+      ...current,
+      user: { ...initialUser, name },
+    })
+  }
+
+  useEffect(() => {
+    const provider = new YjsProvider({
+      doc,
+      baseUrl,
+      docId: roomId,
+      awareness,
+      connect: false, // attach listeners BEFORE connecting
+    })
+
+    provider.on("synced", (s: boolean) => {
+      setIsSynced(s)
+      if (s) setIsLoading(false)
+    })
+    provider.on("status", (s: YjsProviderStatus) => {
+      if (s === "connected") setIsLoading(false)
+    })
+    provider.on("error", (err: Error) => {
+      setError(err)
+      setIsLoading(false)
+    })
+
+    // Strict Mode's effect cleanup may have wiped local state when the
+    // previous provider was destroyed. Re-seed before connecting so the
+    // first broadcast has user info (uses usernameRef, not the stale closure).
+    if (awareness.getLocalState() === null) {
+      awareness.setLocalState({
+        user: { ...initialUser, name: usernameRef.current },
+      })
+    }
+
+    provider.connect()
+    return () => provider.destroy()
+  }, [roomId, doc, awareness, baseUrl, initialUser])
+
+  return (
+    <YjsRoomContext.Provider
+      value={{
+        doc,
+        awareness,
+        roomId,
+        isLoading,
+        isSynced,
+        error,
+        setUsername,
+        username,
+      }}
+    >
+      {children}
+    </YjsRoomContext.Provider>
+  )
+}
+```
+
+Usage — key the Provider on roomId so navigating between rooms fully
+tears down and rebuilds the CRDT:
+
+```tsx
+<YjsRoomProvider
+  key={roomId}
+  roomId={roomId}
+  baseUrl={baseUrl}
+  initialUser={user}
+>
+  <Editor /> {/* consumes via useYjsRoom() */}
+  <PresenceList />
+  <SaveButton />
+</YjsRoomProvider>
+```
+
+Three things to notice: (1) `status` + `synced` + `error` events are all
+attached before `connect()`, (2) the `usernameRef` is read at connect time
+to survive Strict Mode's double-invocation cleanup, (3) `setUsername`
+merges into existing local state instead of overwriting it.
+
 ## TipTap v3
 
 ### Install

--- a/packages/y-durable-streams/skills/yjs-editors/SKILL.md
+++ b/packages/y-durable-streams/skills/yjs-editors/SKILL.md
@@ -30,8 +30,7 @@ the binding setup.
 
 ## React lifecycle pattern (shared by all editors)
 
-All editor integrations MUST use this pattern. It matches the working
-`examples/yjs-demo/src/components/yjs-provider.tsx` in this repository.
+All editor integrations MUST use this pattern.
 
 **Key principle:** Doc and awareness are created once via `useState` (stable
 references). The provider is created in `useEffect` with `connect: false` so
@@ -393,8 +392,6 @@ This is the #1 cause of "stuck Connecting" in agent-built apps. The provider
 connects, syncs, emits `synced: true`, but no listener is attached yet.
 React's `useEffect` runs after the render cycle, by which time the async
 connection has already completed.
-
-Source: Documented in 5+ agent sessions; matches examples/yjs-demo pattern
 
 ### HIGH Using `useMemo` for Y.Doc or Awareness (all editors)
 

--- a/packages/y-durable-streams/skills/yjs-server/SKILL.md
+++ b/packages/y-durable-streams/skills/yjs-server/SKILL.md
@@ -62,6 +62,85 @@ const yjsServer = new YjsServer({
 await yjsServer.start()
 ```
 
+### Single-origin dev server (HTTP/2 multiplexing)
+
+For local development you usually want one origin the browser hits so HTTP/2
+can multiplex the DS stream, Yjs stream, and the Vite dev server over a
+single connection. Spawn Caddy from a Node script alongside YjsServer:
+
+```typescript
+// server.ts
+import { spawn } from "node:child_process"
+import { resolve } from "node:path"
+import { YjsServer } from "@durable-streams/y-durable-streams/server"
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0" // trust Caddy's self-signed cert
+
+const CADDY_PORT = 4443
+const YJS_PORT = 4438
+
+const yjsServer = new YjsServer({
+  port: YJS_PORT,
+  host: "127.0.0.1",
+  dsServerUrl: `https://localhost:${CADDY_PORT}`, // go through Caddy for TLS
+  compactionThreshold: 1024 * 1024,
+})
+await yjsServer.start()
+
+const caddy = spawn(
+  resolve(import.meta.dirname, "./durable-streams-server"),
+  ["run", "--config", resolve(import.meta.dirname, "./Caddyfile")],
+  { stdio: ["ignore", "pipe", "pipe"] }
+)
+
+// Wait for Caddy's ready line before returning control
+await new Promise<void>((ok, fail) => {
+  const t = setTimeout(() => fail(new Error("Caddy start timeout")), 10_000)
+  caddy.stderr.on("data", (buf: Buffer) => {
+    if (buf.toString().includes("serving initial configuration")) {
+      clearTimeout(t)
+      ok()
+    }
+  })
+  caddy.on("exit", (code) => {
+    clearTimeout(t)
+    if (code && code !== 0) fail(new Error(`Caddy exited ${code}`))
+  })
+})
+
+process.on("SIGINT", async () => {
+  await yjsServer.stop()
+  caddy.kill("SIGTERM")
+  process.exit(0)
+})
+```
+
+And the matching dev Caddyfile — DS at `/v1/stream/*`, Yjs proxied to the
+internal YjsServer, everything else to Vite:
+
+```caddy
+{
+  admin off
+}
+
+localhost:4443 {
+  route /v1/stream/* {
+    durable_streams
+  }
+
+  route /v1/yjs/* {
+    reverse_proxy localhost:4438 {
+      flush_interval -1
+    }
+  }
+
+  reverse_proxy localhost:3001   # Vite dev server
+}
+```
+
+The `flush_interval -1` on the Yjs route is mandatory (see Common Mistakes
+below). Keep the dev and production Caddyfiles consistent on this flag.
+
 ### YjsServer options
 
 | Option                | Default         | Description                                         |

--- a/packages/y-durable-streams/skills/yjs-server/SKILL.md
+++ b/packages/y-durable-streams/skills/yjs-server/SKILL.md
@@ -231,8 +231,6 @@ route /v1/yjs/* {
 Without this, Caddy buffers SSE responses. Live updates appear to hang —
 clients connect but never receive data.
 
-Source: examples/yjs-demo/Caddyfile
-
 ### HIGH Exposing Electric Cloud secret to browser clients
 
 Wrong:


### PR DESCRIPTION
## Summary
- Document that custom `headers` (API keys) must go on `durableStreamConnection`, NOT on `useChat` — `useChat` headers are not forwarded by the connection
- Add full read proxy implementation inline (was "see examples/" which agents can't access)
- Recommend query params over dynamic route segments for chat id (avoids TanStack Router issues with slashes)

## Context
AI agents building chat apps consistently put API key headers on `useChat` instead of `durableStreamConnection`, causing 401 errors. The read proxy was referenced but never shown, so agents wrote broken proxies.

Generated with [Claude Code](https://claude.com/claude-code)