### PR TITLE
docs: introduce layered consumer spec into the protocol

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -839,19 +839,17 @@ Content-Type: application/json
 {
   "consumer_id": "my-agent:task-123",
   "streams": ["/agents/task-123"],
-  "namespace": "/agents/*",
   "lease_ttl_ms": 45000
 }
 ```
 
 **Fields:**
 
-| Field          | Required | Description                                                 |
-| -------------- | -------- | ----------------------------------------------------------- |
-| `consumer_id`  | Yes      | Stable, client-provided identifier; must be unique          |
-| `streams`      | Yes      | One or more stream paths to track                           |
-| `namespace`    | No       | Glob pattern for informational grouping (e.g., `/agents/*`) |
-| `lease_ttl_ms` | No       | Lease duration in milliseconds; server default if omitted   |
+| Field          | Required | Description                                               |
+| -------------- | -------- | --------------------------------------------------------- |
+| `consumer_id`  | Yes      | Stable, client-provided identifier; must be unique        |
+| `streams`      | Yes      | One or more stream paths to track                         |
+| `lease_ttl_ms` | No       | Lease duration in milliseconds; server default if omitted |
 
 **Response:**
 
@@ -867,7 +865,6 @@ Content-Type: application/json
   "state": "REGISTERED",
   "epoch": 0,
   "streams": [{ "path": "/agents/task-123", "offset": "-1" }],
-  "namespace": "/agents/*",
   "lease_ttl_ms": 45000
 }
 ```
@@ -931,6 +928,8 @@ POST /consumers/{id}/acquire
 }
 ```
 
+The `offset` in each stream entry is the last-acknowledged offset (i.e., the consumer's current cursor position). The consumer should resume reading from the next offset after this position.
+
 Acquiring the epoch:
 
 - Increments the epoch counter
@@ -981,7 +980,7 @@ Content-Type: application/json
 
 Both cursor-advancing acks and empty acks reset the lease timer.
 
-**Offset semantics:** Offsets are "last processed inclusive." Offset `"1005"` means events through 1005 have been processed; the next read starts from `"1006"`. Offset `"-1"` means nothing has been processed (start from beginning).
+**Offset semantics:** Offsets are "last processed inclusive." Acking offset `"1005"` means events through that offset have been processed; the consumer resumes reading from the offset returned in `Stream-Next-Offset` of the response that delivered offset `"1005"`. Offset `"-1"` means nothing has been processed (start from beginning).
 
 **Error responses:**
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -33,13 +33,43 @@ Copyright (c) 2025 ElectricSQL
    - 5.6. [Read Stream - Catch-up](#56-read-stream---catch-up)
    - 5.7. [Read Stream - Live (Long-poll)](#57-read-stream---live-long-poll)
    - 5.8. [Read Stream - Live (SSE)](#58-read-stream---live-sse)
-6. [Offsets](#6-offsets)
-7. [Content Types](#7-content-types)
-8. [Caching and Collapsing](#8-caching-and-collapsing)
-9. [Extensibility](#9-extensibility)
-10. [Security Considerations](#10-security-considerations)
-11. [IANA Considerations](#11-iana-considerations)
-12. [References](#12-references)
+6. [Named Consumers](#6-named-consumers)
+   - 6.1. [Consumer Registration](#61-consumer-registration)
+   - 6.2. [Consumer State Machine](#62-consumer-state-machine)
+   - 6.3. [Epoch Acquisition](#63-epoch-acquisition)
+   - 6.4. [Acknowledgment](#64-acknowledgment)
+   - 6.5. [Release](#65-release)
+   - 6.6. [Liveness Policy](#66-liveness-policy)
+   - 6.7. [Token Scope](#67-token-scope)
+   - 6.8. [Named Reads](#68-named-reads)
+   - 6.9. [Registration vs. Notification Preferences](#69-registration-vs-notification-preferences)
+7. [Wake-Up Notifications](#7-wake-up-notifications)
+   - 7.1. [Webhook (Unicast Wake)](#71-webhook-unicast-wake)
+     - 7.1.1. [Subscription Model](#711-subscription-model)
+     - 7.1.2. [Consumer Instance Lifecycle](#712-consumer-instance-lifecycle)
+     - 7.1.3. [Wake-up Notification](#713-wake-up-notification)
+     - 7.1.4. [Webhook Signature Verification](#714-webhook-signature-verification)
+     - 7.1.5. [Callback API](#715-callback-api)
+     - 7.1.6. [Dynamic Subscribe/Unsubscribe](#716-dynamic-subscribeunsubscribe)
+     - 7.1.7. [Secondary Subscriptions](#717-secondary-subscriptions)
+     - 7.1.8. [Failure Handling](#718-failure-handling)
+     - 7.1.9. [Subscription HTTP API](#719-subscription-http-api)
+     - 7.1.10. [Garbage Collection](#7110-garbage-collection)
+   - 7.2. [Pull-Wake (Competitive Wake)](#72-pull-wake-competitive-wake)
+     - 7.2.1. [Wake Stream](#721-wake-stream)
+     - 7.2.2. [Claim Protocol](#722-claim-protocol)
+     - 7.2.3. [Bootstrapping](#723-bootstrapping)
+     - 7.2.4. [Liveness Detection](#724-liveness-detection)
+     - 7.2.5. [Contention Handling](#725-contention-handling)
+     - 7.2.6. [Failure Handling](#726-failure-handling)
+   - 7.3. [Mobile Push (Unicast Wake)](#73-mobile-push-unicast-wake)
+8. [Offsets](#8-offsets)
+9. [Content Types](#9-content-types)
+10. [Caching and Collapsing](#10-caching-and-collapsing)
+11. [Extensibility](#11-extensibility)
+12. [Security Considerations](#12-security-considerations)
+13. [IANA Considerations](#13-iana-considerations)
+14. [References](#14-references)
 
 ---
 
@@ -544,7 +574,7 @@ Where `{stream-url}` is the URL of the stream. Checks stream existence and retur
 - `Stream-TTL: <seconds>` (optional): The stream's time-to-live window. Each read or write resets the expiry countdown to this value.
 - `Stream-Expires-At: <rfc3339>` (optional): Absolute expiry time, if applicable
 - `Stream-Closed: true` (optional): Present when the stream has been closed. Absence indicates the stream is still open.
-- `Cache-Control`: See Section 8
+- `Cache-Control`: See Section 10
 
 #### Caching Guidance
 
@@ -577,7 +607,7 @@ For non-live reads without data beyond the requested offset, servers **SHOULD** 
 
 #### Response Headers (on 200)
 
-- `Cache-Control`: Derived from TTL/expiry (see Section 8)
+- `Cache-Control`: Derived from TTL/expiry (see Section 9)
 - `ETag: {internal_stream_id}:{start_offset}:{end_offset}`
   - Entity tag for cache validation
 - `Stream-Cursor: <cursor>` (optional for catch-up, required for live modes)
@@ -635,13 +665,13 @@ Where `{stream-url}` is the URL of the stream. If no data is available at the sp
 #### Response Headers (on 200)
 
 - Same as catch-up reads (Section 5.6), plus:
-- `Stream-Cursor: <cursor>`: Servers **MUST** include this header. See Section 8.1.
+- `Stream-Cursor: <cursor>`: Servers **MUST** include this header. See Section 10.1.
 
 #### Response Headers (on 204)
 
 - `Stream-Next-Offset: <offset>`: Servers **MUST** include a `Stream-Next-Offset` header indicating the current tail offset.
 - `Stream-Up-To-Date: true`: Servers **MUST** include this header to indicate the client is caught up with all available data.
-- `Stream-Cursor: <cursor>`: Servers **MUST** include this header when the stream is open. Servers **MAY** omit this header when `Stream-Closed` is true (cursor is unnecessary when no further polling is expected). Clients **MUST** tolerate its absence when `Stream-Closed` is present. See Section 8.1.
+- `Stream-Cursor: <cursor>`: Servers **MUST** include this header when the stream is open. Servers **MAY** omit this header when `Stream-Closed` is true (cursor is unnecessary when no further polling is expected). Clients **MUST** tolerate its absence when `Stream-Closed` is present. See Section 10.1.
 - `Stream-Closed: true`: **MUST** be present when the stream is closed (see Section 5.6 for semantics). A `204 No Content` with `Stream-Closed: true` indicates EOF.
 
 **EOF Signaling Across Modes:**
@@ -725,7 +755,7 @@ Data is emitted in [Server-Sent Events format](https://developer.mozilla.org/en-
   - Base64 encoding affects only `event: data` payloads. `event: control` events remain JSON as specified and are not encoded.
   - When the stream content type is `application/json`, implementations **MAY** batch multiple logical messages into a single SSE `data` event by streaming a JSON array across multiple `data:` lines, as in the example below.
 - `control`: Emitted after every data event
-  - **MUST** include `streamNextOffset`. See Section 8.1.
+  - **MUST** include `streamNextOffset`. See Section 10.1.
   - **MUST** include `streamCursor` when the stream is open. Servers **MAY** omit `streamCursor` when `streamClosed` is true (cursor is unnecessary when no reconnection is expected).
   - **MUST** include `upToDate: true` when the client is caught up with all available data. Note: `streamClosed: true` implies `upToDate: true` (a closed stream at the final offset is by definition up-to-date), so `upToDate` **MAY** be omitted when `streamClosed` is true.
   - **MUST** include `streamClosed: true` when the stream is closed and all data up to the final offset has been sent.
@@ -794,9 +824,710 @@ data: {"streamNextOffset":"123456_789","streamCursor":"abc"}
 
 SSE on a forked stream delivers inherited data from the source stream followed by the fork's own data, then waits for new fork appends. Source appends after the fork point are never delivered.
 
-## 6. Offsets
+## 6. Named Consumers
 
-Offsets are opaque tokens that identify positions within a stream. They have the following properties:
+Named Consumers (Layer 1) provide mechanism-independent consumer identity, epoch fencing, offset tracking, and lease-based liveness. They are the foundation on which wake-up notification mechanisms (Section 7) are built.
+
+A consumer is a named cursor group: it holds a set of stream paths with their last-acknowledged offsets, an epoch for fencing concurrent readers, and a lease timer for liveness. The consumer lifecycle has two states — REGISTERED (waiting, no active reader) and READING (epoch held, actively consuming). Any mechanism — webhook HTTP callbacks, long-poll, mobile push — can sit on top of this layer by acquiring an epoch and acking offsets.
+
+### 6.1. Consumer Registration
+
+```http
+POST /consumers
+Content-Type: application/json
+
+{
+  "consumer_id": "my-agent:task-123",
+  "streams": ["/agents/task-123"],
+  "namespace": "/agents/*",
+  "lease_ttl_ms": 45000
+}
+```
+
+**Fields:**
+
+| Field          | Required | Description                                                 |
+| -------------- | -------- | ----------------------------------------------------------- |
+| `consumer_id`  | Yes      | Stable, client-provided identifier; must be unique          |
+| `streams`      | Yes      | One or more stream paths to track                           |
+| `namespace`    | No       | Glob pattern for informational grouping (e.g., `/agents/*`) |
+| `lease_ttl_ms` | No       | Lease duration in milliseconds; server default if omitted   |
+
+**Response:**
+
+- `201 Created`: Consumer registered
+- `200 OK`: Consumer already exists with identical configuration (idempotent)
+- `409 Conflict` (`CONSUMER_ALREADY_EXISTS`): Consumer exists with different configuration
+
+**Response body (201/200):**
+
+```json
+{
+  "consumer_id": "my-agent:task-123",
+  "state": "REGISTERED",
+  "epoch": 0,
+  "streams": [{ "path": "/agents/task-123", "offset": "-1" }],
+  "namespace": "/agents/*",
+  "lease_ttl_ms": 45000
+}
+```
+
+Offsets are initialized to `"-1"` (nothing acknowledged) for new streams.
+
+**Get consumer:**
+
+```http
+GET /consumers/{id}
+→ 200 OK  (ConsumerInfo)
+→ 404  (CONSUMER_NOT_FOUND)
+```
+
+**Delete consumer:**
+
+```http
+DELETE /consumers/{id}
+→ 204 No Content
+→ 404  (CONSUMER_NOT_FOUND)
+```
+
+### 6.2. Consumer State Machine
+
+```
+  ┌────────────────────────────────────────────────┐
+  │                                                │
+  │   POST /consumers/{id}/acquire                 │
+  │   (epoch++, token issued, lease timer starts)  │
+  │                                                │
+  ▼                                                │
+REGISTERED ──────────────────────────────► READING
+  ▲                                                │
+  │                                                │
+  │   POST /consumers/{id}/release                 │
+  │   OR lease TTL expires                         │
+  │                                                │
+  └────────────────────────────────────────────────┘
+```
+
+| State        | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `REGISTERED` | Consumer exists; no active reader holds the epoch |
+| `READING`    | Epoch acquired; consumer is actively reading      |
+
+L2 mechanisms map their own richer states on top:
+
+- Webhook Layer 2: IDLE maps to REGISTERED; WAKING + LIVE map to READING
+
+### 6.3. Epoch Acquisition
+
+```http
+POST /consumers/{id}/acquire
+→ 200 OK
+
+{
+  "consumer_id": "my-agent:task-123",
+  "epoch": 3,
+  "token": "eyJ...",
+  "streams": [{ "path": "/agents/task-123", "offset": "1002" }]
+}
+```
+
+Acquiring the epoch:
+
+- Increments the epoch counter
+- Transitions the consumer to READING
+- Issues a bearer token scoped to this consumer and epoch
+- Starts the lease timer
+
+If the consumer is already READING (a previous reader crashed without releasing), this is a **self-supersede**: the epoch is incremented, the previous token is invalidated, and a new token is returned. Any subsequent ack from the old reader will receive `409 STALE_EPOCH`. Self-supersede always succeeds in the single-process reference server — the `EPOCH_HELD` error code is reserved for future multi-server deployments.
+
+**Error responses:**
+
+| Status | Code                 | Description                                |
+| ------ | -------------------- | ------------------------------------------ |
+| 404    | `CONSUMER_NOT_FOUND` | Consumer does not exist                    |
+| 409    | `EPOCH_HELD`         | Reserved; not produced by reference server |
+
+### 6.4. Acknowledgment
+
+Acks advance the consumer's durable cursor for one or more streams. An empty ack (zero offsets) is a heartbeat: it extends the lease without writing a durable cursor update.
+
+```http
+POST /consumers/{id}/ack
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "offsets": [
+    { "path": "/agents/task-123", "offset": "1005" }
+  ]
+}
+
+→ 200 OK
+{ "ok": true, "token": "eyJ..." }
+```
+
+**Heartbeat (empty ack):**
+
+```http
+POST /consumers/{id}/ack
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{ "offsets": [] }
+
+→ 200 OK
+{ "ok": true, "token": "eyJ..." }
+```
+
+Both cursor-advancing acks and empty acks reset the lease timer.
+
+**Offset semantics:** Offsets are "last processed inclusive." Offset `"1005"` means events through 1005 have been processed; the next read starts from `"1006"`. Offset `"-1"` means nothing has been processed (start from beginning).
+
+**Error responses:**
+
+| Status | Code                 | Description                                     |
+| ------ | -------------------- | ----------------------------------------------- |
+| 400    | `INVALID_REQUEST`    | Malformed JSON or missing `offsets` field       |
+| 401    | `TOKEN_EXPIRED`      | Bearer token TTL exceeded                       |
+| 401    | `TOKEN_INVALID`      | Token is malformed or signature invalid         |
+| 409    | `STALE_EPOCH`        | Token epoch does not match current epoch        |
+| 409    | `OFFSET_REGRESSION`  | Ack offset is less than current cursor          |
+| 409    | `INVALID_OFFSET`     | Ack offset is beyond stream tail                |
+| 400    | `UNKNOWN_STREAM`     | Stream path is not registered for this consumer |
+| 404    | `CONSUMER_NOT_FOUND` | Consumer does not exist                         |
+
+### 6.5. Release
+
+```http
+POST /consumers/{id}/release
+Authorization: Bearer {token}
+
+→ 200 OK
+{ "ok": true, "state": "REGISTERED" }
+```
+
+Releasing the epoch:
+
+- Validates the bearer token and epoch
+- Transitions the consumer from READING to REGISTERED
+- Cancels the lease timer
+
+The consumer's offsets are preserved. A subsequent acquire starts from the last acknowledged position.
+
+**Error responses:** Same token/epoch errors as acknowledgment.
+
+### 6.6. Liveness Policy
+
+When a consumer is in READING state, a lease timer runs for `lease_ttl_ms` milliseconds from the last ack. If the timer fires:
+
+- The epoch is released (READING → REGISTERED)
+- Any registered L2 callbacks (`onLeaseExpired`) are invoked, allowing the L2 layer to re-wake the consumer
+
+Both cursor-advancing acks and empty acks (heartbeat shape) reset the timer. The heartbeat pattern lets a slow reader extend its lease without advancing its cursor:
+
+```http
+POST /consumers/{id}/ack
+Authorization: Bearer {token}
+
+{ "offsets": [] }
+```
+
+The token is refreshed in the response when it is nearing expiry (within 5 minutes of its 1-hour TTL).
+
+### 6.7. Token Scope
+
+Bearer token is per-consumer, not per-stream. One consumer may ack across
+multiple streams in one request. Token authorizes the consumer identity;
+epoch validated server-side during ack processing.
+
+Token TTL SHOULD be significantly longer than lease TTL so tokens do not
+expire during normal operation.
+
+### 6.8. Named Reads
+
+- Anonymous L0 reads: client-supplied offset is authoritative
+- Named L1 reads: server-committed cursor is authoritative
+- Acquire returns committed cursor position for each subscribed stream
+- Consumer reads from where server says it left off
+- Named read with explicit offset MAY be used for debugging
+  but MUST NOT advance committed cursor
+
+### 6.9. Registration vs. Notification Preferences
+
+```http
+PUT /consumers/{id}/wake
+Content-Type: application/json
+
+{ "type": "webhook", "url": "https://my-handler.dev/hook" }
+```
+
+or
+
+```json
+{ "type": "pull-wake", "wake_stream": "/wake/my-workers" }
+```
+
+or
+
+```json
+{ "type": "none" }
+```
+
+Registration (Layer 1) and notification preferences (Layer 2) are separate.
+A consumer can be registered without any wake preference (pure pull).
+A consumer can change wake mechanisms without re-registering.
+
+> Phase 2 scope: A consumer has exactly one active wake preference at a time.
+> The RFC's broader "zero-or-more" model (e.g., webhook AND push simultaneously)
+> is deferred to a future phase.
+
+## 7. Wake-Up Notifications
+
+Wake-Up Notifications (Layer 2) sit on top of Named Consumers (Section 6) and deliver a signal to the consumer process when work is available. The consumer uses its existing L1 epoch, ack, and release operations to do the actual reading; the L2 layer only orchestrates who gets notified and when.
+
+Layer 2 is opt-in and requires Layer 1. Each wake mechanism is fully, concretely specified. No abstract interface.
+
+Two structural categories:
+
+- **Unicast wake** (webhook, mobile push): server targets specific consumer
+- **Competitive wake** (pull-wake): workers compete to claim from shared stream
+
+This section defines three sub-mechanisms. The Webhook mechanism (Section 7.1) and Pull-Wake mechanism (Section 7.2) are specified for v1; Mobile Push is a placeholder for future extension.
+
+### 7.1. Webhook (Unicast Wake)
+
+Webhook is a unicast wake mechanism: the server targets a specific consumer directly, so there is no competitive contention (unlike pull-wake).
+
+Webhook subscriptions enable serverless functions and AI agents to react to stream events without maintaining persistent connections. Unlike traditional webhooks that deliver data inline, Durable Streams webhooks are **wake-up signals** — the notification tells the consumer which streams have new events, and the consumer reads the actual data using the standard HTTP protocol (Sections 3–5).
+
+The L2 webhook mechanism layered on top of L1:
+
+- **Subscription** (L2): maps a glob pattern to a webhook URL and secret
+- **Consumer instance lifecycle** (L2): IDLE/WAKING/LIVE states built on L1 REGISTERED/READING
+- **Wake delivery** (L2): HMAC-signed POST notifying the consumer of pending work
+- **Callback API** (L2): bundles wake claim + ack into a single request, delegating to L1 ack internally
+- **Failure handling** (L2): retry, backoff, garbage collection
+
+The L1 Named Consumer (Section 6) provides the actual epoch, offset tracking, and lease.
+
+**Implementation note on L1/L2 coupling:** In the current reference implementation, the webhook subscription creation also creates (or idempotently registers) the underlying L1 consumer. The full dialectic ideal — where L2 only attaches to an independently-registered L1 consumer — is not yet achieved. Similarly, `wake_id_claimed` state is retained on the L2 `WebhookConsumer` record for retry idempotency, even though epoch fencing (L1) subsumes most of its function. These are known compromises; the specs document the actual achieved separation.
+
+#### 7.1.1. Subscription Model
+
+A subscription consists of:
+
+- **`subscription_id`**: Client-provided identifier for this subscription
+- **`pattern`**: Glob pattern matching stream paths (e.g., `/agents/*`)
+- **`webhook`**: URL to POST notifications to
+- **`webhook_secret`**: Server-generated secret for signature verification (returned on creation only, not stored retrievably)
+- **`description`**: Optional human-readable description
+
+Subscriptions are **immutable** — to change the webhook URL or pattern, delete and recreate the subscription.
+
+When a stream is created or receives events that match the pattern, the server spawns a consumer instance (if one doesn't exist) and wakes it.
+
+**Glob patterns** support wildcards:
+
+- `*` matches exactly one path segment
+- `**` matches zero or more path segments (recursive)
+- `/agents/*` matches `/agents/task-123` but not `/agents/foo/bar`
+- `/agents/**` matches `/agents/task-123` and `/agents/foo/bar/baz`
+- `/agents/*/inbox` matches `/agents/worker-1/inbox`
+
+**Existing streams:** When a subscription is created and matching streams already exist, consumer instances are created in IDLE state. They wake only when new events arrive, not immediately.
+
+#### 7.1.2. Consumer Instance Lifecycle
+
+A consumer instance is spawned when a stream matches a subscription's pattern. Each instance has its own identity, epoch, offset tracking, and can dynamically subscribe to additional streams.
+
+**Consumer instance identity** is `{subscription_id}:{url_encoded_stream_path}`. Because a subscription uses a glob pattern (e.g., `/agents/*`), a single subscription can match many streams — each matched stream gets its own consumer instance with independent state, offsets, and lifecycle. The consumer ID encodes both the subscription and the specific stream it tracks. The stream path is URL-encoded to avoid parsing ambiguity. Multiple subscriptions matching the same stream create independent consumer instances.
+
+**L2 states (built on top of L1 REGISTERED/READING):**
+
+- **IDLE** (→ L1 REGISTERED): No pending work; waiting for events
+- **WAKING** (→ L1 READING): Webhook notification sent; waiting for callback claim
+- **LIVE** (→ L1 READING): Actively processing; callback claimed
+
+**Pending work** exists when any subscribed stream has unprocessed events:
+
+```
+pending_work = any(tail[path] > acked[path] for path in subscribed_streams)
+```
+
+Where `acked[path]` is the last acknowledged offset (inclusive — this event was processed), `tail[path]` is the current tail offset of the stream, and offset `-1` means "before any events" (nothing acked yet).
+
+**State transitions:**
+
+1. **IDLE → WAKING**: `pending_work` becomes true; L1 epoch is acquired (incrementing epoch), new `wake_id` generated
+2. **WAKING → LIVE**: Consumer responds to webhook with 2xx, OR a callback claims the `wake_id` (whichever happens first)
+3. **WAKING → IDLE**: Consumer responds to webhook with `{ "done": true }` AND `pending_work` is false; L1 epoch released
+4. **LIVE → IDLE**: Consumer sends `{ "done": true }` in callback AND `pending_work` is false, OR L1 lease TTL expires with no callback activity; L1 epoch released
+5. **Re-wake**: If `{ "done": true }` is received but `pending_work` is still true, immediately trigger a new wake (L1 acquire again, new `wake_id`)
+
+**L1/L2 mapping:**
+
+- **Server acquires L1 epoch BEFORE sending webhook.** The IDLE → WAKING transition acquires the L1 epoch (REGISTERED → READING). The consumer receives the webhook already in READING state — the `epoch` and `token` fields in the payload are from this pre-webhook acquire.
+- **Wake claiming (`wake_id`) is an L2-only protocol step — it does NOT acquire the epoch.** The epoch was already acquired at IDLE → WAKING. Claiming the `wake_id` only transitions the L2 state (WAKING → LIVE); the L1 state remains READING throughout.
+- **Consumer remains REGISTERED (L1) regardless of webhook delivery status.** If webhook delivery fails (timeout, 4xx, 5xx), the server releases the L1 epoch (READING → REGISTERED) and retries. L2 failure handling (Section 7.1.8) never leaves a consumer stuck in READING with no active session.
+- **Done signal transitions L1 READING → REGISTERED.** When `{ "done": true }` is received, the L2 state transitions to IDLE and the L1 epoch is released (READING → REGISTERED). Cursors committed via acks are preserved.
+
+**Epoch** is the L1 epoch (see Section 6.3). Callbacks with a stale epoch **MUST** be rejected with `409 STALE_EPOCH`. This is analogous to producer epochs in Section 5.2.1.
+
+**`wake_id`** is a unique identifier for each wake attempt. The first callback claiming a `wake_id` transitions the consumer to LIVE. Claiming an already-claimed `wake_id` is **idempotent** — the callback succeeds. This handles the case where a 2xx webhook response already transitioned the consumer to LIVE before the callback arrives. Callbacks with a non-matching `wake_id` **MUST** receive `409 ALREADY_CLAIMED`.
+
+**WAKING timeout (10 seconds):** If the consumer has not transitioned to LIVE within 10 seconds of a webhook delivery attempt (no 2xx response and no callback), the server retries the webhook delivery with exponential backoff (see Section 7.1.8). This handles cases where the webhook endpoint is unreachable or slow to start. A 2xx response means the consumer has received the notification and is actively processing — the server transitions immediately to LIVE, and the L1 lease TTL takes over from there.
+
+**Liveness timeout:** Once LIVE, any callback request (including empty heartbeat acks) resets the L1 lease timer. If the lease expires with no callback activity, the consumer transitions to IDLE. Consumers doing slow processing **SHOULD** send periodic callbacks to stay alive. Serverless functions that hold the webhook connection open are covered by the HTTP request timeout (30 seconds) — when the response arrives, it transitions to LIVE and the lease timer begins.
+
+**Wake-up batching:** If multiple events arrive on subscribed streams while the consumer is IDLE, they are batched into a single wake-up. The server **MUST NOT** wake the consumer multiple times — one wake-up per IDLE → WAKING transition.
+
+**No re-wake while LIVE:** If the consumer is already LIVE, new events on subscribed streams **MUST NOT** trigger additional wake-ups.
+
+#### 7.1.3. Wake-up Notification
+
+When waking a consumer, the server **MUST** POST to the webhook URL:
+
+```http
+POST {webhook_url}
+Content-Type: application/json
+Webhook-Signature: t=<timestamp>,sha256=<signature>
+
+{
+  "consumer_id": "{subscription_id}:{url_encoded_stream_path}",
+  "epoch": 7,
+  "wake_id": "w_f8a3b2c1",
+  "primary_stream": "/agents/task-123",
+  "streams": [
+    { "path": "/agents/task-123", "offset": "1002" },
+    { "path": "/shared-filesystem/task-123", "offset": "500" }
+  ],
+  "triggered_by": ["/agents/task-123"],
+  "callback": "{callback_base_url}/callback/{consumer_id}",
+  "token": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
+**Headers:**
+
+- `Webhook-Signature`: HMAC-SHA256 signature for verification (see Section 7.1.4)
+
+**Payload fields:**
+
+- `consumer_id`: Unique identifier for this consumer instance
+- `epoch`: Current L1 epoch; consumers **MUST** include this in callback requests for fencing
+- `wake_id`: Unique identifier for this wake attempt; consumers **MUST** include this in their first callback to claim the wake
+- `primary_stream`: The stream path that originally matched the subscription pattern
+- `streams`: All streams this consumer is subscribed to, with their last acknowledged offset
+- `triggered_by`: Array of stream paths that have pending events (informational)
+- `callback`: Scoped URL for acknowledgments and subscription changes
+- `token`: Initial callback token (from L1 acquire); use in `Authorization: Bearer` header for first callback
+
+The webhook **MAY** respond with `{ "done": true }` to immediately return to IDLE (for simple synchronous processing). This counts as claiming the wake — the server **MUST NOT** redeliver.
+
+#### 7.1.4. Webhook Signature Verification
+
+All webhook notifications **MUST** be signed. Consumers **SHOULD** verify signatures before processing.
+
+**Signature format:**
+
+```
+Webhook-Signature: t=<timestamp>,sha256=<signature>
+```
+
+- `t`: Unix timestamp (seconds) when the signature was generated
+- `sha256`: Hex-encoded HMAC-SHA256 of `<timestamp>.<raw_body>` using the subscription's `webhook_secret`
+
+**Verification steps:**
+
+1. Extract timestamp and signature from the `Webhook-Signature` header
+2. Check timestamp is within acceptable window (±5 minutes) to prevent replay attacks
+3. Compute expected signature: `HMAC-SHA256(webhook_secret, "<timestamp>.<raw_body>")`
+4. Compare signatures using constant-time comparison
+
+Implementations **MUST** use the raw request body bytes for signature verification. Parsing and re-serializing JSON can change whitespace or key order and break the signature.
+
+#### 7.1.5. Callback API
+
+The callback URL is scoped to the specific consumer instance and bundles wake claim + L1 ack in a single request. Consumers authenticate via the `Authorization` header with the token from the webhook payload or the most recent callback response.
+
+```http
+POST {callback_url}
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "epoch": 7,
+  "wake_id": "w_f8a3b2c1",
+  "acks": [
+    { "path": "/agents/task-123", "offset": "1005" }
+  ],
+  "subscribe": ["/tools/task-123"],
+  "unsubscribe": ["/some-old-stream"],
+  "done": true
+}
+```
+
+**Required fields:**
+
+- `epoch`: **MUST** match current L1 consumer epoch (fencing)
+- `wake_id`: **MUST** be included in the first callback to claim the wake; **OPTIONAL** in subsequent callbacks
+
+**Optional fields:**
+
+- `acks`: Array of `{ path, offset }` pairs acknowledging processed events (delegated to L1 ack)
+- `subscribe`: Array of stream paths to subscribe to
+- `unsubscribe`: Array of stream paths to unsubscribe from
+- `done`: Boolean indicating the consumer is finished processing
+
+**Callback semantics:**
+
+- Callbacks are processed **serially** per consumer instance
+- All operations are **idempotent** — safe to retry on timeout
+- Requests are **atomic** — entire request succeeds or fails together
+- Any callback (even empty `{}`) resets the L1 lease timer via an empty ack (heartbeat)
+
+**Success response:**
+
+```json
+{
+  "ok": true,
+  "token": "eyJ...",
+  "streams": [
+    { "path": "/agents/task-123", "offset": "1005" },
+    { "path": "/tools/task-123", "offset": "42" }
+  ]
+}
+```
+
+- `token`: New callback token from L1 (always included; consumer **MUST** use this for subsequent requests)
+- `streams`: Current list of all subscribed streams with their offsets (always included)
+
+**Offset semantics:** Offsets are "last processed inclusive" — the offset value represents the last event that was successfully processed. Offset `"-1"` means no events have been processed yet.
+
+**Error responses:**
+
+| Status | Code              | Description                                              |
+| ------ | ----------------- | -------------------------------------------------------- |
+| 400    | `INVALID_REQUEST` | Malformed JSON or unknown fields                         |
+| 401    | `TOKEN_EXPIRED`   | Callback token has expired (response includes new token) |
+| 401    | `TOKEN_INVALID`   | Callback token is malformed or signature invalid         |
+| 409    | `ALREADY_CLAIMED` | `wake_id` does not match current wake                    |
+| 409    | `INVALID_OFFSET`  | Ack offset is invalid (e.g., beyond stream tail)         |
+| 409    | `STALE_EPOCH`     | Callback epoch is older than current consumer epoch      |
+| 410    | `CONSUMER_GONE`   | Consumer instance no longer exists                       |
+
+Error response body:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "STALE_EPOCH",
+    "message": "Consumer epoch 5 is stale; current epoch is 7"
+  },
+  "token": "eyJ..."
+}
+```
+
+For `TOKEN_EXPIRED`, a new token is included in the error response — the consumer **SHOULD** retry with the new token. For `STALE_EPOCH` and `ALREADY_CLAIMED`, the consumer **SHOULD** stop processing.
+
+**Token refresh:** Every callback response **MUST** include a `token` field. The server **MAY** return the same token if it is not nearing expiry, or a fresh token if the current one will expire soon (e.g., within 5 minutes). Error responses that include a token always provide a fresh one. Consumers **MUST** use the most recently received token for subsequent requests.
+
+#### 7.1.6. Dynamic Subscribe/Unsubscribe
+
+Consumers **MAY** subscribe to additional streams or unsubscribe from existing streams via the callback API.
+
+**Subscribe behavior:**
+
+- New subscriptions start at current tail (new events only)
+- Subscribing to a non-existent stream is allowed — the consumer will be woken when the stream is created and receives its first event
+- No validation of stream paths
+
+**Unsubscribe behavior:**
+
+- Consumers **MAY** unsubscribe from any stream including the primary stream
+- Unsubscribing from all streams removes the consumer instance
+- If a subscribed stream is deleted, it is silently removed from the consumer's subscription list
+
+#### 7.1.7. Secondary Subscriptions
+
+When a consumer subscribes to streams beyond its primary, the coordination works via internal webhooks:
+
+1. The primary stream's server creates a subscription on the secondary stream (marked as internal)
+2. The secondary stream sends webhook notifications to the primary stream's server
+3. The primary stream decides whether to wake the consumer (if IDLE) or let the callback loop handle it (if LIVE)
+
+For single-server deployments, implementations **MAY** optimize internal subscriptions with direct function calls. For distributed deployments, servers **MUST** use the same HMAC signature verification for internal webhooks.
+
+#### 7.1.8. Failure Handling
+
+**Webhook request timeout:** Servers **MUST** wait up to 30 seconds for a response from the webhook endpoint. If the endpoint does not respond within this window, the request is considered failed.
+
+**WAKING timeout:** The server **MUST** wait at least 10 seconds for the consumer to transition from WAKING to LIVE (via 2xx response or callback claim). If neither occurs, the server retries the webhook delivery. A 2xx webhook response transitions the consumer to LIVE — no retry is needed because the consumer has acknowledged the notification.
+
+**Webhook delivery retries** use exponential backoff for failed deliveries:
+
+- Initial retry with exponential backoff up to 30 seconds between attempts
+- Then retry every 60 seconds with jitter
+- Retries continue until the consumer transitions to LIVE, but consumer instances are garbage collected after 3 days of consecutive webhook failures (see Section 7.1.10)
+
+**Delivery guarantee** is at-least-once. Consumers **MUST** handle duplicate events idempotently.
+
+#### 7.1.9. Subscription HTTP API
+
+Subscriptions use the glob pattern as the URL path, with query parameters for CRUD operations.
+
+**Create subscription:**
+
+```http
+PUT /{pattern}?subscription={id}
+Content-Type: application/json
+
+{
+  "webhook": "https://my-agent.workers.dev/handler",
+  "description": "Agent task processor"
+}
+
+→ 201 Created
+{
+  "subscription_id": "{id}",
+  "pattern": "/{pattern}",
+  "webhook": "https://my-agent.workers.dev/handler",
+  "webhook_secret": "whsec_abc123def456...",
+  "description": "Agent task processor"
+}
+```
+
+The `webhook_secret` is only returned on creation. It cannot be retrieved later.
+
+Creating a subscription with an existing ID and identical configuration **MUST** return `200 OK` (idempotent). Creating with an existing ID but different configuration **MUST** return `409 Conflict`.
+
+**URL encoding:** Servers **MUST** treat `*` and `%2A` as equivalent in URL paths.
+
+**List subscriptions under a pattern:**
+
+```http
+GET /{pattern}?subscriptions
+→ 200 OK
+{ "subscriptions": [...] }
+```
+
+**List all subscriptions:**
+
+```http
+GET /**?subscriptions
+→ 200 OK
+{ "subscriptions": [...] }
+```
+
+**Get subscription by ID:**
+
+```http
+GET /**?subscription={id}
+→ 200 OK
+{ "subscription_id": "{id}", "pattern": "/{pattern}", ... }
+```
+
+The response **MUST NOT** include `webhook_secret`.
+
+**Delete subscription:**
+
+```http
+DELETE /{pattern}?subscription={id}
+→ 204 No Content
+```
+
+When a subscription is deleted, all its consumer instances **MUST** be immediately removed. Any in-flight callback requests **MUST** receive `410 CONSUMER_GONE`.
+
+#### 7.1.10. Garbage Collection
+
+Consumer instances **MUST** be removed when:
+
+- The primary stream is deleted
+- Webhook errors continuously for 3 days
+- The consumer unsubscribes from all streams (including primary)
+
+When a consumer instance is removed, all its internal webhook subscriptions to secondary streams **MUST** also be cleaned up.
+
+When a subscription is deleted, all its consumer instances **MUST** be removed immediately (cascade delete).
+
+### 7.2. Pull-Wake (Competitive Wake)
+
+For worker pool patterns where multiple workers compete to process entities.
+
+> **Phase 2 scope:** Pull-wake consumers are single-stream (one consumer per
+> entity stream, e.g., `/users/123` → `user-handler`). Multi-stream pull-wake
+> consumers are deferred to a future phase.
+
+#### 7.2.1. Wake Stream
+
+A Durable Stream (Layer 0 self-hosting) serving as notification channel and coordination log.
+
+**Events:**
+
+```json
+{ "type": "wake",    "stream": "/users/123", "consumer": "user-handler" }
+{ "type": "claimed", "stream": "/users/123", "worker": "worker-7", "epoch": 42 }
+```
+
+- One event per stream (not arrays)
+- Wake events written when REGISTERED consumer has pending data
+- Claimed events written after successful epoch acquisition (informational)
+
+#### 7.2.2. Claim Protocol
+
+Control plane / data plane separation:
+
+- Claims go through atomic `POST /consumers/{id}/acquire` (server authoritative)
+- Server writes claimed notification to wake stream after success
+- Workers use claimed notifications to skip already-claimed wakes (optimization)
+- Worker that misses claimed notification gets 409 from acquire (safe fallback)
+
+**Worker flow:**
+
+1. Read wake stream via SSE (Layer 0)
+2. See wake event with no subsequent claimed event for that stream
+3. Call `POST /consumers/{consumer_id}/acquire` with streams + worker
+4. On success: receive epoch + bearer token, server writes claimed event
+5. On 409: another worker claimed it, skip and continue reading
+
+#### 7.2.3. Bootstrapping
+
+The wake stream operates at Layer 0 only — no named consumers on the wake stream, no wake-about-wake. This is the termination condition for self-hosting recursion (analogous to DNS root servers with hardcoded IPs).
+
+#### 7.2.4. Liveness Detection
+
+Two mechanisms combine:
+
+- SSE connection to wake stream — connection drop means worker is offline
+- Epoch lease timeout — processing sessions have TTL extended by ack activity
+
+#### 7.2.5. Contention Handling
+
+| Pattern         | Readers | Contention | Example                       |
+| --------------- | ------- | ---------- | ----------------------------- |
+| Single consumer | 1       | None       | Desktop app for user entity   |
+| Small pool      | 2–5     | Low        | Team workspace handlers       |
+| Large pool      | Many    | High       | Batch processing, distributed |
+
+Thundering herd mitigation:
+
+- Random backoff before claim attempt (proportional to known worker count)
+- Workers may signal capacity via presence events on wake stream
+
+#### 7.2.6. Failure Handling
+
+- Worker SSE drops → loses access to wake stream
+- Worker reconnects, resumes from last wake stream offset
+- Active session timeout → epoch released (Layer 1 policy)
+
+### 7.3. Mobile Push (Unicast Wake)
+
+[Future — APNs/FCM integration. See RFC § Layer 2 / Mechanism C.]
+
+## 8. Offsets
+
+Offsets are opaque tokens that identify positions within a stream. They are also used as the "last acknowledged" cursor in Named Consumer (Section 6) offset tracking. They have the following properties:
 
 1. **Opaque**: Clients **MUST NOT** interpret offset structure or meaning
 2. **Lexicographically Sortable**: For any two valid offsets for the same stream, a lexicographic comparison determines their relative position in the stream. Clients **MAY** compare offsets lexicographically to determine ordering.
@@ -814,7 +1545,7 @@ Offsets are opaque tokens that identify positions within a stream. They have the
 
   **Catch-up mode** (`offset=now` without `live` parameter):
   - Servers **MUST** return `200 OK` with an empty response body appropriate to the stream's content type:
-    - For `application/json` streams: the body **MUST** be `[]` (empty JSON array), consistent with Section 7.1
+    - For `application/json` streams: the body **MUST** be `[]` (empty JSON array), consistent with Section 9.1
     - For all other content types: the body **MUST** be 0 bytes (empty)
   - Servers **MUST** include a `Stream-Next-Offset` header set to the current tail position
   - Servers **MUST** include `Stream-Up-To-Date: true` header
@@ -854,9 +1585,9 @@ Clients **MUST** use the `Stream-Next-Offset` value returned in responses for su
 
 Forked streams use the same offset space as their source stream — there is no offset translation. The fork offset is the divergence point: data at offsets before it comes from the source, data at or after it comes from the fork. A client reading a forked stream from `-1` sees offsets identical to the source up to the divergence point, then continues with offsets generated by the fork's own appends.
 
-**Fork offset validity:** The `Stream-Fork-Offset` value **MUST** be an offset previously returned by the server (via `Stream-Next-Offset`). As with all offsets, clients **MUST NOT** interpret, construct, or modify offset values (see Section 6, property 1). Servers are **NOT REQUIRED** to validate that a fork offset corresponds to a valid position in the stream's internal storage. If a client provides a client-constructed offset that does not correspond to a valid position, the behavior is undefined — reads on the resulting fork **MAY** return corrupted data or errors. Servers **MAY** validate offset alignment and reject invalid offsets with `400 Bad Request`, but this is not required.
+**Fork offset validity:** The `Stream-Fork-Offset` value **MUST** be an offset previously returned by the server (via `Stream-Next-Offset`). As with all offsets, clients **MUST NOT** interpret, construct, or modify offset values (see Section 8, property 1). Servers are **NOT REQUIRED** to validate that a fork offset corresponds to a valid position in the stream's internal storage. If a client provides a client-constructed offset that does not correspond to a valid position, the behavior is undefined — reads on the resulting fork **MAY** return corrupted data or errors. Servers **MAY** validate offset alignment and reject invalid offsets with `400 Bad Request`, but this is not required.
 
-## 7. Content Types
+## 9. Content Types
 
 The protocol supports arbitrary MIME content types. Most content types operate at the byte level, leaving message framing and interpretation to clients. The `application/json` content type has special semantics defined below.
 
@@ -872,15 +1603,15 @@ Clients **MAY** use any content type for their streams, including:
 - `text/plain` for plain text
 - Custom types for application-specific formats
 
-### 7.1. JSON Mode
+### 9.1. JSON Mode
 
 Streams created with `Content-Type: application/json` have special semantics for message boundaries and batch operations.
 
-#### Message Boundaries
+#### 9.1.1. Message Boundaries
 
 For `application/json` streams, servers **MUST** preserve message boundaries. Each POST request stores messages as a distinct unit, and GET responses **MUST** return data as a JSON array containing all messages from the requested offset range.
 
-#### Array Flattening for Batch Operations
+#### 9.1.2. Array Flattening for Batch Operations
 
 When a POST request body contains a JSON array, servers **MUST** flatten exactly one level of the array, treating each element as a separate message. This enables clients to batch multiple messages in a single HTTP request while preserving individual message semantics.
 
@@ -893,17 +1624,17 @@ When a POST request body contains a JSON array, servers **MUST** flatten exactly
 
 **Note:** Client libraries **MAY** automatically wrap individual values in arrays for batching. For example, a client calling `append({"x": 1})` might send POST body `[{"x": 1}]` to the server, which flattens it to store one message: `{"x": 1}`.
 
-#### Empty Arrays
+#### 9.1.3. Empty Arrays
 
 Servers **MUST** reject POST requests containing empty JSON arrays (`[]`) with `400 Bad Request`. Empty arrays in append operations represent no-op operations with no semantic meaning and likely indicate a client bug.
 
 PUT requests with an empty array body (`[]`) are valid and create an empty stream. The empty array simply means no initial messages are being written.
 
-#### JSON Validation
+#### 9.1.4. JSON Validation
 
 Servers **MUST** validate that appended data is valid JSON. If validation fails, servers **MUST** return `400 Bad Request` with an appropriate error message.
 
-#### Response Format
+#### 9.1.5. Response Format
 
 GET responses for `application/json` streams **MUST** return `Content-Type: application/json` with a body containing a JSON array of all messages in the requested range:
 
@@ -920,9 +1651,9 @@ If no messages exist in the range, servers **MUST** return an empty JSON array `
 
 When a forked stream uses `application/json`, reads spanning the fork boundary (returning both inherited and fork messages) **MUST** wrap all messages in a single JSON array. The fork inherits the source stream's content type if none is specified at creation.
 
-## 8. Caching and Collapsing
+## 10. Caching and Collapsing
 
-### 8.1. Catch-up and Long-poll Reads
+### 10.1. Catch-up and Long-poll Reads
 
 For **shared, non-user-specific streams**, servers **SHOULD** return:
 
@@ -1006,15 +1737,15 @@ GET /stream?offset=123&live=long-poll&cursor=1000
 
 CDNs and proxies **SHOULD NOT** cache `204 No Content` responses from long-poll requests in most cases. Long-poll `200 OK` responses are safe to cache when keyed by `offset`, `cursor`, and authentication credentials.
 
-### 8.2. SSE
+### 10.2. SSE
 
 SSE connections **SHOULD** be closed by the server approximately every 60 seconds. This enables new clients to collapse onto edge requests rather than maintaining long-lived connections to origin servers.
 
-## 9. Extensibility
+## 11. Extensibility
 
 The Durable Streams Protocol is designed to be extended for specific use cases and implementations. Extensions **SHOULD** be pure supersets of the base protocol, ensuring compatibility with any client that implements the base protocol.
 
-### 9.1. Protocol Extensions
+### 11.1. Protocol Extensions
 
 Implementations **MAY** extend the protocol with additional query parameters, headers, or response fields to support domain-specific semantics. For example, a database synchronization implementation might add query parameters to filter by table or schema, or include additional metadata in response headers.
 
@@ -1026,37 +1757,37 @@ Extensions **SHOULD** follow these principles:
 
 - **Version Independence**: Extensions **SHOULD** work with any version of a client that implements the base protocol. Extension negotiation **MAY** be handled through headers or query parameters, but base protocol operations **MUST** remain functional without extension support.
 
-### 9.2. Authentication Extensions
+### 11.2. Authentication Extensions
 
-See Section 10.1 for authentication and authorization details. Implementations **MAY** extend the protocol with authentication-related query parameters or headers (e.g., API keys, OAuth tokens, custom authentication headers).
+See Section 12.1 for authentication and authorization details. Implementations **MAY** extend the protocol with authentication-related query parameters or headers (e.g., API keys, OAuth tokens, custom authentication headers).
 
-## 10. Security Considerations
+## 12. Security Considerations
 
-### 10.1. Authentication and Authorization
+### 12.1. Authentication and Authorization
 
-Authentication and authorization are explicitly out of scope for this protocol specification. Clients **SHOULD** implement all standard HTTP authentication primitives (e.g., Basic Authentication [RFC7617], Bearer tokens [RFC6750], Digest Authentication [RFC7616]). Implementations **MUST** provide appropriate access controls to prevent unauthorized stream creation, modification, or deletion, but may do so using any mechanism they choose, including extending the protocol with authentication-related parameters or headers as described in Section 9.2.
+Authentication and authorization are explicitly out of scope for this protocol specification. Clients **SHOULD** implement all standard HTTP authentication primitives (e.g., Basic Authentication [RFC7617], Bearer tokens [RFC6750], Digest Authentication [RFC7616]). Implementations **MUST** provide appropriate access controls to prevent unauthorized stream creation, modification, or deletion, but may do so using any mechanism they choose, including extending the protocol with authentication-related parameters or headers as described in Section 11.2.
 
-### 10.2. Multi-tenant Safety
+### 12.2. Multi-tenant Safety
 
 If stream URLs are guessable, servers **MUST** enforce access controls even when using shared caches. Servers **SHOULD** validate and sanitize stream URLs to prevent path traversal attacks and ensure URL components are within acceptable limits.
 
-### 10.3. Untrusted Content
+### 12.3. Untrusted Content
 
 Clients **MUST** treat stream contents as untrusted input and **MUST NOT** evaluate or execute stream data without appropriate validation. This is particularly important for append-only streams used as logs, where log injection attacks are a concern.
 
-### 10.4. Content Type Validation
+### 12.4. Content Type Validation
 
 Servers **MUST** validate that appended content types match the stream's declared content type to prevent type confusion attacks.
 
-### 10.5. Rate Limiting
+### 12.5. Rate Limiting
 
 Servers **SHOULD** implement rate limiting to prevent abuse. The `429 Too Many Requests` response code indicates rate limit exhaustion.
 
-### 10.6. Sequence Validation
+### 12.6. Sequence Validation
 
 The optional `Stream-Seq` header provides protection against out-of-order writes in multi-writer scenarios. Servers **MUST** reject sequence regressions to maintain stream integrity.
 
-### 10.7. Browser Security Headers
+### 12.7. Browser Security Headers
 
 When serving streams to browser clients, servers **SHOULD** include the following headers to prevent MIME-sniffing attacks, cross-origin embedding exploits, and cache-related vulnerabilities:
 
@@ -1067,26 +1798,43 @@ When serving streams to browser clients, servers **SHOULD** include the followin
   - Servers **SHOULD** include this header to explicitly control cross-origin embedding. Use `cross-origin` to allow cross-origin access via `fetch()`, `same-site` to restrict to the same registrable domain, or `same-origin` for strict same-origin only. This prevents Cross-Origin Read Blocking (CORB) issues and protects against Spectre-like side-channel attacks.
 
 - `Cache-Control: no-store`
-  - Servers **SHOULD** include this header on HEAD responses and on responses containing sensitive or user-specific stream data. This prevents intermediate proxies and CDNs from caching potentially sensitive content. For public, non-sensitive historical reads, servers **MAY** use `Cache-Control: public, max-age=60, stale-while-revalidate=300` as described in Section 8.
+  - Servers **SHOULD** include this header on HEAD responses and on responses containing sensitive or user-specific stream data. This prevents intermediate proxies and CDNs from caching potentially sensitive content. For public, non-sensitive historical reads, servers **MAY** use `Cache-Control: public, max-age=60, stale-while-revalidate=300` as described in Section 10.
 
 - `Content-Disposition: attachment` (optional)
   - Servers **MAY** include this header for `application/octet-stream` responses to prevent inline rendering if a user navigates directly to the stream URL.
 
 These headers provide defense-in-depth for scenarios where stream URLs might be accessed outside the intended programmatic fetch context (e.g., direct navigation, malicious cross-origin embedding via `<script>` or `<img>` tags).
 
-### 10.8. TLS
+### 12.8. Webhook URL Validation (SSRF Prevention)
+
+Implementations supporting webhook subscriptions **MUST** validate webhook URLs to prevent Server-Side Request Forgery (SSRF) attacks:
+
+- **MUST** require HTTPS for webhook URLs in production (HTTP **MAY** be allowed for localhost in development)
+- **SHOULD** block private IP ranges (RFC 1918), link-local addresses, and loopback addresses
+- **SHOULD** block cloud metadata endpoints (e.g., `169.254.169.254`)
+- **MAY** implement domain allowlisting for webhook URLs
+
+### 12.9. Callback Token Security
+
+Callback tokens **MUST** be passed via the `Authorization` header to avoid logging exposure. Tokens **SHOULD** be signed (e.g., HMAC-signed JWTs) containing the consumer ID, epoch, and expiry. Implementations **MUST** validate token signatures on every callback request. Tokens have a 1-hour TTL and are refreshed only when nearing expiry (e.g., within 5 minutes); otherwise the same token is returned to avoid unnecessary cryptographic overhead.
+
+### 12.10. Webhook Signature Security
+
+Webhook signatures (Section 7.1.4) prevent spoofing of notifications. The `webhook_secret` is generated by the server and returned only on subscription creation. Consumers **SHOULD** verify signatures before processing any webhook payload. Timestamps in signatures prevent replay attacks within the ±5-minute tolerance window.
+
+### 12.11. TLS
 
 All protocol operations **MUST** be performed over HTTPS (TLS) in production environments to protect data in transit.
 
-## 11. IANA Considerations
+## 13. IANA Considerations
 
-### 11.1. Default Port
+### 13.1. Default Port
 
 The default port for standalone Durable Streams servers is **4437/tcp** (with 4437/udp reserved for future use).
 
 This port was selected from the IANA unassigned range 4434-4440. Standalone server implementations **SHOULD** use port 4437 as the default when no explicit port is configured. When Durable Streams is integrated into an existing web server or application framework, it **SHOULD** use the host server's port instead.
 
-### 11.2. HTTP Headers
+### 13.2. HTTP Headers
 
 This document requests registration of the following HTTP headers in the "Permanent Message Header Field Names" registry:
 
@@ -1101,6 +1849,7 @@ This document requests registration of the following HTTP headers in the "Perman
 | `Stream-Closed`      | permanent | This document |
 | `Stream-Forked-From` | permanent | This document |
 | `Stream-Fork-Offset` | permanent | This document |
+| `Webhook-Signature`  | permanent | This document |
 
 **Descriptions:**
 
@@ -1113,10 +1862,11 @@ This document requests registration of the following HTTP headers in the "Perman
 - `Stream-Closed`: Indicates stream is closed / end-of-stream (presence header, value `true`)
 - `Stream-Forked-From`: Source stream path for forked streams, used on `PUT` requests (opaque string)
 - `Stream-Fork-Offset`: Divergence point offset for forked streams, used on `PUT` requests (opaque string)
+- `Webhook-Signature`: HMAC-SHA256 signature for webhook notification verification (Section 7.1.4)
 
-## 12. References
+## 14. References
 
-### 12.1. Normative References
+### 14.1. Normative References
 
 [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997, <https://www.rfc-editor.org/info/rfc2119>.
 
@@ -1134,7 +1884,7 @@ This document requests registration of the following HTTP headers in the "Perman
 
 [RFC7616] Shekh-Yusef, R., Ed., Ahrens, D., and S. Bremer, "HTTP Digest Access Authentication", RFC 7616, DOI 10.17487/RFC7616, September 2015, <https://www.rfc-editor.org/info/rfc7616>.
 
-### 12.2. Informative References
+### 14.2. Informative References
 
 [SSE] Hickson, I., "Server-Sent Events", W3C Recommendation, February 2015, <https://www.w3.org/TR/eventsource/>.
 

--- a/docs/layered-consumer-spec.md
+++ b/docs/layered-consumer-spec.md
@@ -93,10 +93,10 @@ REGISTERED ───────────────────────
 Pending work exists when any subscribed stream has unprocessed events:
 
 ```
-pending_work = any(tail[path] > acked[path] for path in subscribed_streams)
+pending_work = any(tail[path] >lex acked[path] for path in subscribed_streams)
 ```
 
-Where `acked[path]` is the last acknowledged offset (inclusive — the event at this offset was processed) and `tail[path]` is the current stream end. An acked offset of `-1` means no events have been processed yet. Offset comparison uses the fixed-width lexicographic format defined in the main protocol (see PROTOCOL.md § Offsets).
+Where `>lex` denotes lexicographic comparison (see PROTOCOL.md § 8 — offsets are opaque but lexicographically sortable), `acked[path]` is the last acknowledged offset (inclusive — the event at this offset was processed), and `tail[path]` is the current stream end. An acked offset of `-1` means no events have been processed yet.
 
 ### L1 HTTP API
 
@@ -109,7 +109,6 @@ Content-Type: application/json
 {
   "consumer_id": "my-agent:task-123",
   "streams": ["/agents/task-123"],
-  "namespace": "/agents/*",
   "lease_ttl_ms": 45000
 }
 ```
@@ -118,7 +117,6 @@ Content-Type: application/json
 | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `consumer_id`  | Yes      | Stable, client-provided identifier; must be unique. Must not start with reserved prefix `__wh__:` (used by L2/A synthetic consumers) |
 | `streams`      | Yes      | One or more stream paths to track                                                                                                    |
-| `namespace`    | No       | Glob pattern for informational grouping (e.g., `/agents/*`)                                                                          |
 | `lease_ttl_ms` | No       | Lease duration in milliseconds; server default if omitted                                                                            |
 
 **Response:**
@@ -135,7 +133,6 @@ Content-Type: application/json
   "state": "REGISTERED",
   "epoch": 0,
   "streams": [{ "path": "/agents/task-123", "offset": "-1" }],
-  "namespace": "/agents/*",
   "lease_ttl_ms": 45000
 }
 ```
@@ -171,6 +168,8 @@ POST /consumers/{id}/acquire
   "streams": [{ "path": "/agents/task-123", "offset": "1002" }]
 }
 ```
+
+The `offset` in each stream entry is the last-acknowledged offset (i.e., the consumer's current cursor position). The consumer should resume reading from the next offset after this position.
 
 Acquiring the epoch:
 
@@ -226,7 +225,7 @@ Content-Type: application/json
 
 Both cursor-advancing acks and empty acks reset the lease timer.
 
-**Offset semantics:** Offsets are "last processed inclusive." Offset `"1005"` means events through 1005 have been processed; the next read starts from `"1006"`. Offset `"-1"` means nothing has been processed.
+**Offset semantics:** Offsets are "last processed inclusive." Acking offset `"1005"` means events through that offset have been processed; the consumer resumes reading from the offset returned in `Stream-Next-Offset` of the response that delivered offset `"1005"`. Offset `"-1"` means nothing has been processed.
 
 **Error responses:**
 
@@ -318,7 +317,7 @@ Identity: `__wh__:{subscription_id}:{url_encoded_stream_path}`
 
 The `__wh__:` prefix is a reserved namespace that prevents collision with user-created L1 consumers. The L1 registration endpoint rejects consumer IDs starting with this prefix.
 
-Because a subscription uses a glob pattern (e.g., `/agents/*`), a single subscription can match many streams — each matched stream gets its own consumer instance with independent state, offsets, and lifecycle. The consumer ID encodes the prefix, subscription, and specific stream it tracks. The stream path is URL-encoded to avoid parsing ambiguity. Multiple subscriptions matching the same stream create independent consumers.
+Because a subscription uses a glob pattern (e.g., `/agents/*`), a single subscription can match many streams — each matched stream gets its own consumer instance with independent state, offsets, and lifecycle. This one-consumer-per-matched-stream design exists because each stream represents an independent unit of work (e.g., one agent task) that should wake, process, and idle independently. The consumer can later subscribe to additional streams (e.g., shared filesystem, tool outputs) via the callback API, but it starts with the single stream that triggered its creation. The consumer ID encodes the prefix, subscription, and specific stream it tracks. The stream path is URL-encoded to avoid parsing ambiguity. Multiple subscriptions matching the same stream create independent consumers.
 
 **Implementation note:** When extracting the consumer ID from callback URLs (e.g., `/callback/{consumer_id}`), implementations MUST use the raw percent-encoded path, not a decoded version. HTTP frameworks often decode `%2F` → `/` in URL paths automatically, which would break consumer ID lookups.
 
@@ -351,46 +350,46 @@ Rules:
 The L2 states IDLE/WAKING/LIVE are layered on top of L1's REGISTERED/READING:
 
 ```
-                    ┌──────────────────────────────────────────┐
-                    │                                          │
-                    ▼                                          │
-              ┌──────────┐    pending_work    ┌──────────┐    │
-              │          │ ─────────────────► │          │    │
-              │   IDLE   │  L1 acquire()      │  WAKING  │    │
-              │(L1:REG'd)│  wake_id new       │(L1:READ) │    │
-              └──────────┘                    └────┬─────┘    │
-                    ▲                              │          │
-                    │                    ┌─────────┼────┐     │
-                    │                    │         │    │     │
-                    │              callback   webhook   │     │
-                    │              claims     2xx or    │     │
-                    │              wake_id    {done}    │     │
-                    │                    │         │    │     │
-                    │                    ▼         │    │     │
-                    │               ┌─────────┐   │    │     │
-                    │               │         │   │    │     │
-                    │ done+¬pending │  LIVE   │───┘    │     │
-                    │ OR lease exp. │(L1:READ)│        │     │
-                    └───────────────┴─────────┘        │     │
-                    │                                   │     │
-                    │  done + pending_work               │     │
-                    └───────────────────────────────────┘     │
-                                                              │
-                    10s timeout, no 2xx, no callback ──────────┘
-                    (retry webhook delivery)
+              ┌──────────┐   pending_work    ┌──────────┐
+              │          │ ────────────────► │          │──┐
+              │   IDLE   │  L1 acquire(),    │  WAKING  │  │ 10s timeout,
+              │(L1:REG'd)│  new wake_id,     │(L1:READ) │  │ no 2xx/callback
+              │          │  webhook POST     │          │◄─┘ (retry webhook)
+              └──────────┘                   └────┬─────┘
+                ▲   ▲                              │
+                │   │                    ┌─────────┴────────┐
+                │   │                    │                  │
+                │   │              callback claims    webhook responds
+                │   │              wake_id            {done: true}
+                │   │                    │            + ¬pending_work
+                │   │                    ▼                  │
+                │   │               ┌─────────┐            │
+                │   │               │         │            │
+                │   │ done+¬pending │  LIVE   │            │
+                │   │ OR lease exp. │(L1:READ)│            │
+                │   └───────────────┴─────────┘            │
+                │                        │                 │
+                │   done + pending_work  │                 │
+                │   (new wake cycle)     │                 │
+                └────────────────────────┘                 │
+                │                                          │
+                └──────────────────────────────────────────┘
+                    (L1 release, auto-ack to tail)
 ```
 
 #### State Transitions
 
 | From   | To      | Trigger                                                          | Side Effects                            |
 | ------ | ------- | ---------------------------------------------------------------- | --------------------------------------- |
-| IDLE   | WAKING  | `pending_work` becomes true                                      | L1 acquire(), new wake_id, webhook POST |
+| IDLE   | WAKING  | `pending_work` detected (on append to subscribed stream)         | L1 acquire(), new wake_id, webhook POST |
 | WAKING | LIVE    | Webhook responds 2xx, OR callback claims wake_id                 | L1 lease timer running                  |
 | WAKING | IDLE    | Webhook responds `{done: true}` and `¬pending_work`              | L1 release(), auto-ack to tail          |
 | LIVE   | IDLE    | Callback `{done: true}` and `¬pending_work`                      | L1 release()                            |
 | LIVE   | IDLE    | L1 lease timer expires (no callback activity)                    | L1 epoch already released by L1         |
 | LIVE   | WAKING  | Callback `{done: true}` and `pending_work`                       | L1 acquire() again, new wake_id         |
 | Any    | Removed | Primary stream deleted, subscription deleted, or unsubscribe all | L1 consumer deleted                     |
+
+`pending_work` is not a reactive property that the server continuously monitors. It is a condition evaluated at two specific moments: (1) when an append occurs on a subscribed stream (to decide whether to wake an IDLE consumer), and (2) when a `done` callback is received (to decide whether to re-wake or transition to IDLE).
 
 #### Epoch
 
@@ -446,7 +445,7 @@ Webhook-Signature: t=1704067200,sha256=a1b2c3d4e5f6...
 The webhook response may include `{ "done": true }` to immediately return to IDLE without using the callback API. When the server receives this response:
 
 1. The wake is considered claimed
-2. All streams are auto-acked to their current tail offset
+2. All streams are auto-acked to their current tail offset (the consumer has already read to the end of each stream before responding)
 3. L1 epoch is released; consumer returns to REGISTERED
 4. Consumer transitions to IDLE
 5. If new events arrive later, a new wake cycle begins
@@ -567,8 +566,8 @@ For `TOKEN_EXPIRED`, the new token in the error response can be used to retry. F
 
 Offsets are **"last processed inclusive"**:
 
-- `"1005"` means events through 1005 have been processed
-- Next read starts from `"1006"`
+- Acking `"1005"` means events through that offset have been processed
+- The consumer resumes from the `Stream-Next-Offset` returned in the response that delivered that event
 - `"-1"` means no events processed yet
 
 ### Dynamic Subscribe
@@ -790,7 +789,9 @@ Content-Type: application/json
 1. Worker long-polls the wake stream for new events
 2. On receiving a `wake` event, worker calls `POST /consumers/{id}/acquire`
 3. If acquire succeeds, worker reads events, acks progress, and releases when done
-4. If acquire fails (`EPOCH_HELD` or `INTERNAL_ERROR`), another worker claimed it — skip
+4. If acquire returns `INTERNAL_ERROR` (critical callback failed), retry later
+
+In the single-process reference server, acquire always succeeds (self-supersede per L1 LP4) — there is no `EPOCH_HELD` rejection. Multiple workers racing to acquire the same consumer will all succeed sequentially, each superseding the previous one. The last writer wins: earlier acquirers will receive `STALE_EPOCH` on their next ack. Workers should check the `claimed` events on the wake stream to coordinate: if a `claimed` event for a newer epoch appears, the worker should stop processing. In future multi-server deployments, `EPOCH_HELD` may be produced to reject competing acquires from different nodes.
 
 ### L1/L2 Coupling via Critical Callbacks
 

--- a/docs/layered-consumer-spec.md
+++ b/docs/layered-consumer-spec.md
@@ -1,0 +1,827 @@
+# Layered Consumer Specification
+
+## Overview
+
+This document specifies the complete behavior of the Named Consumer protocol and its wake-up mechanisms. It is organized by the layered architecture:
+
+- **Layer 0 (L0)**: The Durable Streams core — append-only streams, HTTP reads, offsets
+- **Layer 1 (L1)**: Named Consumers — mechanism-independent consumer identity, epoch fencing, offset tracking, lease-based liveness
+- **Layer 2 (L2)**: Wake-Up Mechanisms — two mechanisms that notify consumers of pending work:
+  - **L2/A (Webhook)**: Server-initiated push via HTTP POST to a registered URL
+  - **L2/B (Pull-Wake)**: Worker-initiated pull via a shared Durable Stream used as a wake notification channel
+
+L1 is fully specified here and corresponds to PROTOCOL.md § 6 (Named Consumers). L2/A corresponds to PROTOCOL.md § 7.1 (Webhook). L2/B corresponds to PROTOCOL.md § 7.2 (Pull-Wake).
+
+---
+
+## Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  L2/A: Webhook          │  L2/B: Pull-Wake          │
+│  Subscription, wake     │  Wake stream (L0),        │
+│  delivery, callback,    │  race-to-claim via        │
+│  retry, GC              │  POST /consumers/{id}/    │
+│  States: IDLE/WAKING/   │  acquire                  │
+│  LIVE                   │                           │
+├─────────────────────────┴───────────────────────────┤
+│  L1: Named Consumers                                │
+│  Consumer registration, epoch acquisition, ack,     │
+│  release, lease-based liveness                      │
+│  States: REGISTERED / READING                       │
+│  Critical callbacks (L2 can fail an acquire)        │
+├─────────────────────────────────────────────────────┤
+│  L0: Durable Streams Core                           │
+│  Streams, offsets, HTTP reads                       │
+└─────────────────────────────────────────────────────┘
+```
+
+**L1 is mechanism-independent.** Any wake-up mechanism (webhook, pull-wake, mobile push) can sit on top of L1 by acquiring an epoch and acking offsets. The L1 protocol does not reference webhooks, subscriptions, or any L2 concept.
+
+**L2 is additive.** L2 mechanisms extend L1 with delivery/notification. They call L1 acquire on wake and L1 ack on progress, and listen to L1 lease-expiry events to trigger re-wake. Two mechanisms are defined:
+
+- **L2/A (Webhook)**: Server pushes HMAC-signed HTTP POST to a registered URL. Consumers process events and respond via callback API.
+- **L2/B (Pull-Wake)**: Server writes wake/claimed events to a Durable Stream. Workers poll that stream and race to claim work via `POST /consumers/{id}/acquire`.
+
+**Known compromises in the current implementation** (see § L2/A Implementation Notes):
+
+1. Webhook subscription creation implicitly creates (or idempotently registers) the underlying L1 consumer. The full dialectic ideal — where L2 only attaches to an independently-registered L1 consumer — is not yet achieved.
+2. `wake_id_claimed` state is retained on the L2 `WebhookConsumer` record for retry idempotency, even though epoch fencing (L1) subsumes most of its function. This is a known compromise where the L1/L2 boundary is not yet fully clean.
+
+---
+
+## Part I — Layer 1: Named Consumer Protocol
+
+### Concepts
+
+#### Consumer
+
+A **consumer** is a named cursor group. It tracks:
+
+- A stable `consumer_id`
+- A set of stream paths with their last-acknowledged offsets
+- An `epoch` counter for fencing concurrent readers
+- A lease timer controlling READING → REGISTERED transitions
+
+Consumers persist across wake cycles; offsets are durably preserved.
+
+#### Consumer State Machine
+
+```
+  ┌──────────────────────────────────────────────────┐
+  │                                                  │
+  │   POST /consumers/{id}/acquire                   │
+  │   (epoch++, token issued, lease timer starts)    │
+  │                                                  │
+  ▼                                                  │
+REGISTERED ────────────────────────────────► READING
+  ▲                                                  │
+  │                                                  │
+  │   POST /consumers/{id}/release                   │
+  │   OR lease TTL expires                           │
+  │                                                  │
+  └──────────────────────────────────────────────────┘
+```
+
+| State        | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `REGISTERED` | Consumer exists; no active reader holds the epoch |
+| `READING`    | Epoch acquired; consumer is actively reading      |
+
+#### Pending Work
+
+Pending work exists when any subscribed stream has unprocessed events:
+
+```
+pending_work = any(tail[path] > acked[path] for path in subscribed_streams)
+```
+
+Where `acked[path]` is the last acknowledged offset (inclusive — the event at this offset was processed) and `tail[path]` is the current stream end. An acked offset of `-1` means no events have been processed yet. Offset comparison uses the fixed-width lexicographic format defined in the main protocol (see PROTOCOL.md § Offsets).
+
+### L1 HTTP API
+
+#### Consumer Registration
+
+```http
+POST /consumers
+Content-Type: application/json
+
+{
+  "consumer_id": "my-agent:task-123",
+  "streams": ["/agents/task-123"],
+  "namespace": "/agents/*",
+  "lease_ttl_ms": 45000
+}
+```
+
+| Field          | Required | Description                                                                                                                          |
+| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `consumer_id`  | Yes      | Stable, client-provided identifier; must be unique. Must not start with reserved prefix `__wh__:` (used by L2/A synthetic consumers) |
+| `streams`      | Yes      | One or more stream paths to track                                                                                                    |
+| `namespace`    | No       | Glob pattern for informational grouping (e.g., `/agents/*`)                                                                          |
+| `lease_ttl_ms` | No       | Lease duration in milliseconds; server default if omitted                                                                            |
+
+**Response:**
+
+- `201 Created`: Consumer registered
+- `200 OK`: Consumer already exists with identical configuration (idempotent)
+- `409 Conflict` (`CONSUMER_ALREADY_EXISTS`): Consumer exists with different configuration
+
+**Response body (201/200):**
+
+```json
+{
+  "consumer_id": "my-agent:task-123",
+  "state": "REGISTERED",
+  "epoch": 0,
+  "streams": [{ "path": "/agents/task-123", "offset": "-1" }],
+  "namespace": "/agents/*",
+  "lease_ttl_ms": 45000
+}
+```
+
+Offsets are initialized to `"-1"` (nothing acknowledged) for new streams.
+
+**Get consumer:**
+
+```http
+GET /consumers/{id}
+→ 200 OK  (ConsumerInfo)
+→ 404     (CONSUMER_NOT_FOUND)
+```
+
+**Delete consumer:**
+
+```http
+DELETE /consumers/{id}
+→ 204 No Content
+→ 404     (CONSUMER_NOT_FOUND)
+```
+
+#### Epoch Acquisition
+
+```http
+POST /consumers/{id}/acquire
+→ 200 OK
+
+{
+  "consumer_id": "my-agent:task-123",
+  "epoch": 3,
+  "token": "eyJ...",
+  "streams": [{ "path": "/agents/task-123", "offset": "1002" }]
+}
+```
+
+Acquiring the epoch:
+
+- Increments the epoch counter
+- Runs critical L2 callbacks (e.g., L2/B appends a `claimed` event to the wake stream). If any critical callback fails, the acquire is rolled back and returns `INTERNAL_ERROR`
+- Transitions the consumer from REGISTERED to READING
+- Issues a bearer token scoped to this consumer and epoch
+- Starts the lease timer
+
+If the consumer is already READING (a previous reader crashed without releasing), this is a **self-supersede**: the epoch is incremented again, the previous token is invalidated, and a new token is returned. Any subsequent ack from the old reader will receive `STALE_EPOCH`.
+
+**Error responses:**
+
+| Status | Code                 | Description                                      |
+| ------ | -------------------- | ------------------------------------------------ |
+| 404    | `CONSUMER_NOT_FOUND` | Consumer does not exist                          |
+| 409    | `EPOCH_HELD`         | Reserved; not produced by reference server       |
+| 500    | `INTERNAL_ERROR`     | Critical L2 callback failed; acquire rolled back |
+
+> **Implementation note on `EPOCH_HELD`**: The reference server always permits self-supersede. `EPOCH_HELD` is defined but not produced — it is reserved for future multi-server deployments where epoch acquisition involves distributed coordination and a contending acquire from a different node cannot be allowed. A consumer wishing to re-acquire an epoch it holds should call acquire again; this always succeeds in the single-process reference server.
+
+#### Acknowledgment
+
+Acks advance the consumer's durable cursor for one or more streams.
+
+```http
+POST /consumers/{id}/ack
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "offsets": [
+    { "path": "/agents/task-123", "offset": "1005" }
+  ]
+}
+
+→ 200 OK
+{ "ok": true, "token": "eyJ..." }
+```
+
+An **empty ack** (zero offsets) is a heartbeat: it extends the lease without writing a durable cursor update.
+
+```http
+POST /consumers/{id}/ack
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{ "offsets": [] }
+
+→ 200 OK
+{ "ok": true, "token": "eyJ..." }
+```
+
+Both cursor-advancing acks and empty acks reset the lease timer.
+
+**Offset semantics:** Offsets are "last processed inclusive." Offset `"1005"` means events through 1005 have been processed; the next read starts from `"1006"`. Offset `"-1"` means nothing has been processed.
+
+**Error responses:**
+
+| Status | Code                 | Description                                     |
+| ------ | -------------------- | ----------------------------------------------- |
+| 400    | `INVALID_REQUEST`    | Malformed JSON or missing `offsets` field       |
+| 401    | `TOKEN_EXPIRED`      | Bearer token TTL exceeded                       |
+| 401    | `TOKEN_INVALID`      | Token is malformed or signature invalid         |
+| 409    | `STALE_EPOCH`        | Token epoch does not match current epoch        |
+| 409    | `OFFSET_REGRESSION`  | Ack offset is less than current cursor          |
+| 409    | `INVALID_OFFSET`     | Ack offset is beyond stream tail                |
+| 400    | `UNKNOWN_STREAM`     | Stream path is not registered for this consumer |
+| 404    | `CONSUMER_NOT_FOUND` | Consumer does not exist                         |
+
+#### Release
+
+```http
+POST /consumers/{id}/release
+Authorization: Bearer {token}
+
+→ 200 OK
+{ "ok": true, "state": "REGISTERED" }
+```
+
+Releasing the epoch transitions the consumer from READING to REGISTERED and cancels the lease timer. The consumer's offsets are preserved. A subsequent acquire starts from the last acknowledged position.
+
+**Error responses:** Same token/epoch errors as acknowledgment (see above).
+
+### L1 Safety Invariants
+
+**S1 — Epoch Monotonicity**: Epoch values for a given consumer are strictly increasing. Each acquire increments the epoch; epochs never regress.
+
+**S4 — Offset Monotonicity**: Acknowledged offsets for a given stream are monotonically non-decreasing. Acking an offset lower than the current cursor is rejected with `OFFSET_REGRESSION`.
+
+**S5 — Token Present**: Every successful ack response includes a `token` field. The server may return the same token if it is not nearing expiry.
+
+**S6 — Stale Epoch Rejection**: Ack requests with a token epoch that does not match the current consumer epoch are rejected with `STALE_EPOCH`. This fences zombie consumers — a session from a previous epoch cannot interfere with the current one.
+
+**S9 — Critical Callback Atomicity**: If a critical L2 callback fails during acquire, the acquire is rolled back (epoch released) and the caller receives `INTERNAL_ERROR`. L1 and L2 state remain consistent — no acquire completes without its critical L2 side effects succeeding.
+
+**S10 — Reserved Prefix**: Consumer IDs starting with `__wh__:` are reserved for L2/A synthetic consumers. The L1 registration endpoint rejects consumer IDs with this prefix to prevent namespace collision.
+
+### L1 Liveness Properties
+
+**LP1 — Lease Expiry Causes Epoch Release**: When the lease timer fires while the consumer is READING, the epoch is released (READING → REGISTERED). Any registered `onLeaseExpired` callbacks (e.g., the L2 webhook layer) are invoked.
+
+**LP2 — Both Ack Shapes Reset the Lease Timer**: Cursor-advancing acks and empty acks (heartbeat shape) both reset `last_ack_at` and restart the lease timer.
+
+**LP3 — Empty Ack is the Heartbeat Shape**: An ack with `offsets: []` extends the lease without writing a durable cursor update. Consumers doing slow processing should send periodic empty acks to stay alive.
+
+**LP4 — Self-Supersede Always Succeeds**: In the single-process reference server, a consumer calling acquire while already READING always succeeds (epoch incremented, new token issued). `EPOCH_HELD` is defined but not produced — it is reserved for future multi-server deployments.
+
+---
+
+## Part II — Layer 2/A: Webhook Mechanism
+
+Webhook subscriptions enable serverless functions and AI agents to react to stream events without maintaining persistent connections. Unlike traditional webhooks that deliver data inline, Durable Streams webhooks are **wake-up signals** — the notification tells the consumer which streams have new events, and the consumer reads the actual data using the standard Durable Streams HTTP protocol (see PROTOCOL.md §§ 3–5).
+
+The L2/A webhook mechanism adds on top of L1:
+
+- **Subscription**: maps a glob pattern to a webhook URL and secret
+- **Consumer instance lifecycle**: IDLE/WAKING/LIVE states built on L1 REGISTERED/READING
+- **Wake delivery**: HMAC-signed POST notifying the consumer of pending work
+- **Callback API**: bundles wake claim + L1 ack into a single request
+- **Dynamic subscribe/unsubscribe**: consumers can add/remove streams mid-session, with both L1 and L2 indexes kept in sync
+- **Failure handling**: retry, backoff, garbage collection
+
+### Concepts
+
+#### Subscription
+
+A registration that maps a **glob pattern** to a **webhook URL**. Subscriptions are created via the HTTP API and are immutable — to change the webhook URL, delete and recreate.
+
+Fields:
+
+- `subscription_id` — Client-provided identifier
+- `pattern` — Glob pattern matching stream paths
+- `webhook` — URL to POST notifications to
+- `webhook_secret` — Server-generated HMAC secret (returned on creation only)
+- `description` — Optional human-readable label
+
+#### Consumer Instance
+
+Created **lazily on first append** to a stream matching a subscription's pattern. Consumer instances are not created when a stream is first created or when a subscription is registered against existing streams — only when actual events arrive. This avoids materializing consumer records for streams that may never receive data (e.g., 100k agent streams where only a fraction are active).
+
+Each consumer tracks its own offsets across one or more streams and cycles through states independently. The underlying L1 consumer record is created at the same time (see L2/A Implementation Notes).
+
+Identity: `__wh__:{subscription_id}:{url_encoded_stream_path}`
+
+The `__wh__:` prefix is a reserved namespace that prevents collision with user-created L1 consumers. The L1 registration endpoint rejects consumer IDs starting with this prefix.
+
+Because a subscription uses a glob pattern (e.g., `/agents/*`), a single subscription can match many streams — each matched stream gets its own consumer instance with independent state, offsets, and lifecycle. The consumer ID encodes the prefix, subscription, and specific stream it tracks. The stream path is URL-encoded to avoid parsing ambiguity. Multiple subscriptions matching the same stream create independent consumers.
+
+**Implementation note:** When extracting the consumer ID from callback URLs (e.g., `/callback/{consumer_id}`), implementations MUST use the raw percent-encoded path, not a decoded version. HTTP frameworks often decode `%2F` → `/` in URL paths automatically, which would break consumer ID lookups.
+
+#### Pending Work
+
+Pending work exists when any subscribed stream has unprocessed events. Uses the same definition as L1 (see Part I).
+
+### Glob Patterns
+
+Patterns use path-segment wildcards:
+
+| Pattern           | Matches                                 | Does Not Match            |
+| ----------------- | --------------------------------------- | ------------------------- |
+| `/agents/*`       | `/agents/task-1`                        | `/agents/foo/bar`         |
+| `/agents/**`      | `/agents/task-1`, `/agents/foo/bar/baz` | `/other/path`             |
+| `/agents/*/inbox` | `/agents/worker-1/inbox`                | `/agents/worker-1/outbox` |
+
+Rules:
+
+- `*` matches exactly one path segment
+- `**` matches zero or more path segments (recursive)
+- Literal segments match exactly
+- `*` and `%2A` are equivalent (URL encoding)
+- Literal `*` stream names are not supported
+
+### Consumer Lifecycle
+
+#### State Machine
+
+The L2 states IDLE/WAKING/LIVE are layered on top of L1's REGISTERED/READING:
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │                                          │
+                    ▼                                          │
+              ┌──────────┐    pending_work    ┌──────────┐    │
+              │          │ ─────────────────► │          │    │
+              │   IDLE   │  L1 acquire()      │  WAKING  │    │
+              │(L1:REG'd)│  wake_id new       │(L1:READ) │    │
+              └──────────┘                    └────┬─────┘    │
+                    ▲                              │          │
+                    │                    ┌─────────┼────┐     │
+                    │                    │         │    │     │
+                    │              callback   webhook   │     │
+                    │              claims     2xx or    │     │
+                    │              wake_id    {done}    │     │
+                    │                    │         │    │     │
+                    │                    ▼         │    │     │
+                    │               ┌─────────┐   │    │     │
+                    │               │         │   │    │     │
+                    │ done+¬pending │  LIVE   │───┘    │     │
+                    │ OR lease exp. │(L1:READ)│        │     │
+                    └───────────────┴─────────┘        │     │
+                    │                                   │     │
+                    │  done + pending_work               │     │
+                    └───────────────────────────────────┘     │
+                                                              │
+                    10s timeout, no 2xx, no callback ──────────┘
+                    (retry webhook delivery)
+```
+
+#### State Transitions
+
+| From   | To      | Trigger                                                          | Side Effects                            |
+| ------ | ------- | ---------------------------------------------------------------- | --------------------------------------- |
+| IDLE   | WAKING  | `pending_work` becomes true                                      | L1 acquire(), new wake_id, webhook POST |
+| WAKING | LIVE    | Webhook responds 2xx, OR callback claims wake_id                 | L1 lease timer running                  |
+| WAKING | IDLE    | Webhook responds `{done: true}` and `¬pending_work`              | L1 release(), auto-ack to tail          |
+| LIVE   | IDLE    | Callback `{done: true}` and `¬pending_work`                      | L1 release()                            |
+| LIVE   | IDLE    | L1 lease timer expires (no callback activity)                    | L1 epoch already released by L1         |
+| LIVE   | WAKING  | Callback `{done: true}` and `pending_work`                       | L1 acquire() again, new wake_id         |
+| Any    | Removed | Primary stream deleted, subscription deleted, or unsubscribe all | L1 consumer deleted                     |
+
+#### Epoch
+
+The epoch is the L1 epoch (from L1 acquire). It is monotonically increasing. Callbacks with a stale epoch are rejected with `STALE_EPOCH`. This fences zombie consumers — a consumer from a previous wake cycle cannot interfere with the current one.
+
+#### Wake ID
+
+Unique identifier generated for each wake attempt. The first callback that includes a matching `wake_id` claims the wake (WAKING → LIVE). Claiming an already-claimed `wake_id` is **idempotent** — the callback succeeds. This handles the case where a 2xx webhook response already transitioned the consumer to LIVE before the callback arrives. Callbacks with a non-matching `wake_id` receive `ALREADY_CLAIMED`.
+
+#### Liveness Timeout
+
+The L1 lease timer provides the liveness mechanism. Any callback resets the lease timer (via L1 empty ack). If the lease expires while the consumer is LIVE, it transitions to IDLE. Consumers doing slow processing should send periodic callbacks (even `{ epoch: N }` with no other fields) to stay alive — this triggers an empty L1 ack.
+
+### Wake-up Notification
+
+When waking a consumer, the server POSTs to the subscription's webhook URL:
+
+```http
+POST {webhook_url}
+Content-Type: application/json
+Webhook-Signature: t=1704067200,sha256=a1b2c3d4e5f6...
+
+{
+  "consumer_id": "__wh__:my-sub:%2Fagents%2Ftask-123",
+  "epoch": 7,
+  "wake_id": "w_f8a3b2c1",
+  "primary_stream": "/agents/task-123",
+  "streams": [
+    { "path": "/agents/task-123", "offset": "1002" },
+    { "path": "/shared-filesystem/task-123", "offset": "500" }
+  ],
+  "triggered_by": ["/agents/task-123"],
+  "callback": "https://streams.example.com/callback/__wh__:my-sub:%2Fagents%2Ftask-123",
+  "token": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
+### Payload Fields
+
+| Field            | Type     | Description                                      |
+| ---------------- | -------- | ------------------------------------------------ |
+| `consumer_id`    | string   | Unique consumer instance identifier              |
+| `epoch`          | number   | L1 epoch; include in all callbacks               |
+| `wake_id`        | string   | Claim this in the first callback                 |
+| `primary_stream` | string   | The stream that spawned this consumer            |
+| `streams`        | array    | All subscribed streams with last acked offsets   |
+| `triggered_by`   | string[] | Streams that have pending events (informational) |
+| `callback`       | string   | URL for acknowledgments and subscription changes |
+| `token`          | string   | L1 bearer token for the first callback           |
+
+### Synchronous Done
+
+The webhook response may include `{ "done": true }` to immediately return to IDLE without using the callback API. When the server receives this response:
+
+1. The wake is considered claimed
+2. All streams are auto-acked to their current tail offset
+3. L1 epoch is released; consumer returns to REGISTERED
+4. Consumer transitions to IDLE
+5. If new events arrive later, a new wake cycle begins
+
+This is a shortcut for consumers that process events synchronously within the webhook handler. It is equivalent to: claim wake → ack all → L1 release → done.
+
+### Wake Batching
+
+Multiple events arriving while the consumer is IDLE produce a single wake. Events arriving while the consumer is WAKING or LIVE do not trigger additional wakes — the consumer reads new events through its existing connections.
+
+### WAKING Timeout
+
+The server waits up to 10 seconds after sending a webhook for the consumer to transition to LIVE (via 2xx response or callback claim). If neither occurs, the server retries the webhook with exponential backoff.
+
+A 2xx webhook response means the consumer has received the notification and is actively processing — the server transitions immediately to LIVE. The L1 lease TTL covers crash recovery from that point.
+
+---
+
+## Webhook Signature Verification
+
+All notifications include a `Webhook-Signature` header:
+
+```
+Webhook-Signature: t=<unix_timestamp>,sha256=<hex_signature>
+```
+
+Verification:
+
+1. Parse timestamp `t` and signature from header
+2. Check timestamp is within ±5 minutes
+3. Compute: `HMAC-SHA256(webhook_secret, "<timestamp>.<raw_body>")`
+4. Compare signatures using constant-time comparison
+
+The raw request body bytes must be used — do not parse and re-serialize JSON.
+
+---
+
+## Callback API
+
+The callback API is an L2 optimization that bundles wake claim + L1 ack into a single request. Internally, it delegates to L1 ack (via ConsumerManager).
+
+### Request
+
+```http
+POST {callback_url}
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "epoch": 7,
+  "wake_id": "w_f8a3b2c1",
+  "acks": [{ "path": "/agents/task-123", "offset": "1005" }],
+  "subscribe": ["/tools/task-123"],
+  "unsubscribe": ["/old-stream"],
+  "done": true
+}
+```
+
+### Fields
+
+| Field         | Required            | Description                                |
+| ------------- | ------------------- | ------------------------------------------ |
+| `epoch`       | Yes                 | Must match current consumer epoch (L1)     |
+| `wake_id`     | First callback only | Claims the wake (WAKING → LIVE)            |
+| `acks`        | No                  | Acknowledge processed offsets (via L1 ack) |
+| `subscribe`   | No                  | Subscribe to additional streams            |
+| `unsubscribe` | No                  | Unsubscribe from streams                   |
+| `done`        | No                  | Signal processing is complete              |
+
+### Semantics
+
+- Callbacks are processed **serially** per consumer
+- All operations are **idempotent** — safe to retry on timeout
+- Each request is **atomic** — succeeds or fails as a unit
+- Any callback (even `{ "epoch": N }`) triggers an empty L1 ack, resetting the lease timer
+
+### Success Response
+
+```json
+{
+  "ok": true,
+  "token": "eyJ...",
+  "streams": [
+    { "path": "/agents/task-123", "offset": "1005" },
+    { "path": "/tools/task-123", "offset": "42" }
+  ]
+}
+```
+
+- `token` — L1 bearer token for the next callback (refreshed when nearing expiry)
+- `streams` — Current subscribed streams with offsets (always included)
+
+### Error Responses
+
+| Status | Code              | Description                                      |
+| ------ | ----------------- | ------------------------------------------------ |
+| 400    | `INVALID_REQUEST` | Malformed JSON, missing epoch                    |
+| 401    | `TOKEN_EXPIRED`   | Token TTL exceeded (response includes new token) |
+| 401    | `TOKEN_INVALID`   | Token is malformed or signature invalid          |
+| 409    | `ALREADY_CLAIMED` | wake_id does not match current wake              |
+| 409    | `INVALID_OFFSET`  | Ack offset is invalid (e.g., beyond tail)        |
+| 409    | `STALE_EPOCH`     | Callback epoch < current epoch (zombie)          |
+| 410    | `CONSUMER_GONE`   | Consumer instance no longer exists               |
+
+Error response body:
+
+```json
+{
+  "ok": false,
+  "error": { "code": "STALE_EPOCH", "message": "..." },
+  "token": "eyJ..."
+}
+```
+
+For `TOKEN_EXPIRED`, the new token in the error response can be used to retry. For `STALE_EPOCH`, the consumer should stop processing. For `ALREADY_CLAIMED`, the wake_id does not match the current wake — the consumer should stop.
+
+### Offset Semantics
+
+Offsets are **"last processed inclusive"**:
+
+- `"1005"` means events through 1005 have been processed
+- Next read starts from `"1006"`
+- `"-1"` means no events processed yet
+
+### Dynamic Subscribe
+
+- New subscriptions start at current tail (new events only)
+- Subscribing to non-existent streams is allowed (lazy)
+- No validation of stream paths
+- Both L1 stream set and L2 stream-to-consumer index are updated atomically — appends to newly subscribed streams will correctly wake the consumer
+
+### Dynamic Unsubscribe
+
+- Can unsubscribe from any stream including primary
+- Unsubscribing from all streams removes the consumer
+- Both L1 stream set and L2 stream-to-consumer index are updated atomically
+- If the primary stream is unsubscribed, `primary_stream` is updated to the next remaining stream
+
+### Callback Tokens
+
+Tokens are the L1 bearer tokens issued at acquire time. They are HMAC-signed with a 1-hour TTL. Every successful response includes a token (refreshed when nearing expiry). Tokens encode consumer_id, epoch, and expiry. Passed via `Authorization: Bearer` header.
+
+---
+
+## Subscription HTTP API
+
+Subscriptions use the glob pattern as the URL path with query parameters for CRUD operations.
+
+### Create
+
+```http
+PUT /agents/*?subscription=agent-handler
+Content-Type: application/json
+
+{ "webhook": "https://my-agent.workers.dev/handler", "description": "..." }
+
+→ 201 Created
+{
+  "subscription_id": "agent-handler",
+  "pattern": "/agents/*",
+  "webhook": "https://my-agent.workers.dev/handler",
+  "webhook_secret": "whsec_abc123...",
+  "description": "..."
+}
+```
+
+`webhook_secret` is only returned on creation. Idempotent create (same ID + same configuration) returns `200` without the secret. Create with same ID but different configuration returns `409 Conflict`.
+
+### List by Pattern
+
+```http
+GET /agents/*?subscriptions → { "subscriptions": [...] }
+```
+
+### List All
+
+```http
+GET /**?subscriptions → { "subscriptions": [...] }
+```
+
+### Get by ID
+
+```http
+GET /**?subscription=agent-handler → { "subscription_id": "agent-handler", ... }
+```
+
+Response does not include `webhook_secret`.
+
+### Delete
+
+```http
+DELETE /agents/*?subscription=agent-handler → 204 No Content
+```
+
+Cascade: all consumer instances for this subscription are immediately removed (L1 consumers deleted). In-flight callbacks receive `410 CONSUMER_GONE`.
+
+---
+
+## Failure Handling
+
+### Webhook Request Timeout
+
+30 seconds. If the endpoint does not respond within this window, the request is considered failed.
+
+### Retry Schedule
+
+Failed webhook deliveries (timeout, network error, non-2xx response) are retried with exponential backoff:
+
+- Retries 1-10: `min(2^n × 100ms, 30s)` + up to 1s jitter
+- Retries 11+: 60s + up to 5s jitter
+
+A 2xx response stops retries — the consumer transitions to LIVE and the L1 lease timer handles recovery if the consumer crashes.
+
+### Delivery Guarantee
+
+At-least-once. Consumers must handle duplicate events idempotently.
+
+### Partial Failure
+
+If a consumer acks some events and then crashes, the next wake resumes from the last acknowledged offset (durably stored by L1).
+
+---
+
+## Garbage Collection
+
+Consumer instances are removed when:
+
+| Condition                         | Effect                                       |
+| --------------------------------- | -------------------------------------------- |
+| Primary stream deleted            | Consumer removed (L1 consumer deleted)       |
+| Subscription deleted              | All consumers removed (L1 consumers deleted) |
+| Unsubscribe from all streams      | Consumer removed (L1 consumer deleted)       |
+| 3 days continuous webhook failure | Consumer removed (L1 consumer deleted)       |
+
+When a consumer is removed, all internal subscriptions to secondary streams are cleaned up. Subsequent callbacks receive `410 CONSUMER_GONE`.
+
+---
+
+## Existing Streams
+
+When a subscription is created and matching streams already exist, no consumer instances are created immediately. Consumers are created lazily on the first append to a matching stream (see § Consumer Instance). This means:
+
+- No upfront cost for subscriptions covering many existing streams
+- Consumers materialize only when there is actual work to do
+- Assumption: existing streams were handled by a previous subscription
+
+---
+
+## L2/A Safety Invariants
+
+**S2 — Wake ID Uniqueness**: Each wake cycle produces exactly one wake_id. Retries of the same webhook notification reuse the same wake_id — uniqueness is per wake cycle (IDLE → WAKING transition), not per HTTP request.
+
+**S3 — Idempotent Claim**: Claiming the current wake_id is idempotent. Callbacks with a non-matching wake_id are rejected with `ALREADY_CLAIMED`.
+
+**S7 — Gone After Delete**: After a subscription or primary stream is deleted, callbacks for affected consumers return `CONSUMER_GONE`.
+
+**S8 — Signature Presence**: Every webhook notification includes a valid `Webhook-Signature` header verifiable with the subscription's `webhook_secret`.
+
+---
+
+## L2/A Liveness Properties
+
+**L2-L1 — Pending Work Causes Wake**: If pending work exists when the consumer is IDLE, a webhook notification is eventually delivered (subject to retry schedule).
+
+**L2-L2 — Done Without Pending Reaches IDLE**: A `done: true` callback when no pending work exists transitions the consumer to IDLE without re-wake.
+
+**L2-L3 — Done With Pending Causes Re-wake**: A `done: true` callback when pending work exists triggers an immediate new wake cycle (L1 epoch re-acquired, new wake_id generated).
+
+---
+
+## L2/A Implementation Notes
+
+### wake_id Claiming Retained
+
+The dialectic's synthesis concluded that `wake_id` claiming is largely subsumed by epoch fencing (L1). In practice, the implementation retains `wake_id_claimed` on `WebhookConsumer` for retry idempotency:
+
+- When the same webhook is retried before the consumer has called back, the same `wake_id` is used for all retry attempts
+- Once claimed (either via 2xx response or callback), subsequent retries are suppressed
+- This is an L2 concern that complements (rather than duplicates) L1 epoch fencing
+
+### Implicit L1 Registration from Webhook Flows
+
+The full dialectic ideal separates L1 registration (performed independently by the consumer) from L2 subscription creation (performed by the webhook subscriber). In the current implementation, `WebhookManager` creates the L1 consumer lazily on first append to a matching stream. This means:
+
+- L1 consumers are created implicitly by L2/A webhook flows (on first data arrival)
+- A consumer cannot independently register itself at L1 without going through L2 subscription creation (for webhook consumers)
+- The `/consumers` endpoint supports independent registration (for non-webhook consumers), but webhook consumers bypass this path
+
+These are known areas where the L1/L2 boundary is not yet fully clean. The specs document the _actual_ achieved separation: L1 provides consumer identity, epoch, ack, and lease; L2 provides webhook wake/retry/GC. The implicit coupling in registration and the retained `wake_id_claimed` state are acknowledged compromises.
+
+### L1/L2 Index Duality
+
+The webhook layer maintains two parallel indexes for stream-to-consumer mapping:
+
+- **L1 index** (`ConsumerStore.streamConsumers`): Maps stream paths to consumer IDs. Updated by L1 operations (registration, addStreams, removeStreams).
+- **L2 index** (`WebhookStore.streamConsumers`): Maps stream paths to consumer IDs. Used by `onStreamAppend()` to find consumers to wake.
+
+Both indexes must stay in sync. During callback subscribe/unsubscribe, the implementation updates both L1 (via `ConsumerManager`) and L2 (via `WebhookStore.addStreamIndex`/`removeStreamIndex`) atomically. A desync between these indexes would cause appends to newly subscribed streams to silently fail to wake the consumer.
+
+### Payload Enrichment
+
+The webhook manager supports an optional `enrichPayload` hook that can inject additional context into webhook payloads before delivery. If enrichment fails (e.g., a DARIX entity lookup throws), the epoch is released, the consumer transitions to IDLE, and a delayed re-wake is scheduled with exponential backoff. This prevents a hot retry loop while still ensuring the consumer eventually receives the notification once enrichment succeeds.
+
+---
+
+## Part III — Layer 2/B: Pull-Wake Mechanism
+
+The pull-wake mechanism provides an alternative to webhooks for environments where workers can actively poll for work. Instead of the server pushing notifications via HTTP, it writes wake events to a **Durable Stream** that workers read using the standard L0 protocol.
+
+### Concepts
+
+#### Wake Stream
+
+A Durable Stream designated as the notification channel for a consumer. The server writes structured events to this stream:
+
+- **`wake`**: Signals that a consumer has pending work and needs processing. Contains the stream path and consumer ID.
+- **`claimed`**: Records that a worker has successfully acquired the consumer's epoch. Contains the worker identity, epoch, and stream path.
+
+Workers read the wake stream using standard L0 long-poll or SSE, then race to claim work via `POST /consumers/{id}/acquire`.
+
+#### Consumer Registration
+
+Pull-wake consumers are registered via the L1 API with a `wake_preference` specifying the wake stream:
+
+```http
+POST /consumers
+Content-Type: application/json
+
+{
+  "consumer_id": "my-worker:task-123",
+  "streams": ["/agents/task-123"],
+  "wake_preference": {
+    "type": "pull-wake",
+    "wake_stream": "/wake/my-pool"
+  }
+}
+```
+
+### Worker Flow
+
+1. Worker long-polls the wake stream for new events
+2. On receiving a `wake` event, worker calls `POST /consumers/{id}/acquire`
+3. If acquire succeeds, worker reads events, acks progress, and releases when done
+4. If acquire fails (`EPOCH_HELD` or `INTERNAL_ERROR`), another worker claimed it — skip
+
+### L1/L2 Coupling via Critical Callbacks
+
+Pull-wake registers a **critical** epoch-acquired callback on L1. When any code (including L2/A webhook flows) acquires a consumer's epoch, the pull-wake manager appends a `claimed` event to the wake stream. If this append fails, the critical callback mechanism rolls back the acquire — this ensures the wake stream always reflects the true epoch state.
+
+### L2/B Safety Invariants
+
+**S-PW1 — Wake Event on Pending Work**: When pending work exists for a pull-wake consumer in REGISTERED state, a `wake` event is appended to the wake stream.
+
+**S-PW2 — Claimed Event on Acquire**: Every successful epoch acquisition appends a `claimed` event to the wake stream. This is guaranteed by the critical callback mechanism — if the append fails, the acquire itself fails.
+
+**S-PW3 — No Duplicate Wakes While Reading**: While the consumer is in READING state, new appends to subscribed streams do not produce additional wake events.
+
+---
+
+## Security Considerations
+
+### Webhook Signature Verification
+
+All webhook notifications are signed. Consumers should verify signatures before processing. Signatures include timestamps to prevent replay attacks.
+
+### SSRF Prevention
+
+Implementations should:
+
+- Require HTTPS for webhook URLs (except localhost in development)
+- Block private IP ranges (RFC 1918, link-local, loopback)
+- Block cloud metadata endpoints (169.254.169.254)
+
+### Callback Token Security
+
+- Tokens are passed via `Authorization` header (not in URLs) to avoid logging
+- Tokens are HMAC-signed with server secret, not stored in a database
+- Tokens include consumer_id and epoch, preventing cross-consumer use

--- a/docs/webhooks-rfc.md
+++ b/docs/webhooks-rfc.md
@@ -1,0 +1,768 @@
+# Webhooks RFC
+
+> **Note:** The webhook system described in this RFC has been implemented and is now
+> part of the layered consumer protocol (L0/L1/L2). See [RFC: Layered Consumer Protocol](https://github.com/electric-sql/durable-streams/issues/23)
+> for the architecture that separates consumer identity (L1) from webhook wake-up (L2).
+> The webhook behavior described here is preserved as Layer 2 Mechanism A.
+>
+> **Implementation notes (actual vs. ideal layering):**
+>
+> 1. **wake_id claiming**: The RFC's dialectic concluded that `wake_id` claiming is
+>    subsumed by epoch fencing. The implementation retains `wake_id_claimed` on
+>    `WebhookConsumer` for retry idempotency — this is a known L1/L2 boundary compromise.
+> 2. **Implicit L1 registration from webhook flows**: The dialectic's registration-vs-notification
+>    split says L2 should attach to an independently-existing L1 consumer. The implementation
+>    still has `WebhookManager` create L1 consumers during subscription creation. This is a
+>    known area where the L1/L2 boundary is not yet fully clean.
+>
+> The restructured specs (`docs/layered-consumer-spec.md` and `PROTOCOL.md` §§ 6–7) document the
+> _actual_ achieved separation: L1 provides consumer identity, epoch, ack, and lease; L2
+> provides wake-up mechanisms (L2/A webhook, L2/B pull-wake).
+
+## Summary
+
+Serverless functions and AI agents need to react to events without holding persistent connections, but Durable Streams currently only supports pull-based consumption. This RFC adds webhook-based push delivery: register a subscription with a glob pattern and webhook URL, and the server will POST notifications when matching streams receive events. Each matched stream spawns a consumer instance that can dynamically subscribe to additional streams (e.g., an agent subscribing to its task queue plus shared filesystem and tool outputs), with the server tracking offsets across all subscribed streams as a unit. Consumers read events using the standard Durable Streams client, use a scoped callback URL to acknowledge progress and manage subscriptions, and signal completion when done—or get re-woken when new events arrive. The implementation adds subscription CRUD endpoints, consumer instance lifecycle management, exponential backoff retry for failed webhooks, and OpenTelemetry integration for debugging.
+
+## Background
+
+Modern event-driven architectures increasingly run on serverless functions (Cloudflare Workers, AWS Lambda, etc.) where compute spins up only when there's work to do. This pattern is particularly common for AI agent systems, where each agent instance handles a specific task and may need to coordinate across multiple event streams—its own task queue, shared resources, tool outputs.
+
+Durable Streams currently requires consumers to actively poll or maintain persistent connections (long-poll, SSE) to receive events. This works for always-on services but creates friction for serverless deployments:
+
+- Functions can't hold open connections waiting for events
+- Polling from cold functions is wasteful and adds latency
+- Coordinating reads across multiple related streams requires complex client logic
+
+A push-based delivery model—where the server notifies consumers when events arrive—would let serverless functions wake on demand, process events, and shut down cleanly.
+
+### Related Systems
+
+This design draws from several comparable systems:
+
+- **Apache Kafka** — Consumer group protocol with session timeouts, consumer epochs for fencing zombie consumers, and KIP-848 server-side assignment
+- **NATS JetStream** — Push consumers with ack-wait timeouts, max_ack_pending flow control, and delivery policies
+- **Restate** — Virtual Objects with single-writer semantics and keyed state management
+- **Inngest** — Serverless function orchestration with step-based execution and event-driven invocation
+- **Svix/Hookdeck** — Webhook delivery infrastructure with signature verification, retry schedules, and dead letter queues
+
+## Problem
+
+Serverless functions cannot efficiently consume Durable Streams today. The current pull-based model requires either:
+
+1. **Persistent connections** (long-poll/SSE) — incompatible with serverless execution limits
+2. **Periodic polling** — wasteful, adds latency, and doesn't scale when an agent needs to monitor multiple streams
+
+This gap blocks a key use case: **multi-agent systems** where each agent instance needs to:
+
+- React to events on its primary task stream
+- Dynamically subscribe to additional streams (shared filesystem, tool outputs, coordination channels)
+- Maintain offsets across all subscribed streams as a unit
+- Resume exactly where it left off after being idle
+
+Without server-side push, building this requires external orchestration (separate queue systems, workflow engines) that duplicates what Durable Streams already provides—durable, resumable, ordered event delivery.
+
+**Constraints:**
+
+- Must work with serverless functions that have 30-second to 5-minute execution limits
+- Must handle webhook endpoint failures gracefully (deploys, outages, bugs)
+- Protocol must support distributed deployments, even if reference implementations are single-server
+- No authentication built-in (handled at deployment layer, consistent with existing protocol)
+
+## Proposal
+
+### Overview
+
+Add a webhook-based push delivery system to Durable Streams. The core concepts:
+
+- **Subscription**: A registration that maps a glob pattern to a webhook URL. When streams matching the pattern receive events, the server notifies the webhook.
+- **Consumer Instance**: Spawned when a stream matches a subscription's pattern. Each instance has its own identity, epoch (for fencing), offsets, and can dynamically subscribe to additional streams.
+- **Callback**: A scoped URL that consumer instances use to acknowledge progress, subscribe to additional streams, and signal completion.
+
+### Subscription Model
+
+A subscription is registered via HTTP API and consists of:
+
+- `subscription_id`: Client-provided identifier for this subscription
+- `pattern`: Glob pattern matching stream paths (e.g., `/agents/*`)
+- `webhook`: URL to POST notifications to
+- `webhook_secret`: Server-generated secret for signature verification (returned on creation, not stored retrievably)
+- `description`: Optional human-readable description
+- `internal`: Optional boolean flag indicating this is an internal subscription (for secondary stream coordination)
+
+When a stream is created or receives events that match the pattern, the server spawns a consumer instance (if one doesn't exist) and wakes it.
+
+Subscriptions marked as `internal: true` may be routed differently by implementations (e.g., direct function calls instead of HTTP in single-server deployments), but the behavior is identical.
+
+**Glob patterns** support wildcards:
+
+- `*` matches exactly one path segment
+- `**` matches zero or more path segments (recursive)
+- `/agents/*` matches `/agents/task-123` but not `/agents/foo/bar`
+- `/agents/**` matches `/agents/task-123` and `/agents/foo/bar/baz`
+- `/agents/*/inbox` matches `/agents/worker-1/inbox`
+
+### Consumer Instance Lifecycle
+
+```
+Stream matches subscription pattern
+              │
+              ▼
+┌─────────────────────────────────┐
+│  CONSUMER INSTANCE              │
+│  id: {subscription_id}:{stream_path} │
+│  epoch: 1                       │
+│  primary: /agents/task-123      │
+│  streams: [primary]             │
+│  state: IDLE                    │
+└───────────────┬─────────────────┘
+                │ events arrive on any subscribed stream
+                │ epoch incremented, wake_id generated
+                ▼
+┌─────────────────────────────────┐
+│  state: WAKING                  │
+│  epoch: 2, wake_id: "w_abc123"  │
+│  POST webhook with notification │
+│  (re-deliver until claimed)     │
+└───────────────┬─────────────────┘
+                │
+        ┌───────┴───────┐
+        │               │
+        ▼               ▼
+   (callback       (webhook responds
+    claims           { done: true })
+    wake_id,              │
+    OR webhook            │
+    returns 2xx)          │
+        │                 │
+        ▼                 ▼
+┌───────────────┐         │
+│  state: LIVE  │◄──┐     │
+│  epoch: 2     │   │     │
+│  processing   │   │     │
+└───────┬───────┘   │     │
+        │           │     │
+        │ callback  │     │
+        │ activity  │     │
+        └───────────┘     │
+        │                 │
+        │ 45s timeout     │
+        │ OR { done }     │
+        ▼                 │
+┌─────────────────────────┴───────┐
+│  state: IDLE                    │
+│  epoch: 2                       │
+│  (offsets preserved)            │
+└─────────────────────────────────┘
+```
+
+**Pending work definition:**
+
+Pending work exists when any subscribed stream has unprocessed events:
+
+```
+pending_work = any(tail[path] > acked[path] for path in subscribed_streams)
+```
+
+Where:
+
+- `acked[path]` is the last acknowledged offset (inclusive - this event was processed)
+- `tail[path]` is the current end offset of the stream
+- Offset `-1` means "before any events" (nothing acked yet)
+
+This definition drives wake decisions, re-wake after timeouts, and whether `{done: true}` transitions to IDLE.
+
+**State transitions:**
+
+1. **IDLE → WAKING**: `pending_work` becomes true; epoch is incremented, new `wake_id` generated
+2. **WAKING → LIVE**: Webhook responds 2xx, OR first callback claims the `wake_id` (subsequent callbacks with same wake_id are idempotent; callbacks with a non-matching wake_id receive `409 ALREADY_CLAIMED`)
+3. **WAKING → IDLE**: Consumer responds with `{ done: true }` AND `pending_work` is false
+4. **LIVE → IDLE**: Consumer sends `{ done: true }` in callback AND `pending_work` is false, OR 45-second timeout with no callback activity
+5. **Re-wake**: If `{done: true}` is received but `pending_work` is still true, immediately trigger a new wake (increment epoch, new wake_id)
+
+**Epoch and wake_id for fencing:** Two identifiers work together to prevent split-brain scenarios:
+
+- **`epoch`**: Monotonically increasing counter that increments on each IDLE → WAKING transition. Callbacks with a stale epoch are rejected with `409 STALE_EPOCH`. This is analogous to producer epochs in the existing Durable Streams protocol.
+- **`wake_id`**: Unique identifier for each wake attempt within an epoch. The first callback claiming a `wake_id` wins; subsequent callbacks with the same `wake_id` receive `409 ALREADY_CLAIMED`. This handles duplicate webhook deliveries (retries before claim).
+
+**Wake transition:** A 2xx webhook response means the consumer has received the notification and is actively processing — the server transitions immediately to LIVE. The 45-second liveness timeout covers crash recovery from that point. This design supports serverless functions that hold the webhook connection open during processing. If the webhook fails (non-2xx, timeout, network error), the server retries with exponential backoff until a callback claims the `wake_id` or the webhook succeeds.
+
+**Webhook connection model:** The webhook connection can be held open for the platform's execution limit (e.g., 15 minutes on some serverless platforms). The server tracks consumer liveness via callback activity, not the webhook connection. Consumers should call the callback regularly (at least every 45 seconds) to stay alive. If the webhook connection closes without `{ done: true }` and no recent callback activity, the server treats this as a crash and will re-wake if there's pending work.
+
+**Timeout (45 seconds):** Any callback request (including empty `{}`) resets the timeout. If no callback activity occurs within 45 seconds, the consumer transitions to IDLE. Consumers doing slow processing should send periodic callbacks (even just re-acking the same offset) to stay alive.
+
+**Consumer instance identity** is `{subscription_id}:{url_encoded_stream_path}`. The stream path is URL-encoded to avoid parsing ambiguity (paths contain `/`). Multiple subscriptions can match the same stream, each creating independent consumer instances.
+
+### Wake-up Notification
+
+When waking a consumer, the server POSTs to the webhook:
+
+```http
+POST https://my-agent.workers.dev/handler
+Content-Type: application/json
+Webhook-Signature: t=1704067200,sha256=a1b2c3d4e5f6...
+
+{
+  "consumerId": "sub_a1b2c3d4:%2Fagents%2Ftask-123",
+  "epoch": 7,
+  "wakeId": "w_f8a3b2c1",
+  "streamPath": "/agents/task-123",
+  "streams": [
+    { "path": "/agents/task-123", "offset": "1002" },
+    { "path": "/shared-filesystem/task-123", "offset": "500" }
+  ],
+  "triggeredBy": ["/agents/task-123", "/shared-filesystem/task-123"],
+  "callback": "https://streams.example.com/callback/sub_a1b2c3d4/%2Fagents%2Ftask-123",
+  "claimToken": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
+**Headers:**
+
+- `Webhook-Signature`: Signature for verification (see Webhook Signature Verification below)
+
+**Payload fields:**
+
+- `consumerId`: Unique identifier for this consumer instance
+- `epoch`: Current epoch; consumers must include this in callback requests for fencing
+- `wakeId`: Unique identifier for this wake attempt; consumers must include this in their first callback to claim the wake
+- `streamPath`: Canonical main stream path for the wake
+- `streams`: All streams this consumer is subscribed to, with their last acknowledged offset
+- `triggeredBy`: Array of stream paths that have pending events (informational—consumer should read from all streams based on their offsets, not just triggered ones)
+- `callback`: Scoped URL for acknowledgments and subscription changes
+- `claimToken`: Initial callback credential; use in `Authorization: Bearer` header for first callback
+
+The webhook can respond with `{ "done": true }` to immediately return to IDLE (for simple synchronous processing). This counts as claiming the wake—the server will not redeliver.
+
+**Wake-up batching:** If multiple events arrive on subscribed streams while the consumer is IDLE, they are batched into a single wake-up. The server does not wake the consumer multiple times—one wake-up per IDLE → WAKING transition.
+
+**No re-wake while LIVE:** If the consumer is already LIVE (actively processing), new events on subscribed streams do not trigger additional wake-ups. The consumer reads new events through its existing client connections.
+
+### Webhook Signature Verification
+
+All webhook notifications are signed to prevent spoofing. Consumers should verify signatures before processing.
+
+**Signature format:**
+
+```
+Webhook-Signature: t=<timestamp>,sha256=<signature>
+```
+
+- `t`: Unix timestamp (seconds) when the signature was generated
+- `sha256`: HMAC-SHA256 of `<timestamp>.<body>` using the subscription's `webhook_secret`
+
+**Verification steps:**
+
+1. Extract timestamp and signature from header
+2. Check timestamp is within acceptable window (e.g., ±5 minutes) to prevent replay attacks
+3. Compute expected signature: `HMAC-SHA256(webhook_secret, "<timestamp>.<raw_body>")`
+4. Compare signatures using constant-time comparison
+
+**Important:** Use the raw request body bytes (UTF-8, as received) for signature verification. Do not parse and re-stringify JSON—this can change whitespace or key order and break the signature.
+
+**Example verification:**
+
+```typescript
+import { createHmac, timingSafeEqual } from "crypto"
+
+function verifyWebhookSignature(
+  body: string,
+  signatureHeader: string,
+  secret: string,
+  toleranceSeconds = 300
+): boolean {
+  const match = signatureHeader.match(/t=(\d+),sha256=([a-f0-9]+)/)
+  if (!match) return false
+
+  const [, timestamp, signature] = match
+  const ts = parseInt(timestamp, 10)
+
+  // Check timestamp is within tolerance
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - ts) > toleranceSeconds) return false
+
+  // Compute expected signature
+  const payload = `${timestamp}.${body}`
+  const expected = createHmac("sha256", secret).update(payload).digest("hex")
+
+  // Constant-time comparison
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+}
+```
+
+### Event Reading
+
+The webhook notification tells the consumer _what_ to read, not the events themselves. Consumers read events using **standard Durable Streams HTTP reads** via the client library.
+
+This separation keeps the webhook system focused on coordination while leveraging the existing protocol for data transfer. Authentication for reading streams is handled at the deployment layer, same as existing reads.
+
+### Callback API
+
+The callback URL is scoped to the specific consumer instance. The claim token is passed via the `Authorization` header to avoid logging exposure; it handles authentication and expiry (1 hour TTL) only. Fencing is handled by `epoch` and `wakeId`.
+
+```http
+POST {callback}
+Authorization: Bearer eyJ...
+Content-Type: application/json
+
+{
+  "epoch": 7,
+  "wakeId": "w_f8a3b2c1",
+  "acks": [
+    { "path": "/agents/task-123", "offset": "1005" },
+    { "path": "/shared-filesystem/task-123", "offset": "520" }
+  ],
+  "subscribe": ["/tools/task-123"],
+  "unsubscribe": ["/some-old-stream"],
+  "done": true
+}
+```
+
+**Required fields:**
+
+- `epoch`: Must match current consumer epoch (fencing)
+- `wakeId`: Must be included in first callback to claim the wake; optional in subsequent callbacks
+
+**Optional fields:**
+
+- `acks`, `subscribe`, `unsubscribe`, `done`: All optional
+
+**Callback semantics:**
+
+- Callbacks are processed **serially** per consumer instance (no concurrent processing)
+- All operations are **idempotent**—safe to retry on timeout
+- Requests are **atomic**—entire request succeeds or fails together
+- Any callback (even empty `{}`) resets the 45-second timeout
+
+**Success response:**
+
+```json
+{
+  "ok": true,
+  "claimToken": "eyJ...",
+  "streams": [
+    { "path": "/agents/task-123", "offset": "1005" },
+    { "path": "/shared-filesystem/task-123", "offset": "520" },
+    { "path": "/tools/task-123", "offset": "42" }
+  ]
+}
+```
+
+- `claimToken`: New callback credential (always included; consumer should use this for subsequent requests)
+- `streams`: Current list of all subscribed streams with their offsets (always included)
+
+**Error responses:**
+
+| Status | Code              | Description                                                                 |
+| ------ | ----------------- | --------------------------------------------------------------------------- |
+| 400    | `INVALID_REQUEST` | Malformed JSON, unknown fields                                              |
+| 401    | `TOKEN_EXPIRED`   | Callback token has expired (response includes new token)                    |
+| 401    | `TOKEN_INVALID`   | Callback token is malformed or signature invalid                            |
+| 409    | `ALREADY_CLAIMED` | This `wake_id` was already claimed by another callback (duplicate delivery) |
+| 409    | `INVALID_OFFSET`  | Ack offset is invalid (e.g., beyond stream tail)                            |
+| 409    | `STALE_EPOCH`     | Callback epoch is older than current consumer epoch (zombie consumer)       |
+| 410    | `CONSUMER_GONE`   | Consumer instance no longer exists (subscription deleted)                   |
+
+Error response body:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "STALE_EPOCH",
+    "message": "Consumer epoch 5 is stale; current epoch is 7"
+  },
+  "claimToken": "eyJ..."
+}
+```
+
+For `TOKEN_EXPIRED`, a new claim token is included in the error response—consumer should retry with the new token.
+
+For `STALE_EPOCH`, the consumer should stop processing—a newer instance has taken over.
+
+For `ALREADY_CLAIMED`, another callback already claimed this wake—the consumer should stop processing (this typically happens with duplicate webhook deliveries due to retries).
+
+**Offset semantics:**
+
+Offsets are **"last processed inclusive"**—the offset value represents the last event that was successfully processed. This means:
+
+- Offset `"1005"` means events up to and including 1005 have been processed
+- Next read should start from offset `"1006"`
+- Offset `"-1"` means no events have been processed yet (start from beginning)
+
+**Subscribe behavior:**
+
+- New subscriptions start at current tail (new events only)
+- Subscribing to a non-existent stream is allowed—consumer will be woken when the stream is created and receives its first event (useful for tool output streams that appear during execution)
+- No validation of stream paths; typos won't be caught until the stream fails to appear
+
+**Unsubscribe behavior:**
+
+- Consumer can unsubscribe from any stream including its primary
+- Unsubscribing from primary is valid—any remaining subscribed stream can still wake the consumer
+- Unsubscribing from all streams removes the consumer instance
+
+**Stream removal:** If a subscribed stream is deleted, it is silently removed from the consumer's subscription list. The next callback response will show the updated `streams` array without the deleted stream.
+
+### Secondary Subscriptions (Internal Webhooks)
+
+When a consumer subscribes to streams beyond its primary, the coordination works via internal webhooks:
+
+1. Primary stream's server creates a subscription on the secondary stream (marked as `internal: true`)
+2. Secondary stream sends webhook notifications to the primary stream's server (not directly to the consumer)
+3. Primary stream decides whether to wake the consumer (if IDLE) or let the callback loop handle it (if LIVE)
+
+This model:
+
+- Uses the same webhook mechanism everywhere (including HMAC signature verification for internal webhooks)
+- Works naturally in distributed deployments where streams live on different servers
+- Keeps the primary stream as single source of truth for consumer state
+
+For single-server deployments, implementations may optimize internal subscriptions (e.g., direct function calls). For distributed deployments, it's HTTP between servers with the same signature verification. The routing optimization is implementation-specific.
+
+### Failure Handling
+
+**Webhook request timeout:** The server waits up to 30 seconds for a response from the webhook endpoint. If the endpoint hangs beyond this, the request is considered failed and enters the retry loop.
+
+**Retry on failure:** The server retries webhook delivery on failure (non-2xx, timeout, network error) until a callback claims the `wake_id` or a 2xx response transitions the consumer to LIVE. A 2xx response means the consumer is actively processing — the liveness timeout handles crash recovery.
+
+**Webhook delivery retries** use exponential backoff (AWS standard algorithm):
+
+- Initial retry with exponential backoff up to 30 seconds between attempts
+- Then retry every 60 seconds with jitter
+- Retries continue until claimed, but consumer instances are GC'd after 3 days of consecutive webhook failures (see Garbage Collection)
+
+This ensures consumers auto-recover after deploys, outages, or bug fixes without manual intervention.
+
+**Delivery guarantee** is at-least-once. Consumers must handle duplicate events idempotently.
+
+**Partial failures**: If a consumer processes some events and acks progress but crashes before completing, the next wake-up resumes from the last acknowledged offset.
+
+### Garbage Collection
+
+Consumer instances are removed when:
+
+- Primary stream is deleted
+- Webhook errors continuously for 3 days
+- Consumer unsubscribes from all streams (including primary)
+
+When a consumer instance is removed, all its internal webhook subscriptions to secondary streams are also cleaned up.
+
+No explicit deletion API is needed—unsubscribe handles cleanup.
+
+### Subscription HTTP API
+
+Subscriptions use the glob pattern as the URL path, with query parameters for CRUD operations. This keeps subscriptions as a property of the path namespace rather than a separate resource.
+
+**Create subscription:**
+
+```http
+PUT /agents/*?subscription=agent-handler
+Content-Type: application/json
+
+{
+  "webhook": "https://my-agent.workers.dev/handler",
+  "description": "Agent task processor"
+}
+
+→ 201 Created
+{
+  "subscription_id": "agent-handler",
+  "pattern": "/agents/*",
+  "webhook": "https://my-agent.workers.dev/handler",
+  "webhook_secret": "whsec_abc123def456...",
+  "description": "Agent task processor"
+}
+```
+
+The glob pattern (`/agents/*`) is the path; the subscription ID is provided via query parameter.
+
+**Note:** The `webhook_secret` is only returned on creation. Store it securely—it cannot be retrieved later.
+
+**URL encoding:** The `*` character is valid in URL paths but requires shell quoting (`curl 'https://.../agents/*?...'`). Servers should treat `*` and `%2A` as equivalent. Literal `*` stream names are not supported.
+
+**List subscriptions under a pattern:**
+
+```http
+GET /agents/*?subscriptions
+→ { "subscriptions": [...] }
+```
+
+**List all subscriptions (search all patterns):**
+
+```http
+GET /**?subscriptions
+→ { "subscriptions": [...] }
+```
+
+**Get subscription by ID (search all patterns):**
+
+```http
+GET /**?subscription=agent-handler
+→ { "subscription_id": "agent-handler", "pattern": "/agents/*", ... }
+```
+
+(Does not include `webhook_secret`)
+
+**Delete subscription:**
+
+```http
+DELETE /agents/*?subscription=agent-handler
+→ 204 No Content
+```
+
+When a subscription is deleted, all its consumer instances are immediately removed. Any in-flight callback requests will receive `410 CONSUMER_GONE`.
+
+Subscriptions are immutable—to change the webhook URL, delete and recreate.
+
+### State Storage
+
+Subscription and consumer instance state lives in the same Store abstraction as stream data. This keeps the implementation simple and leverages existing persistence.
+
+### Existing Streams
+
+When a subscription is created and matching streams already exist:
+
+- Consumer instances are created in IDLE state
+- They wake only when new events arrive (not immediately)
+- Assumption: existing streams were handled by a previous subscription/version
+
+### Example Consumer (Serverless Function)
+
+```typescript
+import { createHmac, timingSafeEqual } from "crypto"
+import { stream } from "@durable-streams/client"
+
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!
+const PLATFORM_TIMEOUT_MS = 30_000 // e.g., Cloudflare Workers limit
+const IDLE_TIMEOUT_MS = 15_000 // exit if no messages for 15s
+const SAFETY_MARGIN_MS = 5_000 // exit 5s before platform kills us
+
+export default {
+  async fetch(request: Request) {
+    const body = await request.text()
+    const signature = request.headers.get("Webhook-Signature")
+
+    // Verify webhook signature
+    if (
+      !signature ||
+      !verifyWebhookSignature(body, signature, WEBHOOK_SECRET)
+    ) {
+      return new Response("Invalid signature", { status: 401 })
+    }
+
+    const {
+      consumer_id,
+      epoch,
+      wake_id,
+      streams: initialStreams,
+      callback,
+      token: initialToken,
+    } = JSON.parse(body)
+    const startTime = Date.now()
+
+    // Subscribe to additional streams and claim wake_id
+    // First callback claims the wake and transitions WAKING → LIVE
+    let token = initialToken
+    let subRes = await fetch(callback, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        epoch,
+        wake_id, // Claims this wake attempt
+        subscribe: [
+          `/shared-filesystem/${consumer_id}`,
+          `/tools/${consumer_id}`,
+        ],
+      }),
+    })
+
+    // Check if another instance already claimed this wake
+    const subBody = await subRes.json()
+    if (subRes.status === 409) {
+      if (subBody.error?.code === "ALREADY_CLAIMED") {
+        // Another callback already claimed this wake - exit gracefully
+        return new Response("Already claimed", { status: 200 })
+      }
+    }
+    let { streams: allStreams, token: newToken } = subBody
+    token = newToken
+
+    let lastMessageTime = Date.now()
+    const pendingAcks: Promise<Response>[] = []
+    const controller = new AbortController()
+
+    // Set up concurrent readers for all subscribed streams
+    const readers = allStreams.map((s: { path: string; offset: string }) =>
+      stream({
+        url: `https://streams.example.com${s.path}`,
+        offset: s.offset,
+        live: true,
+        signal: controller.signal,
+      }).then((res) => {
+        res.subscribeJson(async (batch) => {
+          lastMessageTime = Date.now()
+
+          for (const item of batch.items) {
+            await processEvent(s.path, item)
+          }
+
+          // Track ack promises so we can flush before exit
+          pendingAcks.push(
+            fetch(callback, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+              },
+              body: JSON.stringify({
+                epoch,
+                acks: [{ path: s.path, offset: batch.offset }],
+              }),
+            })
+              .then((res) => res.json())
+              .then((data) => {
+                token = data.token // keep token fresh
+                return data
+              })
+          )
+        })
+      })
+    )
+
+    await Promise.all(readers)
+
+    // Check exit conditions periodically
+    while (true) {
+      await sleep(1000)
+
+      const elapsed = Date.now() - startTime
+      const idleTime = Date.now() - lastMessageTime
+
+      if (elapsed >= PLATFORM_TIMEOUT_MS - SAFETY_MARGIN_MS) break
+      if (idleTime >= IDLE_TIMEOUT_MS) break
+    }
+
+    controller.abort()
+
+    // Flush pending acks before exit
+    await Promise.allSettled(pendingAcks)
+
+    // Response signals done - transitions LIVE → IDLE
+    return Response.json({ done: true })
+  },
+}
+
+function verifyWebhookSignature(
+  body: string,
+  signatureHeader: string,
+  secret: string,
+  toleranceSeconds = 300
+): boolean {
+  const match = signatureHeader.match(/t=(\d+),sha256=([a-f0-9]+)/)
+  if (!match) return false
+
+  const [, timestamp, signature] = match
+  const ts = parseInt(timestamp, 10)
+
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - ts) > toleranceSeconds) return false
+
+  const payload = `${timestamp}.${body}`
+  const expected = createHmac("sha256", secret).update(payload).digest("hex")
+
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+declare function processEvent(path: string, item: unknown): Promise<void>
+```
+
+### Security Considerations
+
+While authentication is handled at the deployment layer, implementations should consider:
+
+**Webhook signature verification:**
+
+- All webhook notifications include a `Webhook-Signature` header
+- Consumers should verify signatures before processing (see example above)
+- Signatures include timestamps to prevent replay attacks
+
+**Webhook URL validation (SSRF prevention):**
+
+- Require HTTPS for webhook URLs (except localhost in development)
+- Block private IP ranges (RFC 1918, link-local, loopback)
+- Block cloud metadata endpoints (169.254.169.254)
+- Consider allowlisting webhook domains
+
+**Callback token security:**
+
+- Tokens are passed via `Authorization` header to avoid logging exposure
+- Tokens should be signed JWTs with consumer_id, epoch, and expiry
+- Implementations should validate token signatures on every callback
+
+### Implementation Scope
+
+**In scope for v1:**
+
+- Subscription CRUD API
+- Consumer instance lifecycle (IDLE → WAKING → LIVE → IDLE, and WAKING → IDLE shortcut)
+- Consumer epochs and wake_ids for fencing zombie consumers and duplicate deliveries
+- Webhook 2xx transitions to LIVE; retry on failure until claimed or 2xx
+- Webhook signature verification
+- Wake-up notifications and callback API
+- Dynamic subscribe/unsubscribe for secondary streams
+- Internal webhook routing for secondary subscriptions (single-server)
+- Exponential backoff retry with indefinite retries
+- OpenTelemetry integration in Node.js server for debugging
+
+**Out of scope for v1:**
+
+- Distributed server implementation (protocol supports it)
+- Consumer instance listing/inspection APIs
+- Complex glob patterns (character classes, negation)
+- Authentication (handled at deployment layer)
+- Configurable callback TTL (fixed at 1 hour for v1)
+
+### Future Considerations
+
+The following features are not included in v1 but may be added based on demand:
+
+- **Backfill/replay delivery policies** — Allow subscriptions to specify `deliver_policy: "all" | "new" | "from_offset"` to control whether existing streams trigger immediate wake-ups
+- **Subscription pause/resume** — Temporarily disable webhook delivery without deleting subscription state
+- **Consumer instance inspection API** — Query consumer state for debugging (stats, state, last activity)
+- **Configurable retry schedules** — Per-subscription retry timing configuration
+- **Dead letter queue** — Capture consumer state when GC'd for inspection/replay
+
+## Definition of Success
+
+This feature is successful when a multi-agent system running on serverless functions works smoothly without DX friction. Specifically:
+
+**Functional requirements:**
+
+- Agents wake reliably when events arrive on any subscribed stream
+- Dynamic subscribe/unsubscribe works correctly mid-session
+- Offsets are preserved across wake cycles
+- Agents can stay alive processing live events, then cleanly exit
+- Failed webhooks retry indefinitely and recover automatically after deploys/fixes
+- Zombie consumers are fenced via epochs
+- Duplicate webhook deliveries are handled via wake_id claiming
+
+**Developer experience:**
+
+- Consumer code is straightforward (see example above)
+- Webhook signature verification is simple to implement
+- No external orchestration needed—Durable Streams handles coordination
+- Debugging is tractable via OpenTelemetry traces in the Node.js server
+
+**Out of scope for v1:**
+
+- Distributed server implementation (protocol supports it, reference impl is single-server)
+- Consumer instance listing/inspection APIs
+- Complex glob patterns (character classes, negation)
+- Authentication (handled at deployment layer)


### PR DESCRIPTION
Introduces webhook subscriptions for push-based event delivery, backed by a new layered consumer architecture (L1 named consumers, L2 pull-wake), plus the protocol additions, conformance suite, docs, and server-side perf work that came along the way.

## Protocol (PROTOCOL.md)
- §6 Named Consumers — mechanism-independent consumer identity with epoch fencing, offset tracking, and lease-based liveness (the L1 layer that wake mechanisms are built on).
- §7 Wake-Up Notifications — push-based wake mechanisms over L1, including webhook subscriptions and pull-wake.

New Webhook-Signature header (HMAC-SHA256) registered in §13.
Implements the layered consumer spec