### PR TITLE
fix(y-durable-streams): retain awareness subscription lifecycle

### DIFF
--- a/.changeset/fix-awareness-subscription-lifecycle.md
+++ b/.changeset/fix-awareness-subscription-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/y-durable-streams": patch
+---
+
+Retain awareness subscription unsubscribe callback and clean it up on disconnect, matching the document updates subscription lifecycle

--- a/packages/y-durable-streams/src/yjs-provider.ts
+++ b/packages/y-durable-streams/src/yjs-provider.ts
@@ -156,6 +156,7 @@ export class YjsProvider extends ObservableV2<YjsProviderEvents> {
   private pendingAwareness: AwarenessUpdate | null = null
 
   private awarenessHeartbeat: ReturnType<typeof setInterval> | null = null
+  private awarenessSubscription: (() => void) | null = null
 
   constructor(options: YjsProviderOptions) {
     super()
@@ -309,6 +310,11 @@ export class YjsProvider extends ObservableV2<YjsProviderEvents> {
     if (this.updatesSubscription) {
       this.updatesSubscription()
       this.updatesSubscription = null
+    }
+
+    if (this.awarenessSubscription) {
+      this.awarenessSubscription()
+      this.awarenessSubscription = null
     }
 
     // Flush and close producer before aborting
@@ -863,8 +869,9 @@ export class YjsProvider extends ObservableV2<YjsProviderEvents> {
       // Ensure closed promise is handled to avoid unhandled rejections.
       void response.closed.catch(() => {})
 
+      this.awarenessSubscription?.()
       // eslint-disable-next-line @typescript-eslint/require-await
-      response.subscribeBytes(async (chunk) => {
+      this.awarenessSubscription = response.subscribeBytes(async (chunk) => {
         if (signal.aborted) return
 
         if (chunk.data.length > 0) {


### PR DESCRIPTION
## Summary

Retains the awareness subscription unsubscribe callback and cleans it up on disconnect, matching the document updates subscription lifecycle.

## Reviewer guidance

### Root cause

The awareness subscription in `subscribeAwareness()` discarded the return value from `response.subscribeBytes()`:

```typescript
// Document updates — retained ✓
this.updatesSubscription = response.subscribeBytes(async (chunk) => { ... })

// Awareness — dropped ✗
response.subscribeBytes(async (chunk) => { ... })
```

On disconnect, `this.updatesSubscription()` is called to explicitly unsubscribe the document updates callback. No equivalent cleanup existed for awareness. The subscription relied solely on `signal.aborted` checks inside the callback, which is a weaker guarantee than explicit unsubscription — especially across SSE reconnection cycles where `subscribeAwareness` calls itself recursively.

### Approach

Three changes to align awareness with the document updates pattern:

1. **Store the reference**: `this.awarenessSubscription = response.subscribeBytes(...)`
2. **Clean up on disconnect**: call `this.awarenessSubscription()` in `disconnect()`
3. **Clean up on resubscribe**: call `this.awarenessSubscription?.()` before creating a new subscription

### Key invariants

- Every `response.subscribeBytes()` return value must be stored and explicitly cleaned up
- `disconnect()` must tear down all active subscriptions before aborting the controller
- The awareness and document update subscription lifecycles follow the same pattern

### Non-goals

- Not changing awareness transport mode (still hardcodes `live: 'sse'`)
- Not changing the `offset: 'now'` start position for awareness subscriptions

## Files changed

- **`packages/y-durable-streams/src/yjs-provider.ts`** — Add `awarenessSubscription` field, store the unsubscribe callback, clean up in `disconnect()` and before resubscribing
- **`.changeset/fix-awareness-subscription-lifecycle.md`** — Patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)