### PR TITLE
fix(server): serialize concurrent appends to the same stream

### DIFF
--- a/.changeset/fix-file-store-append-race.md
+++ b/.changeset/fix-file-store-append-race.md
@@ -1,0 +1,23 @@
+---
+"@durable-streams/server": patch
+---
+
+fix(server): serialize concurrent appends to the same stream
+
+Without per-stream serialization, the file-backed `append()` had a race
+in the read-modify-write of `streamMeta.currentOffset`: two concurrent
+appenders could read the same starting offset, both compute the same
+`newOffset`, both write a frame to the segment file, and only one's
+LMDB metadata update would win. The file then contained two frames at
+positions past the LMDB-tracked `currentOffset`, so subsequent
+`getTailOffset` lookups (and `stream-next-offset` headers) lagged the
+actual stream contents — causing valid `done`-callback acks at offsets
+that the server's stale tail had never seen to be rejected with
+`INVALID_OFFSET`.
+
+Reproduced with N concurrent appends to one stream collapsing to a
+single offset value (added as a regression test in
+`packages/server/test/file-backed.test.ts`). The fix wraps `append()`
+in a per-stream lock (mirrors `acquireProducerLock`), so the
+read-currentOffset → write-frame → fsync → put-LMDB sequence runs
+atomically per stream.

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -232,6 +232,13 @@ export class FileBackedStreamStore {
    * Key: "{streamPath}:{producerId}"
    */
   private producerLocks = new Map<string, Promise<unknown>>()
+  /**
+   * Per-stream append locks. Serializes the read-modify-write of currentOffset
+   * across all concurrent appenders on the same stream so the LMDB-tracked
+   * offset cannot drift behind the file's actual byte position.
+   * Key: streamPath
+   */
+  private streamAppendLocks = new Map<string, Promise<unknown>>()
 
   constructor(options: FileBackedStreamStoreOptions) {
     this.dataDir = options.dataDir
@@ -531,6 +538,33 @@ export class FileBackedStreamStore {
 
     return () => {
       this.producerLocks.delete(lockKey)
+      releaseLock!()
+    }
+  }
+
+  /**
+   * Acquire a per-stream append lock that serializes the read-modify-write
+   * of currentOffset across all concurrent appenders on the same stream.
+   * Without this, two concurrent appends can read the same starting
+   * currentOffset, both compute their newOffset, both write a frame to the
+   * file, but only one of their LMDB updates wins — leaving currentOffset
+   * lagging the file's actual byte position. Returns a release function.
+   */
+  private async acquireStreamAppendLock(
+    streamPath: string
+  ): Promise<() => void> {
+    while (this.streamAppendLocks.has(streamPath)) {
+      await this.streamAppendLocks.get(streamPath)
+    }
+
+    let releaseLock: () => void
+    const lockPromise = new Promise<void>((resolve) => {
+      releaseLock = resolve
+    })
+    this.streamAppendLocks.set(streamPath, lockPromise)
+
+    return () => {
+      this.streamAppendLocks.delete(streamPath)
       releaseLock!()
     }
   }
@@ -985,7 +1019,25 @@ export class FileBackedStreamStore {
     }
   }
 
+  /**
+   * Public append entry point. Serializes concurrent appends to the same
+   * stream so the read-modify-write of currentOffset cannot interleave —
+   * see acquireStreamAppendLock for the underlying race.
+   */
   async append(
+    streamPath: string,
+    data: Uint8Array,
+    options: AppendOptions & { isInitialCreate?: boolean } = {}
+  ): Promise<StreamMessage | AppendResult | null> {
+    const releaseLock = await this.acquireStreamAppendLock(streamPath)
+    try {
+      return await this.appendInner(streamPath, data, options)
+    } finally {
+      releaseLock()
+    }
+  }
+
+  private async appendInner(
     streamPath: string,
     data: Uint8Array,
     options: AppendOptions & { isInitialCreate?: boolean } = {}

--- a/packages/server/test/file-backed.test.ts
+++ b/packages/server/test/file-backed.test.ts
@@ -276,3 +276,47 @@ describe(`Recovery and Crash Consistency`, () => {
     await server2.stop()
   })
 })
+
+// ============================================================================
+// Concurrent Append Tests
+// ============================================================================
+
+describe(`Concurrent appends`, () => {
+  test(`currentOffset stays in sync with file under concurrent appends to the same stream`, async () => {
+    // Regression test: without per-stream serialization in append(), two
+    // concurrent appends can both read the same starting currentOffset,
+    // both compute their newOffset, both write a frame to the file, but
+    // only one's LMDB update wins — leaving currentOffset lagging the
+    // file's actual byte position. The next append/read then sees an
+    // offset that the LMDB-tracked tail doesn't acknowledge, which on the
+    // server side surfaces as INVALID_OFFSET ack rejections.
+    server.store.create(`/concurrent`, { contentType: `text/plain` })
+
+    const N = 50
+    const payload = encode(`x`.repeat(64))
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        server.store.append(`/concurrent`, payload)
+      )
+    )
+
+    // Every append must have produced a message with a unique offset.
+    const offsets = results
+      .map((r) => (r && `offset` in r ? r.offset : null))
+      .filter((o): o is string => o !== null)
+    expect(offsets).toHaveLength(N)
+    expect(new Set(offsets).size).toBe(N)
+
+    // The file must contain N messages — read() walks the file directly.
+    const { messages } = server.store.read(`/concurrent`)
+    expect(messages).toHaveLength(N)
+
+    // The LMDB-tracked currentOffset must equal the offset of the last
+    // frame in the file. Otherwise the server's stream-next-offset header
+    // (and getTailOffset) would lag the actual stream contents and reject
+    // valid acks.
+    const meta = (server.store as any).db.get(`stream:/concurrent`)
+    const lastMessageOffset = messages[messages.length - 1].offset
+    expect(meta.currentOffset).toBe(lastMessageOffset)
+  })
+})


### PR DESCRIPTION
## Summary

The file-backed `append()` had a race in the read-modify-write of `streamMeta.currentOffset`. With N concurrent appenders on the same stream, two requests could both read the same starting offset, both compute the same `newOffset`, both write a frame to the segment file, but only one's LMDB metadata update would win. The file then contained frames at byte positions past the LMDB-tracked `currentOffset`.

The user-visible failure I hit: a multi-agent example with ~15 workers fanning out and ack'ing back to a shared orchestrator stream. About 1–2 minutes after the workers started reporting back, the orchestrator's `done`-callback consumer would enter a permanent `INVALID_OFFSET` retry loop. Direct evidence:

```
GET /orchestrator/.../main?offset=-1
  Response header:  stream-next-offset: 0000000000000000_0000000000125439
  Response body:    317 events, last event's offset = 0000000000000000_0000000000185600
```

The `stream-next-offset` header (built from the LMDB `currentOffset`) reported `125439`. The body — read by walking the segment file — contained events up to `185600`. `getTailOffset()` would then reject any ack at an offset between those two values, even though the events were durably present.

## Fix

Wrap `append()` in a per-stream lock (`acquireStreamAppendLock(streamPath)`, mirrors the existing `acquireProducerLock`). The whole read-currentOffset → write-frame → fsync → put-LMDB sequence now runs atomically per stream.

`appendWithProducer` (and other producer-lock holders) re-enter through `append()` and pick up the stream lock on top — same lock order across all callers, so no deadlock.

## Test plan

Added a regression test `currentOffset stays in sync with file under concurrent appends to the same stream` in `packages/server/test/file-backed.test.ts`:

- [x] Test fails on `origin/main` without the fix: 50 concurrent appends collapse to a single unique offset.
- [x] Test passes with the fix: all 50 offsets are unique, the file contains 50 messages, and `currentOffset` matches the last frame's offset.
- [x] Full server test suite passes (616/616).
- [x] Verified end-to-end against the original repro: orchestrator with 15 fanning-out workers ack'd cleanly with 0 `INVALID_OFFSET` errors after the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)