### PR TITLE
fix(release): wire up Python publish to PyPI

### DIFF
--- a/.changeset/fix-python-publish-pipeline.md
+++ b/.changeset/fix-python-publish-pipeline.md
@@ -1,0 +1,31 @@
+---
+"@durable-streams/client-py": patch
+---
+
+fix(release): wire up Python package publishing to PyPI
+
+The repo had `scripts/sync-python-versions.mjs` and
+`scripts/publish-python.mjs` checked in but neither was invoked by the
+`changeset:version` / `changeset:publish` npm scripts, so PyPI never
+received any release after `0.1.0` despite Changesets bumping the bridge
+`package.json` and writing CHANGELOG entries up to `0.1.3` (which
+includes the Kafka-style idempotent producer from #140).
+
+This wires both helpers into the release flow:
+
+- `changeset:version` now runs `sync-python-versions.mjs` so a Changesets
+  Version Packages PR also bumps `pyproject.toml`.
+- `changeset:publish` now runs `publish-python.mjs` after `changeset
+  publish`, so `uv build && uv publish` runs whenever the npm publish
+  step does.
+- `publish-python.mjs` now passes `--check-url https://pypi.org/simple/`
+  so the script is idempotent — TS-only changesets that don't bump the
+  Python version will simply skip the upload instead of erroring.
+- `sync-python-versions.mjs` now edits `pyproject.toml` directly instead
+  of shelling out to `uv version <X>` (the setter form requires uv
+  ≥ 0.7), making it work across uv releases.
+- `release.yml` now installs `uv` + Python and passes
+  `UV_PUBLISH_TOKEN` from the `PYPI_TOKEN` secret.
+- `pyproject.toml` is bumped from `0.1.0` to `0.1.3` to catch up with
+  the bridge `package.json`, so the next release publishes the
+  already-changelogged versions to PyPI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,16 @@ jobs:
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       # Workaround for npm/cli#9151: Node 22.22.2 ships npm 10.9.7 which
       # crashes during self-upgrade to 11.x (lazy require of promise-retry).
       # npm 10.9.8 fixes this with an eager require (npm/cli#9152).
@@ -62,6 +72,7 @@ jobs:
           title: "ci: Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       - name: Comment on PRs about release
         if: steps.changesets.outputs.published == 'true'

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "typecheck": "tsc --build && pnpm -r --filter '@durable-streams/example-*' typecheck",
     "prepare": "husky",
     "changeset": "changeset",
-    "changeset:version": "changeset version && pnpm install --no-frozen-lockfile",
-    "changeset:publish": "pnpm build && changeset publish",
+    "changeset:version": "changeset version && node scripts/sync-python-versions.mjs && pnpm install --no-frozen-lockfile",
+    "changeset:publish": "pnpm build && changeset publish && node scripts/publish-python.mjs",
     "docs:dev": "pnpm --filter @durable-streams/docs dev",
     "docs:build": "pnpm --filter @durable-streams/docs build",
     "docs:preview": "pnpm --filter @durable-streams/docs preview"

--- a/packages/client-py/pyproject.toml
+++ b/packages/client-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "durable-streams"
-version = "0.1.0"
+version = "0.1.3"
 description = "Python client for the Durable Streams protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/client-py/uv.lock
+++ b/packages/client-py/uv.lock
@@ -182,7 +182,7 @@ toml = [
 
 [[package]]
 name = "durable-streams"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/scripts/publish-python.mjs
+++ b/scripts/publish-python.mjs
@@ -30,11 +30,22 @@ for (const pkg of PY_PKGS) {
 
   console.log(`Publishing ${pkg.dir}...`)
 
-  // Publish to PyPI
-  // Uses UV_PUBLISH_TOKEN env var for authentication
-  execFileSync(`uv`, [`publish`, `--directory`, pkg.dir], {
-    stdio: `inherit`,
-  })
+  // Publish to PyPI.
+  // Uses UV_PUBLISH_TOKEN env var for authentication.
+  // --check-url makes this idempotent: uv skips files already on the index,
+  // so the script is safe to run on every release (e.g. TS-only changesets
+  // where pyproject.toml's version was not bumped).
+  execFileSync(
+    `uv`,
+    [
+      `publish`,
+      `--directory`,
+      pkg.dir,
+      `--check-url`,
+      `https://pypi.org/simple/`,
+    ],
+    { stdio: `inherit` }
+  )
 
   console.log(`Successfully published ${pkg.dir}`)
 }

--- a/scripts/sync-python-versions.mjs
+++ b/scripts/sync-python-versions.mjs
@@ -1,15 +1,22 @@
 /**
- * Sync Python package versions from bridge package.json files to pyproject.toml
+ * Sync Python package versions from bridge package.json files to pyproject.toml.
  * This script is called by Changesets during the version command.
+ *
+ * Edits pyproject.toml directly rather than calling `uv version <X>` so it
+ * works regardless of which uv release is installed (the setter form was
+ * added in uv 0.7).
  */
 
-import { readFile } from "node:fs/promises"
-import { execFileSync } from "node:child_process"
+import { readFile, writeFile } from "node:fs/promises"
 
 const PY_PKGS = [
   {
     dir: `packages/client-py`,
     bridge: `packages/client-py/package.json`,
+    pyproject: `packages/client-py/pyproject.toml`,
+    lockfile: `packages/client-py/uv.lock`,
+    // PEP 503 normalized name as recorded in uv.lock
+    distName: `durable-streams`,
   },
 ]
 
@@ -29,13 +36,37 @@ for (const pkg of PY_PKGS) {
   const { version } = JSON.parse(await readFile(pkg.bridge, `utf8`))
   const pep440Version = toPep440(version)
 
-  console.log(`Syncing ${pkg.dir} to version ${pep440Version}`)
-
-  execFileSync(
-    `uv`,
-    [`--directory`, pkg.dir, `version`, pep440Version, `--frozen`],
-    { stdio: `inherit` }
+  // Match the first top-level `version = "..."` line in pyproject.toml.
+  const pyprojectRe = /^version\s*=\s*"[^"]*"\s*$/m
+  const pyproject = await readFile(pkg.pyproject, `utf8`)
+  if (!pyprojectRe.test(pyproject)) {
+    throw new Error(
+      `Failed to find version field in ${pkg.pyproject} — sync aborted`
+    )
+  }
+  await writeFile(
+    pkg.pyproject,
+    pyproject.replace(pyprojectRe, `version = "${pep440Version}"`)
   )
+  console.log(`Synced ${pkg.pyproject} to version ${pep440Version}`)
+
+  // Keep uv.lock in sync so `uv sync --frozen` keeps working without
+  // requiring a separate `uv lock` step in CI.
+  const lockEntryRe = new RegExp(
+    String.raw`(\[\[package\]\]\s*\nname\s*=\s*"${pkg.distName}"\s*\nversion\s*=\s*")[^"]*(")`,
+    `m`
+  )
+  const lockfile = await readFile(pkg.lockfile, `utf8`)
+  if (!lockEntryRe.test(lockfile)) {
+    throw new Error(
+      `Failed to find ${pkg.distName} entry in ${pkg.lockfile} — sync aborted`
+    )
+  }
+  await writeFile(
+    pkg.lockfile,
+    lockfile.replace(lockEntryRe, `$1${pep440Version}$2`)
+  )
+  console.log(`Synced ${pkg.lockfile} to version ${pep440Version}`)
 }
 
 console.log(`Python versions synced successfully`)


### PR DESCRIPTION
## Summary

PyPI never received any client-py release after `0.1.0`, even though Changesets has been bumping the bridge `package.json` and writing CHANGELOG entries up to `0.1.3` — which means the Kafka-style idempotent producer (#140), the auto-live-mode removal (#177), and the SSE fixes (#209, #223) shipped to npm but **not** to PyPI users.

Root cause: `scripts/sync-python-versions.mjs` and `scripts/publish-python.mjs` were already in the repo but **never invoked** from `changeset:version` / `changeset:publish`. There was no PyPI auth configured in `release.yml` either.

## Changes

- `package.json`: `changeset:version` now also runs `sync-python-versions.mjs`; `changeset:publish` now also runs `publish-python.mjs`.
- `scripts/publish-python.mjs`: pass `--check-url https://pypi.org/simple/` so the script is idempotent — TS-only changesets that don't bump the Python version simply skip the upload instead of erroring on duplicate file rejection.
- `scripts/sync-python-versions.mjs`: edit `pyproject.toml` directly instead of shelling out to `uv version <X>` (the setter form requires uv ≥ 0.7); also keep the local-package entry in `uv.lock` in sync so `uv sync --frozen` keeps working.
- `.github/workflows/release.yml`: install `uv` + Python and pass `UV_PUBLISH_TOKEN` from the `PYPI_TOKEN` secret.
- `packages/client-py/pyproject.toml` + `uv.lock`: bumped from `0.1.0` to `0.1.3` to match the bridge `package.json`. The next release will land `0.1.4` (this PR's changeset) on PyPI, which subsumes everything queued in the CHANGELOG.

## Required before merging

A `PYPI_TOKEN` secret needs to be configured on the repo (https://github.com/durable-streams/durable-streams/settings/secrets/actions). It should be a PyPI API token scoped to the `durable-streams` project. Without it, `uv publish` will fail with an auth error.

Alternatively, configure PyPI Trusted Publishers for this repo + workflow and drop the secret — `uv publish` auto-detects OIDC when no token is set. The workflow already has `id-token: write`.

## Test plan

- [x] `node scripts/sync-python-versions.mjs` runs successfully and is idempotent across repeated invocations.
- [x] `uv build --directory packages/client-py --no-sources` produces `durable_streams-0.1.3.tar.gz` and `durable_streams-0.1.3-py3-none-any.whl`.
- [ ] After merge: confirm Changesets opens a Version Packages PR that bumps `pyproject.toml` 0.1.3 → 0.1.4 alongside the bridge `package.json`.
- [ ] After Version Packages PR is merged: confirm `release.yml` runs `publish-python.mjs` and the new version appears on https://pypi.org/project/durable-streams/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)