### PR TITLE
fix(server): fork PUT inherits source content-type when header omitted

### DIFF
--- a/.changeset/fork-inherit-content-type.md
+++ b/.changeset/fork-inherit-content-type.md
@@ -1,0 +1,16 @@
+---
+"@durable-streams/server": patch
+"@durable-streams/server-conformance-tests": patch
+---
+
+fix(server): fork PUT inherits source content type when Content-Type header is omitted
+
+Per the protocol (Section 4.2), when forking a stream the `Content-Type` header is
+optional — an omitted header means "inherit from source." The TS dev server was
+defaulting empty Content-Type to `application/octet-stream` before the store could
+inherit, causing fork creation to fail with `409 Conflict` (content-type mismatch)
+whenever the source's content type differed from the default.
+
+Adds a server conformance test (`Fork - Creation > should fork inheriting
+content-type when header omitted`) that exercises this behavior end-to-end:
+fork response, HEAD, and a follow-up POST with the inherited content type.

--- a/packages/server-conformance-tests/src/index.ts
+++ b/packages/server-conformance-tests/src/index.ts
@@ -8015,6 +8015,43 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
       })
       expect(headRes.headers.get(`content-type`)).toBe(`application/json`)
     })
+
+    test(`should fork inheriting content-type when header omitted`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-ct-inherit-src-${id}`
+      const forkPath = `/v1/stream/fork-create-ct-inherit-fork-${id}`
+
+      // Create source with application/json
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"key":"value"}]`,
+      })
+
+      // Fork WITHOUT Content-Type header → fork must inherit source's
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+      expect(forkRes.headers.get(`content-type`)).toBe(`application/json`)
+
+      // HEAD on fork should also show the inherited content type
+      const headRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `HEAD`,
+      })
+      expect(headRes.headers.get(`content-type`)).toBe(`application/json`)
+
+      // Appending with the inherited content-type must succeed (no 409)
+      const appendRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `POST`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"key":"appended"}]`,
+      })
+      expect(appendRes.status).toBe(204)
+    })
   })
 
   // ============================================================================

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -562,13 +562,24 @@ export class DurableStreamTestServer {
   ): Promise<void> {
     let contentType = req.headers[`content-type`]
 
-    // Sanitize content-type: if empty or invalid, use default
+    // Parse fork headers (must come before content-type sanitization so
+    // forks can fall through to the store's content-type inheritance)
+    const forkedFromHeader = req.headers[
+      STREAM_FORKED_FROM_HEADER.toLowerCase()
+    ] as string | undefined
+    const forkOffsetHeader = req.headers[
+      STREAM_FORK_OFFSET_HEADER.toLowerCase()
+    ] as string | undefined
+
+    // Sanitize content-type: if empty or invalid, use default — but only
+    // for non-fork creates. For forks, an omitted Content-Type means "inherit
+    // from source", which is resolved by the store.
     if (
       !contentType ||
       contentType.trim() === `` ||
       !/^[\w-]+\/[\w-]+/.test(contentType)
     ) {
-      contentType = `application/octet-stream`
+      contentType = forkedFromHeader ? undefined : `application/octet-stream`
     }
 
     const ttlHeader = req.headers[STREAM_TTL_HEADER.toLowerCase()] as
@@ -581,14 +592,6 @@ export class DurableStreamTestServer {
     // Parse Stream-Closed header
     const closedHeader = req.headers[STREAM_CLOSED_HEADER.toLowerCase()]
     const createClosed = closedHeader === `true`
-
-    // Parse fork headers
-    const forkedFromHeader = req.headers[
-      STREAM_FORKED_FROM_HEADER.toLowerCase()
-    ] as string | undefined
-    const forkOffsetHeader = req.headers[
-      STREAM_FORK_OFFSET_HEADER.toLowerCase()
-    ] as string | undefined
 
     // Validate TTL and Expires-At headers
     if (ttlHeader && expiresAtHeader) {
@@ -681,6 +684,8 @@ export class DurableStreamTestServer {
     }
 
     const stream = this.store.get(path)!
+    const resolvedContentType =
+      stream.contentType ?? contentType ?? `application/octet-stream`
 
     // Call lifecycle hook for new streams
     if (isNew && this.options.onStreamCreated) {
@@ -688,7 +693,7 @@ export class DurableStreamTestServer {
         this.options.onStreamCreated({
           type: `created`,
           path,
-          contentType: stream.contentType ?? contentType,
+          contentType: resolvedContentType,
           timestamp: Date.now(),
         })
       )
@@ -696,7 +701,7 @@ export class DurableStreamTestServer {
 
     // Return 201 for new streams, 200 for idempotent creates
     const headers: Record<string, string> = {
-      "content-type": stream.contentType ?? contentType,
+      "content-type": resolvedContentType,
       [STREAM_OFFSET_HEADER]: stream.currentOffset,
     }
 


### PR DESCRIPTION
## Summary

- Per protocol §4.2, an omitted `Content-Type` on fork creation means "inherit from source." The TS dev server was defaulting empty `Content-Type` to `application/octet-stream` before the store could inherit, so any fork of a non-default-CT stream returned `409 Conflict` (content-type mismatch).
- Fix in `packages/server/src/server.ts`: skip the empty-CT default when `Stream-Forked-From` is present, so the store's existing inherit logic runs.
- Adds a server conformance test (`Fork - Creation > should fork inheriting content-type when header omitted`) that PUTs a fork without `Content-Type`, asserts response/HEAD report the inherited type, and verifies a follow-up POST with the inherited type is accepted.
- Caddy plugin already implements this correctly (verified end-to-end against the new test); only the TS server handler needed the fix.

## Test plan

- [x] New test fails on TS server before the fix (`409 Conflict` in store, content-type mismatch)
- [x] New test passes on TS server (in-memory + file-backed) after the fix
- [x] New test passes on Caddy plugin (memory + file store)
- [x] Full server suite green (617 tests)
- [x] All 114 fork conformance tests still pass
- [x] Top-level `tsc --build` clean
- [x] No new lint findings on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)