### PR TITLE
feat: fetch-then-live pattern for CDN-cacheable catch-up

### DIFF
--- a/.changeset/fetch-then-live.md
+++ b/.changeset/fetch-then-live.md
@@ -1,0 +1,8 @@
+---
+"@durable-streams/client": patch
+"@durable-streams/client-conformance-tests": patch
+---
+
+Implement fetch-then-live pattern: initial requests omit the `live` query parameter so catch-up responses are cacheable by CDNs and browsers. Live mode (long-poll or SSE) activates only after the client reaches up-to-date.
+
+For SSE mode, a dedicated `startSSE` path opens a persistent connection only after HTTP catch-up completes, replacing the previous single-connection approach.

--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,8 @@ target/
 .claude/settings.local.json
 .beads
 examples/yjs-demo/.tanstack
+.opentrace/
+.tool-versions
 
 # Local Netlify folder
 .netlify

--- a/packages/client-conformance-tests/src/adapters/typescript-adapter.ts
+++ b/packages/client-conformance-tests/src/adapters/typescript-adapter.ts
@@ -418,8 +418,83 @@ async function handleCommand(command: TestCommand): Promise<TestResult> {
           finalOffset = response.offset
           upToDate = response.upToDate
           streamClosed = response.streamClosed
+        } else if (isJson) {
+          const startTime = Date.now()
+          let chunkCount = 0
+          let done = false
+
+          await new Promise<void>((resolve, reject) => {
+            const subscriptionTimeoutId = setTimeout(() => {
+              done = true
+              abortController.abort()
+              upToDate = response.upToDate || true
+              finalOffset = response.offset
+              streamClosed = response.streamClosed
+              resolve()
+            }, timeoutMs)
+
+            const unsubscribe = response.subscribeJson(async (batch) => {
+              if (done || chunkCount >= maxChunks) {
+                return
+              }
+
+              if (Date.now() - startTime > timeoutMs) {
+                done = true
+                resolve()
+                return
+              }
+
+              if (batch.items.length > 0) {
+                chunks.push({
+                  data: JSON.stringify(batch.items),
+                  offset: batch.offset,
+                })
+                chunkCount++
+              }
+
+              finalOffset = batch.offset
+              upToDate = batch.upToDate
+              streamClosed = batch.streamClosed
+
+              if (command.waitForUpToDate && batch.upToDate) {
+                done = true
+                clearTimeout(subscriptionTimeoutId)
+                resolve()
+                return
+              }
+
+              if (chunkCount >= maxChunks) {
+                done = true
+                clearTimeout(subscriptionTimeoutId)
+                resolve()
+              }
+
+              await Promise.resolve()
+            })
+
+            response.closed
+              .then(() => {
+                if (!done) {
+                  done = true
+                  clearTimeout(subscriptionTimeoutId)
+                  upToDate = response.upToDate
+                  finalOffset = response.offset
+                  streamClosed = response.streamClosed
+                  resolve()
+                }
+              })
+              .catch((err) => {
+                if (!done) {
+                  done = true
+                  clearTimeout(subscriptionTimeoutId)
+                  reject(err)
+                }
+              })
+
+            void unsubscribe
+          })
         } else {
-          // For live mode, use subscribeBytes which provides per-chunk metadata
+          // For live non-JSON mode, use subscribeBytes which provides per-chunk metadata
           const decoder = new TextDecoder()
           const startTime = Date.now()
           let chunkCount = 0

--- a/packages/client-conformance-tests/test-cases/consumer/read-sse.yaml
+++ b/packages/client-conformance-tests/test-cases/consumer/read-sse.yaml
@@ -289,23 +289,38 @@ tests:
           minChunks: 1
 
   - id: sse-strips-single-leading-space
-    name: HTTP catch-up preserves leading spaces
+    name: SSE strips only single leading space
     description: |
-      With fetch-then-live, existing data is delivered by HTTP catch-up before
-      the client transitions to SSE. EventSource data-line normalization only
-      applies to live SSE events, so catch-up must preserve leading spaces.
+      Per EventSource spec section 9.2.4: "If value starts with a
+      U+0020 SPACE character, remove it from value."
+      Only ONE space should be removed, preserving any additional spaces.
+      This test appends data after the reader reaches the tail so every client
+      receives the payload through SSE, including fetch-then-live clients.
     setup:
       - action: create
         as: streamPath
         contentType: text/plain
       - action: append
         path: ${streamPath}
-        data: "  two leading spaces"
+        data: "initial"
+        expect:
+          storeOffsetAs: tailOffset
     operations:
       - action: read
         path: ${streamPath}
+        offset: ${tailOffset}
         live: sse
-        waitForUpToDate: true
+        maxChunks: 1
+        timeoutMs: 10000
+        background: true
+        as: readOp
+      - action: wait
+        ms: 200
+      - action: server-append
+        path: ${streamPath}
+        data: "  two leading spaces"
+      - action: await
+        ref: readOp
         expect:
-          data: "  two leading spaces"
+          data: " two leading spaces"
           minChunks: 1

--- a/packages/client-conformance-tests/test-cases/consumer/read-sse.yaml
+++ b/packages/client-conformance-tests/test-cases/consumer/read-sse.yaml
@@ -289,13 +289,11 @@ tests:
           minChunks: 1
 
   - id: sse-strips-single-leading-space
-    name: SSE strips only single leading space
+    name: HTTP catch-up preserves leading spaces
     description: |
-      Per EventSource spec section 9.2.4: "If value starts with a
-      U+0020 SPACE character, remove it from value."
-      Only ONE space should be removed, preserving any additional spaces.
-      This prevents parsers from using trim() or similar which would
-      incorrectly strip all leading/trailing whitespace.
+      With fetch-then-live, existing data is delivered by HTTP catch-up before
+      the client transitions to SSE. EventSource data-line normalization only
+      applies to live SSE events, so catch-up must preserve leading spaces.
     setup:
       - action: create
         as: streamPath
@@ -309,5 +307,5 @@ tests:
         live: sse
         waitForUpToDate: true
         expect:
-          data: " two leading spaces"
+          data: "  two leading spaces"
           minChunks: 1

--- a/packages/client-conformance-tests/test-cases/consumer/sse-parsing-errors.yaml
+++ b/packages/client-conformance-tests/test-cases/consumer/sse-parsing-errors.yaml
@@ -49,6 +49,8 @@ tests:
       - action: append
         path: ${streamPath}
         data: "data-before-error"
+        expect:
+          storeOffsetAs: tailOffset
     operations:
       # Inject a control event with invalid JSON
       - action: inject-error
@@ -56,10 +58,14 @@ tests:
         injectSseEvent:
           eventType: "control"
           data: "{invalid json here"
-        count: 1
+        # Fetch-then-live makes an HTTP catch-up request before opening SSE.
+        # The first injected fault is consumed by catch-up; the second is
+        # delivered on the live SSE request.
+        count: 2
       # Client should throw a parse error
       - action: read
         path: ${streamPath}
+        offset: ${tailOffset}
         live: sse
         maxChunks: 1
         expect:
@@ -77,6 +83,8 @@ tests:
       - action: append
         path: ${streamPath}
         data: "actual-data"
+        expect:
+          storeOffsetAs: tailOffset
     operations:
       # Inject a control event with empty data
       - action: inject-error
@@ -84,10 +92,14 @@ tests:
         injectSseEvent:
           eventType: "control"
           data: ""
-        count: 1
+        # Fetch-then-live makes an HTTP catch-up request before opening SSE.
+        # The first injected fault is consumed by catch-up; the second is
+        # delivered on the live SSE request.
+        count: 2
       # Client should throw because empty is not valid JSON
       - action: read
         path: ${streamPath}
+        offset: ${tailOffset}
         live: sse
         maxChunks: 1
         expect:

--- a/packages/client-conformance-tests/test-cases/consumer/streaming-equivalence.yaml
+++ b/packages/client-conformance-tests/test-cases/consumer/streaming-equivalence.yaml
@@ -131,6 +131,7 @@ tests:
         path: ${streamPath}
         offset: ${initialOffset}
         live: long-poll
+        maxChunks: 1
         timeoutMs: 5000
         background: true
         as: longpollRead
@@ -164,6 +165,7 @@ tests:
         path: ${streamPath}
         offset: ${initialOffset}
         live: sse
+        maxChunks: 1
         timeoutMs: 5000
         background: true
         as: sseRead

--- a/packages/client-conformance-tests/test-cases/lifecycle/stream-closure.yaml
+++ b/packages/client-conformance-tests/test-cases/lifecycle/stream-closure.yaml
@@ -335,15 +335,28 @@ tests:
         contentType: text/plain
       - action: append
         path: ${streamPath}
-        data: "sse-data"
-      - action: close
-        path: ${streamPath}
+        data: "initial"
+        expect:
+          storeOffsetAs: tailOffset
     operations:
-      # Read via SSE - may need multiple chunks as SSE delivers data then control event
+      # Start at the tail, then close with a final body so the data is delivered
+      # as the SSE final event rather than as HTTP catch-up data.
       - action: read
         path: ${streamPath}
+        offset: ${tailOffset}
         live: sse
+        maxChunks: 1
         timeoutMs: 5000
+        background: true
+        as: readOp
+      - action: wait
+        ms: 200
+      - action: server-close
+        path: ${streamPath}
+        data: "sse-data"
+        contentType: text/plain
+      - action: await
+        ref: readOp
         expect:
           data: "sse-data"
           streamClosed: true

--- a/packages/client-dotnet/src/DurableStreams.ConformanceAdapter/Program.cs
+++ b/packages/client-dotnet/src/DurableStreams.ConformanceAdapter/Program.cs
@@ -420,7 +420,7 @@ async Task<object> HandleRead(JsonElement root)
 
                 if (chunkCount >= maxChunks)
                 {
-                    stoppedForMaxChunks = true;
+                    stoppedForMaxChunks = !response.StreamClosed;
                     break;
                 }
                 if (upToDate && !waitForUpToDate && live == LiveMode.Off) break;

--- a/packages/client-elixir/lib/durable_streams/http_finch.ex
+++ b/packages/client-elixir/lib/durable_streams/http_finch.ex
@@ -123,11 +123,12 @@ defmodule DurableStreams.HTTP.Finch do
               if acc.error != nil do
                 {:error, acc.error}
               else
-                {:ok, %{
-                  next_offset: acc.next_offset,
-                  up_to_date: acc.up_to_date,
-                  events_delivered: acc.events_delivered
-                }}
+                {:ok,
+                 %{
+                   next_offset: acc.next_offset,
+                   up_to_date: acc.up_to_date,
+                   events_delivered: acc.events_delivered
+                 }}
               end
           end
 
@@ -160,7 +161,15 @@ defmodule DurableStreams.HTTP.Finch do
     up_to_date = get_header(headers, "stream-up-to-date") == "true"
     # Detect encoding from the stream-sse-data-encoding response header
     encoding = get_header(headers, "stream-sse-data-encoding")
-    {:cont, %{acc | headers: headers, next_offset: next_offset, up_to_date: up_to_date, encoding: encoding}}
+
+    {:cont,
+     %{
+       acc
+       | headers: headers,
+         next_offset: next_offset,
+         up_to_date: up_to_date,
+         encoding: encoding
+     }}
   end
 
   defp handle_stream_message({:data, chunk}, acc) do
@@ -169,19 +178,25 @@ defmodule DurableStreams.HTTP.Finch do
     {events, remaining_buffer} = parse_sse_events(buffer)
 
     # Deliver each event immediately
-    acc = Enum.reduce(events, acc, fn event, acc ->
-      deliver_event(event, acc)
-    end)
+    acc =
+      Enum.reduce(events, acc, fn event, acc ->
+        deliver_event(event, acc)
+      end)
 
     new_acc = %{acc | buffer: remaining_buffer}
+
+    # Halt immediately on parse errors so malformed SSE control events do not
+    # leave the conformance adapter blocked on the open SSE connection.
+    has_error = new_acc.error != nil
 
     # Halt when up_to_date if configured
     # - halt_on_up_to_date_immediate: halt as soon as up_to_date (even with 0 events)
     # - halt_on_up_to_date: only halt if we've received some data
-    should_halt = new_acc.up_to_date and (
-      new_acc.halt_on_up_to_date_immediate or
-      (new_acc.halt_on_up_to_date and new_acc.events_delivered > 0)
-    )
+    should_halt =
+      has_error or
+        (new_acc.up_to_date and
+           (new_acc.halt_on_up_to_date_immediate or
+              (new_acc.halt_on_up_to_date and new_acc.events_delivered > 0)))
 
     if should_halt do
       {:halt, new_acc}
@@ -197,6 +212,7 @@ defmodule DurableStreams.HTTP.Finch do
   # Flush any remaining complete events from buffer
   defp flush_buffer(acc) do
     {events, _remaining} = parse_sse_events(acc.buffer)
+
     Enum.reduce(events, acc, fn event, acc ->
       deliver_event(event, acc)
     end)
@@ -280,7 +296,11 @@ defmodule DurableStreams.HTTP.Finch do
         String.starts_with?(line, "data:") ->
           data_line = String.slice(line, 5..-1//1)
           # Remove leading space if present (SSE spec)
-          data_line = if String.starts_with?(data_line, " "), do: String.slice(data_line, 1..-1//1), else: data_line
+          data_line =
+            if String.starts_with?(data_line, " "),
+              do: String.slice(data_line, 1..-1//1),
+              else: data_line
+
           %{event | data: [data_line | event.data]}
 
         String.starts_with?(line, "id:") ->
@@ -313,9 +333,14 @@ defmodule DurableStreams.HTTP.Finch do
   defp decode_sse_data(data, "base64") when is_binary(data) do
     # Remove any newlines/carriage returns per SSE protocol
     cleaned = String.replace(data, ~r/[\n\r]/, "")
+
     case Base.decode64(cleaned) do
-      {:ok, decoded} -> decoded
-      :error -> raise DurableStreams.ParseError, message: "Failed to decode base64 SSE data: invalid base64 encoding"
+      {:ok, decoded} ->
+        decoded
+
+      :error ->
+        raise DurableStreams.ParseError,
+          message: "Failed to decode base64 SSE data: invalid base64 encoding"
     end
   end
 
@@ -323,6 +348,7 @@ defmodule DurableStreams.HTTP.Finch do
 
   defp get_header(headers, name) do
     name_lower = String.downcase(name)
+
     Enum.find_value(headers, fn {k, v} ->
       if String.downcase(k) == name_lower, do: v
     end)

--- a/packages/client-go/base64_test.go
+++ b/packages/client-go/base64_test.go
@@ -53,8 +53,7 @@ func TestBase64DecodeSSEData(t *testing.T) {
 			// Create SSE response with base64-encoded data
 			sseData := "event: data\ndata: " + encoded + "\n\nevent: control\ndata: {\"streamNextOffset\":\"100\"}\n\n"
 
-			// Create test server that returns Stream-SSE-Data-Encoding header
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(catchUpThenSSE(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.Header().Set("Stream-SSE-Data-Encoding", "base64")
 				w.WriteHeader(http.StatusOK)
@@ -75,6 +74,8 @@ func TestBase64DecodeSSEData(t *testing.T) {
 			)
 			defer it.Close()
 
+			mustCatchUp(t, it)
+
 			chunk, err := it.Next()
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -92,7 +93,7 @@ func TestBase64DecodeInvalidData(t *testing.T) {
 	// Create SSE response with invalid base64 data
 	sseData := "event: data\ndata: !!!invalid-base64!!!\n\nevent: control\ndata: {\"streamNextOffset\":\"100\"}\n\n"
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(catchUpThenSSE(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Stream-SSE-Data-Encoding", "base64")
 		w.WriteHeader(http.StatusOK)
@@ -110,6 +111,8 @@ func TestBase64DecodeInvalidData(t *testing.T) {
 		WithLive(LiveModeSSE),
 	)
 	defer it.Close()
+
+	mustCatchUp(t, it)
 
 	_, err := it.Next()
 	if err == nil {
@@ -130,7 +133,7 @@ func TestBase64MultipleDataEvents(t *testing.T) {
 	// Create SSE response with two data events before control
 	sseData := "event: data\ndata: " + encoded1 + "\n\nevent: data\ndata: " + encoded2 + "\n\nevent: control\ndata: {\"streamNextOffset\":\"100\"}\n\n"
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(catchUpThenSSE(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Stream-SSE-Data-Encoding", "base64")
 		w.WriteHeader(http.StatusOK)
@@ -148,6 +151,8 @@ func TestBase64MultipleDataEvents(t *testing.T) {
 		WithLive(LiveModeSSE),
 	)
 	defer it.Close()
+
+	mustCatchUp(t, it)
 
 	chunk, err := it.Next()
 	if err != nil {
@@ -166,8 +171,7 @@ func TestSSEWithoutEncodingPassesThroughData(t *testing.T) {
 	// Create SSE response with raw (non-base64) data
 	sseData := "event: data\ndata: " + rawData + "\n\nevent: control\ndata: {\"streamNextOffset\":\"100\"}\n\n"
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// No Stream-SSE-Data-Encoding header - data should pass through as-is
+	server := httptest.NewServer(catchUpThenSSE(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(sseData))
@@ -180,9 +184,10 @@ func TestSSEWithoutEncodingPassesThroughData(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Read SSE without encoding option
 	it := stream.Read(ctx, WithLive(LiveModeSSE))
 	defer it.Close()
+
+	mustCatchUp(t, it)
 
 	chunk, err := it.Next()
 	if err != nil {
@@ -196,26 +201,25 @@ func TestSSEWithoutEncodingPassesThroughData(t *testing.T) {
 
 // TestStreamingWithBase64ReconnectDetectsEncoding tests that encoding is detected from response header on each SSE connection
 func TestStreamingWithBase64ReconnectDetectsEncoding(t *testing.T) {
-	callCount := 0
+	sseCallCount := 0
 	testData := []byte("test data")
 	encoded := base64.StdEncoding.EncodeToString(testData)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+	server := httptest.NewServer(catchUpThenSSE(func(w http.ResponseWriter, r *http.Request) {
+		sseCallCount++
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Stream-SSE-Data-Encoding", "base64")
 		w.WriteHeader(http.StatusOK)
 
-		if callCount == 1 {
-			// First call: send data and close (simulating disconnect)
+		if sseCallCount == 1 {
+			// First SSE call: send data and close (simulating disconnect)
 			sseData := "event: data\ndata: " + encoded + "\n\nevent: control\ndata: {\"streamNextOffset\":\"100\"}\n\n"
 			w.Write([]byte(sseData))
-			// Let the handler return to close the connection
 			return
 		}
 
-		// Second call: send more data
+		// Second SSE call: send more data
 		sseData := "event: data\ndata: " + encoded + "\n\nevent: control\ndata: {\"streamNextOffset\":\"200\",\"upToDate\":true}\n\n"
 		w.Write([]byte(sseData))
 	}))
@@ -232,7 +236,9 @@ func TestStreamingWithBase64ReconnectDetectsEncoding(t *testing.T) {
 	)
 	defer it.Close()
 
-	// Read first chunk
+	mustCatchUp(t, it)
+
+	// Read first SSE chunk
 	chunk1, err := it.Next()
 	if err != nil {
 		t.Fatalf("first read error: %v", err)
@@ -250,9 +256,32 @@ func TestStreamingWithBase64ReconnectDetectsEncoding(t *testing.T) {
 		t.Errorf("second chunk: got %v, want %v", chunk2.Data, testData)
 	}
 
-	// Verify we made at least 2 calls (reconnected)
-	if callCount < 2 {
-		t.Errorf("expected at least 2 server calls, got %d", callCount)
+	// Verify we made at least 2 SSE calls (reconnected)
+	if sseCallCount < 2 {
+		t.Errorf("expected at least 2 SSE calls, got %d", sseCallCount)
+	}
+}
+
+// catchUpThenSSE wraps an SSE handler with a catch-up phase that immediately
+// returns up-to-date, simulating the fetch-then-live pattern used by all tests.
+func catchUpThenSSE(sseHandler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("live") != "sse" {
+			w.Header().Set("Stream-Next-Offset", "0")
+			w.Header().Set("Stream-Up-To-Date", "true")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		sseHandler(w, r)
+	}
+}
+
+// mustCatchUp calls it.Next() and fails the test if the catch-up request errors.
+func mustCatchUp(t *testing.T, it *ChunkIterator) {
+	t.Helper()
+	_, err := it.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on catch-up: %v", err)
 	}
 }
 

--- a/packages/client-go/cmd/conformance-adapter/main.go
+++ b/packages/client-go/cmd/conformance-adapter/main.go
@@ -31,10 +31,10 @@ const clientVersion = "0.1.0"
 
 // Command types from the test runner
 type Command struct {
-	Type      string            `json:"type"`
-	ServerURL string            `json:"serverUrl,omitempty"`
-	TimeoutMs int               `json:"timeoutMs,omitempty"`
-	Path      string            `json:"path,omitempty"`
+	Type      string `json:"type"`
+	ServerURL string `json:"serverUrl,omitempty"`
+	TimeoutMs int    `json:"timeoutMs,omitempty"`
+	Path      string `json:"path,omitempty"`
 	// Create fields
 	ContentType string `json:"contentType,omitempty"`
 	TTLSeconds  int    `json:"ttlSeconds,omitempty"`
@@ -620,6 +620,15 @@ func handleRead(cmd Command) Result {
 				var parsed any
 				if err := json.Unmarshal(chunk.Data, &parsed); err != nil {
 					return errorResult("read", fmt.Errorf("failed to parse JSON response: %w", err))
+				}
+				if items, ok := parsed.([]any); ok && len(items) == 0 {
+					finalOffset = string(chunk.NextOffset)
+					upToDate = chunk.UpToDate
+					streamClosed = streamClosed || chunk.StreamClosed
+					if cmd.WaitForUpToDate && chunk.UpToDate {
+						break
+					}
+					continue
 				}
 				// Re-serialize with compact formatting to match TypeScript/Python
 				compactJSON, _ := json.Marshal(parsed)

--- a/packages/client-go/cmd/conformance-adapter/main.go
+++ b/packages/client-go/cmd/conformance-adapter/main.go
@@ -649,7 +649,7 @@ func handleRead(cmd Command) Result {
 		streamClosed = streamClosed || chunk.StreamClosed
 
 		if len(chunks) >= maxChunks {
-			stoppedForMaxChunks = true
+			stoppedForMaxChunks = !chunk.StreamClosed
 			break
 		}
 

--- a/packages/client-go/iterator.go
+++ b/packages/client-go/iterator.go
@@ -81,9 +81,10 @@ type ChunkIterator struct {
 	doneOnce bool
 
 	// SSE state
-	sseParser      *sse.Parser
-	sseResponse    *http.Response
-	ssePending     *Chunk // Pending chunk from SSE data event
+	sseStarted      bool // true once SSE mode has been entered (stays true across reconnects)
+	sseParser       *sse.Parser
+	sseResponse     *http.Response
+	ssePending      *Chunk // Pending chunk from SSE data event
 	sseDataEncoding string // Detected from Stream-SSE-Data-Encoding response header
 
 	// initErr holds any validation error from Read() to be returned on first Next()
@@ -130,8 +131,11 @@ func (it *ChunkIterator) Next() (*Chunk, error) {
 	default:
 	}
 
-	// Handle SSE mode
-	if it.live == LiveModeSSE {
+	// Handle SSE mode — only after catching up (fetch-then-live pattern).
+	// Once SSE has started, stay in SSE mode across reconnects even if
+	// UpToDate is momentarily false.
+	if it.live == LiveModeSSE && (it.sseStarted || it.UpToDate) {
+		it.sseStarted = true
 		return it.nextSSE()
 	}
 
@@ -141,8 +145,16 @@ func (it *ChunkIterator) Next() (*Chunk, error) {
 
 // nextHTTP handles regular HTTP requests (catch-up and long-poll).
 func (it *ChunkIterator) nextHTTP() (*Chunk, error) {
-	// Build the read URL
-	readURL := it.stream.buildReadURL(it.offset, it.live, it.cursor)
+	// Only set live mode when already caught up — catch-up requests without
+	// live are cacheable by CDNs/browsers (fetch-then-live pattern).
+	liveForRequest := LiveModeNone
+	if it.UpToDate {
+		switch it.live {
+		case LiveModeLongPoll, LiveModeSSE:
+			liveForRequest = LiveModeLongPoll
+		}
+	}
+	readURL := it.stream.buildReadURL(it.offset, liveForRequest, it.cursor)
 
 	// Create request
 	req, err := http.NewRequestWithContext(it.ctx, http.MethodGet, readURL, nil)

--- a/packages/client-java/conformance-adapter/src/main/java/com/durablestreams/ConformanceAdapter.java
+++ b/packages/client-java/conformance-adapter/src/main/java/com/durablestreams/ConformanceAdapter.java
@@ -427,6 +427,16 @@ public class ConformanceAdapter {
                         finalOffset = iterOffset;
                     }
                 }
+
+                // If an SSE offset=now read timed out before receiving the initial
+                // control event, resolve "now" to the current tail so the returned
+                // checkpoint can still be used for future reads.
+                if ("now".equals(finalOffset) && chunks.isEmpty()) {
+                    Metadata headMeta = client.head(url);
+                    if (headMeta.getNextOffset() != null) {
+                        finalOffset = headMeta.getNextOffset().getValue();
+                    }
+                }
             }
 
             // Check stream closed status via HEAD

--- a/packages/client-py/conformance_adapter.py
+++ b/packages/client-py/conformance_adapter.py
@@ -499,7 +499,7 @@ def handle_read(cmd: dict[str, Any]) -> dict[str, Any]:
                     chunk_count = 1 if data else 0
                     while chunk_count < max_chunks and not (wait_for_up_to_date and up_to_date):
                         # Do a long-poll fetch for more data
-                        next_response = response._fetch_next(response.offset, response.cursor)
+                        next_response = response._fetch_next(response.offset, response.cursor, response.up_to_date)
                         response._update_metadata_from_response(next_response)
 
                         if next_response.status_code == 204:

--- a/packages/client-py/conformance_adapter.py
+++ b/packages/client-py/conformance_adapter.py
@@ -458,7 +458,7 @@ def handle_read(cmd: dict[str, Any]) -> dict[str, Any]:
                     up_to_date = event.up_to_date
 
                     if chunk_count >= max_chunks:
-                        stopped_for_max_chunks = True
+                        stopped_for_max_chunks = not response.stream_closed
                         break
 
                     # For waitForUpToDate: stop when upToDate becomes True AND
@@ -544,7 +544,7 @@ def handle_read(cmd: dict[str, Any]) -> dict[str, Any]:
         "chunks": chunks,
         "offset": final_offset,
         "upToDate": up_to_date,
-        "streamClosed": False if stopped_for_max_chunks else stream_closed,
+        "streamClosed": stream_closed and not stopped_for_max_chunks,
     }
     if headers_sent:
         result["headersSent"] = headers_sent

--- a/packages/client-py/conformance_adapter_async.py
+++ b/packages/client-py/conformance_adapter_async.py
@@ -450,7 +450,7 @@ async def handle_read(cmd: dict[str, Any]) -> dict[str, Any]:
                     up_to_date = event.up_to_date
 
                     if chunk_count >= max_chunks:
-                        stopped_for_max_chunks = True
+                        stopped_for_max_chunks = not response.stream_closed
                         break
 
                     # For waitForUpToDate: stop when upToDate becomes True AND
@@ -489,9 +489,17 @@ async def handle_read(cmd: dict[str, Any]) -> dict[str, Any]:
 
                     # Continue polling until we reach maxChunks or timeout
                     chunk_count = 1 if data else 0
-                    while chunk_count < max_chunks and not (wait_for_up_to_date and up_to_date):
+                    while (
+                        chunk_count < max_chunks
+                        and not response.stream_closed
+                        and not (wait_for_up_to_date and up_to_date)
+                    ):
                         # Do a long-poll fetch for more data
-                        next_response = await response._fetch_next(response.offset, response.cursor)
+                        next_response = await response._fetch_next(
+                            response.offset,
+                            response.cursor,
+                            response.up_to_date,
+                        )
                         response._update_metadata_from_response(next_response)
 
                         if next_response.status_code == 204:
@@ -536,7 +544,7 @@ async def handle_read(cmd: dict[str, Any]) -> dict[str, Any]:
         "chunks": chunks,
         "offset": final_offset,
         "upToDate": up_to_date,
-        "streamClosed": False if stopped_for_max_chunks else stream_closed,
+        "streamClosed": stream_closed and not stopped_for_max_chunks,
     }
     if headers_sent:
         result["headersSent"] = headers_sent

--- a/packages/client-py/src/durable_streams/_response.py
+++ b/packages/client-py/src/durable_streams/_response.py
@@ -400,7 +400,9 @@ class StreamResponse(Generic[T]):
                 if self._start_sse is None:
                     return
                 sse_response = self._start_sse(self._offset, self._cursor)
-                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                from durable_streams._types import (
+                    STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR,
+                )
                 encoding_header = sse_response.headers.get(_ENC_HDR)
                 if encoding_header == "base64":
                     self._encoding = "base64"
@@ -441,7 +443,7 @@ class StreamResponse(Generic[T]):
                 finally:
                     response.close()
 
-    def _iter_sse_text(self, response: "httpx.Response | None" = None) -> Iterator[str]:
+    def _iter_sse_text(self, response: httpx.Response | None = None) -> Iterator[str]:
         """Iterate SSE data events as text."""
         from durable_streams._sse import SSEDataEvent, parse_sse_sync
 
@@ -545,7 +547,9 @@ class StreamResponse(Generic[T]):
                 if self._start_sse is None:
                     return
                 sse_response = self._start_sse(self._offset, self._cursor)
-                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                from durable_streams._types import (
+                    STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR,
+                )
                 encoding_header = sse_response.headers.get(_ENC_HDR)
                 if encoding_header == "base64":
                     self._encoding = "base64"
@@ -582,7 +586,7 @@ class StreamResponse(Generic[T]):
     def _iter_sse_json_batches(
         self,
         decode: Callable[[Any], T] | None,
-        response: "httpx.Response | None" = None,
+        response: httpx.Response | None = None,
     ) -> Iterator[list[T]]:
         """Iterate SSE data events as JSON batches."""
         from durable_streams._sse import SSEDataEvent, parse_sse_sync
@@ -685,7 +689,9 @@ class StreamResponse(Generic[T]):
                 if self._start_sse is None:
                     return
                 sse_response = self._start_sse(self._offset, self._cursor)
-                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                from durable_streams._types import (
+                    STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR,
+                )
                 encoding_header = sse_response.headers.get(_ENC_HDR)
                 if encoding_header == "base64":
                     self._encoding = "base64"
@@ -751,7 +757,7 @@ class StreamResponse(Generic[T]):
         self,
         mode: Literal["bytes", "text", "json", "json_batches"],
         decode: Callable[[Any], T] | None,
-        response: "httpx.Response | None" = None,
+        response: httpx.Response | None = None,
     ) -> Iterator[StreamEvent[Any]]:
         """
         Iterate SSE events with metadata.
@@ -1382,7 +1388,9 @@ class AsyncStreamResponse(Generic[T]):
                 if self._start_sse is None:
                     return
                 sse_response = await self._start_sse(self._offset, self._cursor)
-                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                from durable_streams._types import (
+                    STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR,
+                )
                 encoding_header = sse_response.headers.get(_ENC_HDR)
                 if encoding_header == "base64":
                     self._encoding = "base64"
@@ -1424,7 +1432,7 @@ class AsyncStreamResponse(Generic[T]):
                 finally:
                     await response.aclose()
 
-    async def _aiter_sse_text(self, response: "httpx.Response | None" = None) -> AsyncIterator[str]:
+    async def _aiter_sse_text(self, response: httpx.Response | None = None) -> AsyncIterator[str]:
         """Iterate SSE data events as text."""
         from durable_streams._sse import SSEDataEvent, parse_sse_async
 
@@ -1510,7 +1518,9 @@ class AsyncStreamResponse(Generic[T]):
                 if self._start_sse is None:
                     return
                 sse_response = await self._start_sse(self._offset, self._cursor)
-                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                from durable_streams._types import (
+                    STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR,
+                )
                 encoding_header = sse_response.headers.get(_ENC_HDR)
                 if encoding_header == "base64":
                     self._encoding = "base64"
@@ -1546,7 +1556,7 @@ class AsyncStreamResponse(Generic[T]):
     async def _aiter_sse_json_batches(
         self,
         decode: Callable[[Any], T] | None,
-        response: "httpx.Response | None" = None,
+        response: httpx.Response | None = None,
     ) -> AsyncIterator[list[T]]:
         """Iterate SSE data events as JSON batches."""
         from durable_streams._sse import SSEDataEvent, parse_sse_async
@@ -1638,7 +1648,9 @@ class AsyncStreamResponse(Generic[T]):
                 if self._start_sse is None:
                     return
                 sse_response = await self._start_sse(self._offset, self._cursor)
-                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                from durable_streams._types import (
+                    STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR,
+                )
                 encoding_header = sse_response.headers.get(_ENC_HDR)
                 if encoding_header == "base64":
                     self._encoding = "base64"
@@ -1701,7 +1713,7 @@ class AsyncStreamResponse(Generic[T]):
         self,
         mode: Literal["bytes", "text", "json", "json_batches"],
         decode: Callable[[Any], T] | None,
-        response: "httpx.Response | None" = None,
+        response: httpx.Response | None = None,
     ) -> AsyncIterator[StreamEvent[Any]]:
         """
         Iterate SSE events with metadata.

--- a/packages/client-py/src/durable_streams/_response.py
+++ b/packages/client-py/src/durable_streams/_response.py
@@ -74,7 +74,8 @@ class StreamResponse(Generic[T]):
         start_offset: Offset | None,
         offset: Offset | None,
         cursor: str | None,
-        fetch_next: Callable[[Offset, str | None], httpx.Response],
+        fetch_next: Callable[[Offset, str | None, bool], httpx.Response],
+        start_sse: Callable[[Offset, str | None], httpx.Response] | None = None,
         is_sse: bool = False,
         own_client: bool = False,
         encoding: SSEEncoding | None = None,
@@ -87,6 +88,7 @@ class StreamResponse(Generic[T]):
         self._offset = offset or ""
         self._cursor = cursor
         self._fetch_next = fetch_next
+        self._start_sse = start_sse
         self._is_sse = is_sse
         self._own_client = own_client
 
@@ -164,6 +166,12 @@ class StreamResponse(Generic[T]):
             return not self._up_to_date
         # Otherwise, keep tailing until explicitly closed
         return True
+
+    def _is_empty_json_body(self, content: bytes) -> bool:
+        """Check if content is an empty JSON array from a JSON stream (no actual data)."""
+        if self._content_type and "json" in self._content_type.lower():
+            return content.strip() == b"[]"
+        return False
 
     def _decode_base64(self, data: str) -> bytes:
         """
@@ -308,7 +316,7 @@ class StreamResponse(Generic[T]):
 
         # Continue with live updates if needed
         while self._should_continue_live():
-            response = self._fetch_next(self._offset, self._cursor)
+            response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -355,7 +363,48 @@ class StreamResponse(Generic[T]):
         import codecs
 
         if self._is_sse:
-            yield from self._iter_sse_text()
+            # Fetch-then-live: catch up via regular HTTP, then switch to SSE
+            decoder = codecs.getincrementaldecoder(encoding)("replace")
+            try:
+                for chunk in self._response.iter_bytes():
+                    text = decoder.decode(chunk)
+                    if text:
+                        yield text
+                final = decoder.decode(b"", final=True)
+                if final:
+                    yield final
+            finally:
+                self._response.close()
+
+            # Continue HTTP catch-up until caught up
+            while self._should_continue_live() and not self._up_to_date:
+                response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
+                decoder = codecs.getincrementaldecoder(encoding)("replace")
+                try:
+                    self._update_metadata_from_response(response)
+                    if response.status_code == 204:
+                        response.close()
+                        continue
+                    for chunk in response.iter_bytes():
+                        text = decoder.decode(chunk)
+                        if text:
+                            yield text
+                    final = decoder.decode(b"", final=True)
+                    if final:
+                        yield final
+                finally:
+                    response.close()
+
+            # Switch to SSE for live updates
+            if self._should_continue_live():
+                if self._start_sse is None:
+                    return
+                sse_response = self._start_sse(self._offset, self._cursor)
+                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                encoding_header = sse_response.headers.get(_ENC_HDR)
+                if encoding_header == "base64":
+                    self._encoding = "base64"
+                yield from self._iter_sse_text(sse_response)
         else:
             # Use incremental decoder for correct handling of multi-byte chars
             # split across chunk boundaries
@@ -373,7 +422,7 @@ class StreamResponse(Generic[T]):
                 self._response.close()
 
             while self._should_continue_live():
-                response = self._fetch_next(self._offset, self._cursor)
+                response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
                 decoder = codecs.getincrementaldecoder(encoding)("replace")
                 try:
                     self._update_metadata_from_response(response)
@@ -392,11 +441,13 @@ class StreamResponse(Generic[T]):
                 finally:
                     response.close()
 
-    def _iter_sse_text(self) -> Iterator[str]:
+    def _iter_sse_text(self, response: "httpx.Response | None" = None) -> Iterator[str]:
         """Iterate SSE data events as text."""
         from durable_streams._sse import SSEDataEvent, parse_sse_sync
 
-        for event in parse_sse_sync(self._response.iter_bytes()):
+        sse_response = response if response is not None else self._response
+
+        for event in parse_sse_sync(sse_response.iter_bytes()):
             if isinstance(event, SSEDataEvent):
                 # If encoding is base64, decode and convert back to text
                 if self._encoding == "base64":
@@ -463,7 +514,42 @@ class StreamResponse(Generic[T]):
     ) -> Iterator[list[T]]:
         """Internal JSON batch iteration."""
         if self._is_sse:
-            yield from self._iter_sse_json_batches(decode)
+            # Fetch-then-live: catch up via regular HTTP, then switch to SSE
+            try:
+                content = self._response.read()
+                if content:
+                    items = decode_json_items(content, decode)
+                    if items:
+                        yield items
+            finally:
+                self._response.close()
+
+            # Continue HTTP catch-up until caught up
+            while self._should_continue_live() and not self._up_to_date:
+                response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
+                try:
+                    self._update_metadata_from_response(response)
+                    if response.status_code == 204:
+                        response.close()
+                        continue
+                    content = response.read()
+                    if content:
+                        items = decode_json_items(content, decode)
+                        if items:
+                            yield items
+                finally:
+                    response.close()
+
+            # Switch to SSE for live updates
+            if self._should_continue_live():
+                if self._start_sse is None:
+                    return
+                sse_response = self._start_sse(self._offset, self._cursor)
+                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                encoding_header = sse_response.headers.get(_ENC_HDR)
+                if encoding_header == "base64":
+                    self._encoding = "base64"
+                yield from self._iter_sse_json_batches(decode, sse_response)
         else:
             # Read and parse the first response
             try:
@@ -477,7 +563,7 @@ class StreamResponse(Generic[T]):
 
             # Continue with live updates if needed
             while self._should_continue_live():
-                response = self._fetch_next(self._offset, self._cursor)
+                response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
                 try:
                     self._update_metadata_from_response(response)
 
@@ -496,11 +582,14 @@ class StreamResponse(Generic[T]):
     def _iter_sse_json_batches(
         self,
         decode: Callable[[Any], T] | None,
+        response: "httpx.Response | None" = None,
     ) -> Iterator[list[T]]:
         """Iterate SSE data events as JSON batches."""
         from durable_streams._sse import SSEDataEvent, parse_sse_sync
 
-        for event in parse_sse_sync(self._response.iter_bytes()):
+        sse_response = response if response is not None else self._response
+
+        for event in parse_sse_sync(sse_response.iter_bytes()):
             if isinstance(event, SSEDataEvent):
                 # If encoding is base64, decode first
                 if self._encoding == "base64":
@@ -554,7 +643,53 @@ class StreamResponse(Generic[T]):
     ) -> Iterator[StreamEvent[Any]]:
         """Internal event iteration."""
         if self._is_sse:
-            yield from self._iter_sse_events(mode, decode)
+            # Fetch-then-live: catch up via regular HTTP, then switch to SSE
+            # Phase 1: Read initial response as regular HTTP
+            try:
+                content = self._response.read()
+                if content and not self._is_empty_json_body(content):
+                    data = self._convert_content(content, mode, encoding, decode)
+                    yield StreamEvent(
+                        data=data,
+                        next_offset=self._offset,
+                        up_to_date=self._up_to_date,
+                        cursor=self._cursor,
+                    )
+            finally:
+                self._response.close()
+
+            # Continue HTTP catch-up until caught up
+            while self._should_continue_live() and not self._up_to_date:
+                response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
+                try:
+                    self._update_metadata_from_response(response)
+
+                    if response.status_code == 204:
+                        response.close()
+                        continue
+
+                    content = response.read()
+                    if content and not self._is_empty_json_body(content):
+                        data = self._convert_content(content, mode, encoding, decode)
+                        yield StreamEvent(
+                            data=data,
+                            next_offset=self._offset,
+                            up_to_date=self._up_to_date,
+                            cursor=self._cursor,
+                        )
+                finally:
+                    response.close()
+
+            # Phase 2: Switch to SSE for live updates
+            if self._should_continue_live():
+                if self._start_sse is None:
+                    return
+                sse_response = self._start_sse(self._offset, self._cursor)
+                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                encoding_header = sse_response.headers.get(_ENC_HDR)
+                if encoding_header == "base64":
+                    self._encoding = "base64"
+                yield from self._iter_sse_events(mode, decode, sse_response)
         else:
             # Handle first response
             try:
@@ -572,7 +707,7 @@ class StreamResponse(Generic[T]):
 
             # Continue with live updates
             while self._should_continue_live():
-                response = self._fetch_next(self._offset, self._cursor)
+                response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
                 try:
                     self._update_metadata_from_response(response)
 
@@ -616,6 +751,7 @@ class StreamResponse(Generic[T]):
         self,
         mode: Literal["bytes", "text", "json", "json_batches"],
         decode: Callable[[Any], T] | None,
+        response: "httpx.Response | None" = None,
     ) -> Iterator[StreamEvent[Any]]:
         """
         Iterate SSE events with metadata.
@@ -632,10 +768,12 @@ class StreamResponse(Generic[T]):
         """
         from durable_streams._sse import SSEDataEvent, parse_sse_sync
 
+        sse_response = response if response is not None else self._response
+
         # Buffer to hold data events until we see their control event
         buffered_data: list[Any] = []
 
-        for event in parse_sse_sync(self._response.iter_bytes()):
+        for event in parse_sse_sync(sse_response.iter_bytes()):
             if isinstance(event, SSEDataEvent):
                 # If encoding is base64, decode first
                 if self._encoding == "base64":
@@ -728,7 +866,7 @@ class StreamResponse(Generic[T]):
         while not self._up_to_date:
             if self._live is False:
                 break
-            response = self._fetch_next(self._offset, self._cursor)
+            response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -823,7 +961,7 @@ class StreamResponse(Generic[T]):
         while not self._up_to_date:
             if self._live is False:
                 break
-            response = self._fetch_next(self._offset, self._cursor)
+            response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -891,7 +1029,7 @@ class StreamResponse(Generic[T]):
         while not self._up_to_date:
             if self._live is False:
                 break
-            response = self._fetch_next(self._offset, self._cursor)
+            response = self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -936,7 +1074,8 @@ class AsyncStreamResponse(Generic[T]):
         start_offset: Offset | None,
         offset: Offset | None,
         cursor: str | None,
-        fetch_next: Callable[[Offset, str | None], Any],  # Returns awaitable
+        fetch_next: Callable[[Offset, str | None, bool], Any],  # Returns awaitable
+        start_sse: Callable[[Offset, str | None], Any] | None = None,  # Returns awaitable
         is_sse: bool = False,
         own_client: bool = False,
         encoding: SSEEncoding | None = None,
@@ -949,6 +1088,7 @@ class AsyncStreamResponse(Generic[T]):
         self._offset = offset or ""
         self._cursor = cursor
         self._fetch_next = fetch_next
+        self._start_sse = start_sse
         self._is_sse = is_sse
         self._own_client = own_client
 
@@ -1025,6 +1165,12 @@ class AsyncStreamResponse(Generic[T]):
             return not self._up_to_date
         # Otherwise, keep tailing until explicitly closed
         return True
+
+    def _is_empty_json_body(self, content: bytes) -> bool:
+        """Check if content is an empty JSON array from a JSON stream (no actual data)."""
+        if self._content_type and "json" in self._content_type.lower():
+            return content.strip() == b"[]"
+        return False
 
     def _decode_base64(self, data: str) -> bytes:
         """
@@ -1156,7 +1302,7 @@ class AsyncStreamResponse(Generic[T]):
             await self._response.aclose()
 
         while self._should_continue_live():
-            response = await self._fetch_next(self._offset, self._cursor)
+            response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -1199,8 +1345,49 @@ class AsyncStreamResponse(Generic[T]):
         import codecs
 
         if self._is_sse:
-            async for text in self._aiter_sse_text():
-                yield text
+            # Fetch-then-live: catch up via regular HTTP, then switch to SSE
+            decoder = codecs.getincrementaldecoder(encoding)("replace")
+            try:
+                async for chunk in self._response.aiter_bytes():
+                    text = decoder.decode(chunk)
+                    if text:
+                        yield text
+                final = decoder.decode(b"", final=True)
+                if final:
+                    yield final
+            finally:
+                await self._response.aclose()
+
+            # Continue HTTP catch-up until caught up
+            while self._should_continue_live() and not self._up_to_date:
+                response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
+                decoder = codecs.getincrementaldecoder(encoding)("replace")
+                try:
+                    self._update_metadata_from_response(response)
+                    if response.status_code == 204:
+                        await response.aclose()
+                        continue
+                    async for chunk in response.aiter_bytes():
+                        text = decoder.decode(chunk)
+                        if text:
+                            yield text
+                    final = decoder.decode(b"", final=True)
+                    if final:
+                        yield final
+                finally:
+                    await response.aclose()
+
+            # Switch to SSE for live updates
+            if self._should_continue_live():
+                if self._start_sse is None:
+                    return
+                sse_response = await self._start_sse(self._offset, self._cursor)
+                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                encoding_header = sse_response.headers.get(_ENC_HDR)
+                if encoding_header == "base64":
+                    self._encoding = "base64"
+                async for text in self._aiter_sse_text(sse_response):
+                    yield text
         else:
             # Use incremental decoder for correct handling of multi-byte chars
             # split across chunk boundaries
@@ -1218,7 +1405,7 @@ class AsyncStreamResponse(Generic[T]):
                 await self._response.aclose()
 
             while self._should_continue_live():
-                response = await self._fetch_next(self._offset, self._cursor)
+                response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
                 decoder = codecs.getincrementaldecoder(encoding)("replace")
                 try:
                     self._update_metadata_from_response(response)
@@ -1237,11 +1424,13 @@ class AsyncStreamResponse(Generic[T]):
                 finally:
                     await response.aclose()
 
-    async def _aiter_sse_text(self) -> AsyncIterator[str]:
+    async def _aiter_sse_text(self, response: "httpx.Response | None" = None) -> AsyncIterator[str]:
         """Iterate SSE data events as text."""
         from durable_streams._sse import SSEDataEvent, parse_sse_async
 
-        async for event in parse_sse_async(self._response.aiter_bytes()):
+        sse_response = response if response is not None else self._response
+
+        async for event in parse_sse_async(sse_response.aiter_bytes()):
             if isinstance(event, SSEDataEvent):
                 # If encoding is base64, decode and convert back to text
                 if self._encoding == "base64":
@@ -1290,8 +1479,43 @@ class AsyncStreamResponse(Generic[T]):
     ) -> AsyncIterator[list[T]]:
         """Internal async JSON batch iteration."""
         if self._is_sse:
-            async for batch in self._aiter_sse_json_batches(decode):
-                yield batch
+            # Fetch-then-live: catch up via regular HTTP, then switch to SSE
+            try:
+                content = await self._response.aread()
+                if content:
+                    items = decode_json_items(content, decode)
+                    if items:
+                        yield items
+            finally:
+                await self._response.aclose()
+
+            # Continue HTTP catch-up until caught up
+            while self._should_continue_live() and not self._up_to_date:
+                response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
+                try:
+                    self._update_metadata_from_response(response)
+                    if response.status_code == 204:
+                        await response.aclose()
+                        continue
+                    content = await response.aread()
+                    if content:
+                        items = decode_json_items(content, decode)
+                        if items:
+                            yield items
+                finally:
+                    await response.aclose()
+
+            # Switch to SSE for live updates
+            if self._should_continue_live():
+                if self._start_sse is None:
+                    return
+                sse_response = await self._start_sse(self._offset, self._cursor)
+                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                encoding_header = sse_response.headers.get(_ENC_HDR)
+                if encoding_header == "base64":
+                    self._encoding = "base64"
+                async for batch in self._aiter_sse_json_batches(decode, sse_response):
+                    yield batch
         else:
             try:
                 content = await self._response.aread()
@@ -1303,7 +1527,7 @@ class AsyncStreamResponse(Generic[T]):
                 await self._response.aclose()
 
             while self._should_continue_live():
-                response = await self._fetch_next(self._offset, self._cursor)
+                response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
                 try:
                     self._update_metadata_from_response(response)
 
@@ -1322,11 +1546,14 @@ class AsyncStreamResponse(Generic[T]):
     async def _aiter_sse_json_batches(
         self,
         decode: Callable[[Any], T] | None,
+        response: "httpx.Response | None" = None,
     ) -> AsyncIterator[list[T]]:
         """Iterate SSE data events as JSON batches."""
         from durable_streams._sse import SSEDataEvent, parse_sse_async
 
-        async for event in parse_sse_async(self._response.aiter_bytes()):
+        sse_response = response if response is not None else self._response
+
+        async for event in parse_sse_async(sse_response.aiter_bytes()):
             if isinstance(event, SSEDataEvent):
                 # If encoding is base64, decode first
                 if self._encoding == "base64":
@@ -1369,8 +1596,54 @@ class AsyncStreamResponse(Generic[T]):
     ) -> AsyncIterator[StreamEvent[Any]]:
         """Internal async event iteration."""
         if self._is_sse:
-            async for event in self._aiter_sse_events(mode, decode):
-                yield event
+            # Fetch-then-live: catch up via regular HTTP, then switch to SSE
+            # Phase 1: Read initial response as regular HTTP
+            try:
+                content = await self._response.aread()
+                if content and not self._is_empty_json_body(content):
+                    data = self._convert_content(content, mode, encoding, decode)
+                    yield StreamEvent(
+                        data=data,
+                        next_offset=self._offset,
+                        up_to_date=self._up_to_date,
+                        cursor=self._cursor,
+                    )
+            finally:
+                await self._response.aclose()
+
+            # Continue HTTP catch-up until caught up
+            while self._should_continue_live() and not self._up_to_date:
+                response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
+                try:
+                    self._update_metadata_from_response(response)
+
+                    if response.status_code == 204:
+                        await response.aclose()
+                        continue
+
+                    content = await response.aread()
+                    if content and not self._is_empty_json_body(content):
+                        data = self._convert_content(content, mode, encoding, decode)
+                        yield StreamEvent(
+                            data=data,
+                            next_offset=self._offset,
+                            up_to_date=self._up_to_date,
+                            cursor=self._cursor,
+                        )
+                finally:
+                    await response.aclose()
+
+            # Phase 2: Switch to SSE for live updates
+            if self._should_continue_live():
+                if self._start_sse is None:
+                    return
+                sse_response = await self._start_sse(self._offset, self._cursor)
+                from durable_streams._types import STREAM_SSE_DATA_ENCODING_HEADER as _ENC_HDR
+                encoding_header = sse_response.headers.get(_ENC_HDR)
+                if encoding_header == "base64":
+                    self._encoding = "base64"
+                async for event in self._aiter_sse_events(mode, decode, sse_response):
+                    yield event
         else:
             try:
                 content = await self._response.aread()
@@ -1386,7 +1659,7 @@ class AsyncStreamResponse(Generic[T]):
                 await self._response.aclose()
 
             while self._should_continue_live():
-                response = await self._fetch_next(self._offset, self._cursor)
+                response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
                 try:
                     self._update_metadata_from_response(response)
 
@@ -1428,6 +1701,7 @@ class AsyncStreamResponse(Generic[T]):
         self,
         mode: Literal["bytes", "text", "json", "json_batches"],
         decode: Callable[[Any], T] | None,
+        response: "httpx.Response | None" = None,
     ) -> AsyncIterator[StreamEvent[Any]]:
         """
         Iterate SSE events with metadata.
@@ -1444,10 +1718,12 @@ class AsyncStreamResponse(Generic[T]):
         """
         from durable_streams._sse import SSEDataEvent, parse_sse_async
 
+        sse_response = response if response is not None else self._response
+
         # Buffer to hold data events until we see their control event
         buffered_data: list[Any] = []
 
-        async for event in parse_sse_async(self._response.aiter_bytes()):
+        async for event in parse_sse_async(sse_response.aiter_bytes()):
             if isinstance(event, SSEDataEvent):
                 # If encoding is base64, decode first
                 if self._encoding == "base64":
@@ -1533,7 +1809,7 @@ class AsyncStreamResponse(Generic[T]):
         while not self._up_to_date:
             if self._live is False:
                 break
-            response = await self._fetch_next(self._offset, self._cursor)
+            response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -1612,7 +1888,7 @@ class AsyncStreamResponse(Generic[T]):
         while not self._up_to_date:
             if self._live is False:
                 break
-            response = await self._fetch_next(self._offset, self._cursor)
+            response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 
@@ -1672,7 +1948,7 @@ class AsyncStreamResponse(Generic[T]):
         while not self._up_to_date:
             if self._live is False:
                 break
-            response = await self._fetch_next(self._offset, self._cursor)
+            response = await self._fetch_next(self._offset, self._cursor, self._up_to_date)
             try:
                 self._update_metadata_from_response(response)
 

--- a/packages/client-py/src/durable_streams/astream.py
+++ b/packages/client-py/src/durable_streams/astream.py
@@ -272,12 +272,9 @@ async def _astream_internal(
     if offset is not None:
         query_params[OFFSET_QUERY_PARAM] = offset
 
-    is_sse = False
-    if live == "long-poll":
-        query_params[LIVE_QUERY_PARAM] = "long-poll"
-    elif live == "sse":
-        query_params[LIVE_QUERY_PARAM] = "sse"
-        is_sse = True
+    # Never set live on the initial request — catch-up responses without live
+    # are cacheable by CDNs/browsers. Live mode activates only after catching up.
+    is_sse = live == "sse"
 
     if cursor:
         query_params[CURSOR_QUERY_PARAM] = cursor
@@ -296,10 +293,6 @@ async def _astream_internal(
         # Apply any mutations from previous on_error calls
         current_headers = {**resolved_headers, **header_mutations}
         current_params = {**resolved_params, **param_mutations}
-
-        # Add Accept header for SSE mode (standard SSE negotiation)
-        if is_sse and "accept" not in {k.lower() for k in current_headers}:
-            current_headers["Accept"] = "text/event-stream"
 
         # Merge query params (user params + protocol params)
         all_params = {**current_params, **query_params}
@@ -373,17 +366,19 @@ async def _astream_internal(
     captured_param_mutations = param_mutations.copy()
 
     async def fetch_next(
-        next_offset: Offset, next_cursor: str | None
+        next_offset: Offset, next_cursor: str | None, up_to_date: bool = False
     ) -> httpx.Response:
         """Fetch the next chunk for live updates."""
         next_params: dict[str, str] = {}
         next_params[OFFSET_QUERY_PARAM] = next_offset
 
-        # For auto mode (True), use long-poll for subsequent requests
-        if live is True or live == "long-poll":
-            next_params[LIVE_QUERY_PARAM] = "long-poll"
-        elif live == "sse":
-            next_params[LIVE_QUERY_PARAM] = "sse"
+        # Only set live mode after catching up (up_to_date) — catch-up requests
+        # without live are cacheable by CDNs/browsers.
+        if up_to_date:
+            if live is True or live == "long-poll":
+                next_params[LIVE_QUERY_PARAM] = "long-poll"
+            elif live == "sse":
+                next_params[LIVE_QUERY_PARAM] = "sse"
 
         if next_cursor:
             next_params[CURSOR_QUERY_PARAM] = next_cursor
@@ -450,6 +445,42 @@ async def _astream_internal(
                         continue
                 raise
 
+    async def start_sse(next_offset: Offset, next_cursor: str | None) -> httpx.Response:
+        """Start the SSE live connection after HTTP catch-up."""
+        sse_params: dict[str, str] = {
+            OFFSET_QUERY_PARAM: next_offset,
+            LIVE_QUERY_PARAM: "sse",
+        }
+        if next_cursor:
+            sse_params[CURSOR_QUERY_PARAM] = next_cursor
+
+        resolved_hdrs = await resolve_headers_async(headers)
+        resolved_prms = await resolve_params_async(params)
+        final_hdrs = {**resolved_hdrs, **captured_header_mutations}
+        final_prms = {**resolved_prms, **captured_param_mutations}
+
+        if "accept" not in {k.lower() for k in final_hdrs}:
+            final_hdrs["Accept"] = "text/event-stream"
+
+        all_prms = {**final_prms, **sse_params}
+        sse_url = build_url_with_params(url, all_prms)
+
+        request = client.build_request(
+            "GET",
+            sse_url,
+            headers=final_hdrs,
+            timeout=timeout,
+            **kwargs,
+        )
+        resp = await client.send(request, stream=True)
+        if not resp.is_success and resp.status_code != 204:
+            body_bytes = await resp.aread()
+            await resp.aclose()
+            body = body_bytes.decode("utf-8", errors="replace")
+            hdrs = parse_httpx_headers(resp.headers)
+            raise error_from_status(resp.status_code, url, body=body, headers=hdrs)
+        return resp
+
     return AsyncStreamResponse(
         url=url,
         response=response,
@@ -459,6 +490,7 @@ async def _astream_internal(
         offset=meta.next_offset,  # Current offset from response headers
         cursor=meta.cursor,
         fetch_next=fetch_next,
+        start_sse=start_sse if is_sse else None,
         is_sse=is_sse,
         own_client=_own_client,
         encoding=encoding,

--- a/packages/client-py/src/durable_streams/stream.py
+++ b/packages/client-py/src/durable_streams/stream.py
@@ -123,13 +123,9 @@ def _stream_internal(
     if offset is not None:
         query_params[OFFSET_QUERY_PARAM] = offset
 
-    # Add live mode for explicit modes
-    is_sse = False
-    if live == "long-poll":
-        query_params[LIVE_QUERY_PARAM] = "long-poll"
-    elif live == "sse":
-        query_params[LIVE_QUERY_PARAM] = "sse"
-        is_sse = True
+    # Never set live on the initial request — catch-up responses without live
+    # are cacheable by CDNs/browsers. Live mode activates only after catching up.
+    is_sse = live == "sse"
 
     # Add cursor if provided
     if cursor:
@@ -149,10 +145,6 @@ def _stream_internal(
         # Apply any mutations from previous on_error calls
         current_headers = {**resolved_headers, **header_mutations}
         current_params = {**resolved_params, **param_mutations}
-
-        # Add Accept header for SSE mode (standard SSE negotiation)
-        if is_sse and "accept" not in {k.lower() for k in current_headers}:
-            current_headers["Accept"] = "text/event-stream"
 
         # Merge query params (user params + protocol params)
         all_params = {**current_params, **query_params}
@@ -222,16 +214,18 @@ def _stream_internal(
     captured_header_mutations = header_mutations.copy()
     captured_param_mutations = param_mutations.copy()
 
-    def fetch_next(next_offset: Offset, next_cursor: str | None) -> httpx.Response:
+    def fetch_next(next_offset: Offset, next_cursor: str | None, up_to_date: bool = False) -> httpx.Response:
         """Fetch the next chunk for live updates."""
         next_params: dict[str, str] = {}
         next_params[OFFSET_QUERY_PARAM] = next_offset
 
-        # For auto mode (True), use long-poll for subsequent requests
-        if live is True or live == "long-poll":
-            next_params[LIVE_QUERY_PARAM] = "long-poll"
-        elif live == "sse":
-            next_params[LIVE_QUERY_PARAM] = "sse"
+        # Only set live mode after catching up (up_to_date) — catch-up requests
+        # without live are cacheable by CDNs/browsers.
+        if up_to_date:
+            if live is True or live == "long-poll":
+                next_params[LIVE_QUERY_PARAM] = "long-poll"
+            elif live == "sse":
+                next_params[LIVE_QUERY_PARAM] = "sse"
 
         if next_cursor:
             next_params[CURSOR_QUERY_PARAM] = next_cursor
@@ -293,6 +287,41 @@ def _stream_internal(
                         continue
                 raise
 
+    def start_sse(next_offset: Offset, next_cursor: str | None) -> httpx.Response:
+        """Start the SSE live connection after HTTP catch-up."""
+        sse_params: dict[str, str] = {
+            OFFSET_QUERY_PARAM: next_offset,
+            LIVE_QUERY_PARAM: "sse",
+        }
+        if next_cursor:
+            sse_params[CURSOR_QUERY_PARAM] = next_cursor
+
+        resolved_hdrs = resolve_headers_sync(headers)
+        resolved_prms = resolve_params_sync(params)
+        final_hdrs = {**resolved_hdrs, **captured_header_mutations}
+        final_prms = {**resolved_prms, **captured_param_mutations}
+
+        if "accept" not in {k.lower() for k in final_hdrs}:
+            final_hdrs["Accept"] = "text/event-stream"
+
+        all_prms = {**final_prms, **sse_params}
+        sse_url = build_url_with_params(url, all_prms)
+
+        request = client.build_request(
+            "GET",
+            sse_url,
+            headers=final_hdrs,
+            timeout=timeout,
+            **kwargs,
+        )
+        resp = client.send(request, stream=True)
+        if not resp.is_success and resp.status_code != 204:
+            body = resp.read().decode("utf-8", errors="replace")
+            resp.close()
+            hdrs = parse_httpx_headers(resp.headers)
+            raise error_from_status(resp.status_code, url, body=body, headers=hdrs)
+        return resp
+
     return StreamResponse(
         url=url,
         response=response,
@@ -302,6 +331,7 @@ def _stream_internal(
         offset=meta.next_offset,  # Current offset from response headers
         cursor=meta.cursor,
         fetch_next=fetch_next,
+        start_sse=start_sse if is_sse else None,
         is_sse=is_sse,
         own_client=_own_client,
         encoding=encoding,

--- a/packages/client-py/tests/test_durable_stream.py
+++ b/packages/client-py/tests/test_durable_stream.py
@@ -215,8 +215,8 @@ class TestDurableStreamStream:
         called_url = get_streaming_url(mock_client)
         assert "offset=1_11" in called_url
 
-    def test_stream_includes_live_mode_in_query_params(self):
-        """Should include live mode in query params."""
+    def test_stream_omits_live_mode_from_initial_catchup_request(self):
+        """Should omit live mode from the initial catch-up request."""
         mock_client = MagicMock(spec=httpx.Client)
         mock_response = MockResponse(
             b"data",
@@ -235,7 +235,7 @@ class TestDurableStreamStream:
         handle.stream(live="long-poll")
 
         called_url = get_streaming_url(mock_client)
-        assert "live=long-poll" in called_url
+        assert "live=long-poll" not in called_url
 
     def test_stream_exposes_up_to_date_on_response(self):
         """Should expose upToDate on response."""

--- a/packages/client-py/tests/test_stream_api.py
+++ b/packages/client-py/tests/test_stream_api.py
@@ -142,8 +142,8 @@ class TestStreamBasicFunctionality:
         called_url = get_request_url(mock_client)
         assert "offset=1_5" in called_url
 
-    def test_stream_sets_live_query_param_for_explicit_modes(self):
-        """Should set live query param for explicit modes."""
+    def test_stream_omits_live_query_param_from_initial_catchup_request(self):
+        """Should omit live query param from the initial catch-up request."""
         mock_response = MockResponse(
             b"data",
             headers={
@@ -160,7 +160,7 @@ class TestStreamBasicFunctionality:
         )
 
         called_url = get_request_url(mock_client)
-        assert "live=long-poll" in called_url
+        assert "live=long-poll" not in called_url
 
 
 class TestStreamResponseConsumption:

--- a/packages/client/src/response.ts
+++ b/packages/client/src/response.ts
@@ -10,6 +10,7 @@ import {
   STREAM_CLOSED_HEADER,
   STREAM_CURSOR_HEADER,
   STREAM_OFFSET_HEADER,
+  STREAM_SSE_DATA_ENCODING_HEADER,
   STREAM_UP_TO_DATE_HEADER,
 } from "./constants"
 import { DurableStreamError } from "./error"
@@ -401,6 +402,13 @@ export class StreamResponseImpl<
     this.#syncState = this.#syncState.withSSEControl(controlEvent)
   }
 
+  #updateEncodingFromSSEResponse(response: Response): void {
+    this.#encoding =
+      response.headers.get(STREAM_SSE_DATA_ENCODING_HEADER) === `base64`
+        ? `base64`
+        : undefined
+  }
+
   /**
    * Mark the start of an SSE connection for duration tracking.
    * If the state is not SSEState (e.g., auto-detected SSE from content-type),
@@ -478,6 +486,7 @@ export class StreamResponseImpl<
       this.cursor,
       this.#requestAbortController.signal
     )
+    this.#updateEncodingFromSSEResponse(newSSEResponse)
     if (newSSEResponse.body) {
       return parseSSEStream(
         newSSEResponse.body,
@@ -664,6 +673,7 @@ export class StreamResponseImpl<
             if (isSSE && firstResponse.body) {
               // Track SSE connection start for resilience monitoring
               this.#markSSEConnectionStart()
+              this.#updateEncodingFromSSEResponse(firstResponse)
               // Create per-request abort controller for SSE connection
               this.#requestAbortController = new AbortController()
               // Start parsing SSE events
@@ -712,6 +722,7 @@ export class StreamResponseImpl<
               this.cursor,
               this.#requestAbortController.signal
             )
+            this.#updateEncodingFromSSEResponse(sseResponse)
             if (sseResponse.body) {
               sseEventIterator = parseSSEStream(
                 sseResponse.body,

--- a/packages/client/src/response.ts
+++ b/packages/client/src/response.ts
@@ -69,6 +69,7 @@ export interface StreamResponseConfig {
     offset: Offset,
     cursor: string | undefined,
     signal: AbortSignal,
+    upToDate: boolean,
     resumingFromPause?: boolean
   ) => Promise<Response>
   /** Function to start SSE connection and return a Response with SSE body */
@@ -685,6 +686,40 @@ export class StreamResponseImpl<
             }
           }
 
+          // Transition to SSE once caught up (fetch-then-live pattern)
+          if (
+            !sseEventIterator &&
+            this.upToDate &&
+            this.#startSSE &&
+            this.#shouldContinueLive()
+          ) {
+            if (this.#state === `pause-requested` || this.#state === `paused`) {
+              this.#state = `paused`
+              if (this.#pausePromise) {
+                await this.#pausePromise
+              }
+              if (this.#abortController.signal.aborted) {
+                this.#markClosed()
+                controller.close()
+                return
+              }
+            }
+
+            this.#markSSEConnectionStart()
+            this.#requestAbortController = new AbortController()
+            const sseResponse = await this.#startSSE(
+              this.offset,
+              this.cursor,
+              this.#requestAbortController.signal
+            )
+            if (sseResponse.body) {
+              sseEventIterator = parseSSEStream(
+                sseResponse.body,
+                this.#requestAbortController.signal
+              )
+            }
+          }
+
           // SSE mode: process events from the SSE stream
           if (sseEventIterator) {
             // Check for pause state before processing SSE events
@@ -776,6 +811,7 @@ export class StreamResponseImpl<
               this.offset,
               this.cursor,
               this.#requestAbortController.signal,
+              this.upToDate,
               resumingFromPause
             )
 

--- a/packages/client/src/stream-api.ts
+++ b/packages/client/src/stream-api.ts
@@ -136,12 +136,9 @@ async function streamInternal<TJson = unknown>(
   const startOffset = options.offset ?? `-1`
   fetchUrl.searchParams.set(OFFSET_QUERY_PARAM, startOffset)
 
-  // Set live query param for explicit modes
-  // true means auto-select (no query param, handled by consumption method)
+  // Never set live on the initial request — catch-up responses without live
+  // are cacheable by CDNs/browsers. Live mode activates only after catching up.
   const live: LiveMode = options.live ?? true
-  if (live === `long-poll` || live === `sse`) {
-    fetchUrl.searchParams.set(LIVE_QUERY_PARAM, live)
-  }
 
   // Add custom params
   const params = await resolveParams(options.params)
@@ -212,17 +209,17 @@ async function streamInternal<TJson = unknown>(
     offset: Offset,
     cursor: string | undefined,
     signal: AbortSignal,
+    upToDate: boolean,
     resumingFromPause?: boolean
   ): Promise<Response> => {
     const nextUrl = new URL(url)
     nextUrl.searchParams.set(OFFSET_QUERY_PARAM, offset)
 
-    // For subsequent requests, set live mode unless resuming from pause
-    // (resuming from pause needs immediate response for UI status)
-    if (!resumingFromPause) {
-      if (live === `sse`) {
-        nextUrl.searchParams.set(LIVE_QUERY_PARAM, `sse`)
-      } else if (live === true || live === `long-poll`) {
+    // Only set live mode after catching up (upToDate) — catch-up requests
+    // without live are cacheable by CDNs/browsers.
+    // Also skip live when resuming from pause (needs immediate response for UI status).
+    if (upToDate && !resumingFromPause) {
+      if (live === true || live === `long-poll`) {
         nextUrl.searchParams.set(LIVE_QUERY_PARAM, `long-poll`)
       }
     }

--- a/packages/client/test/stream-api.test.ts
+++ b/packages/client/test/stream-api.test.ts
@@ -99,7 +99,7 @@ describe(`stream() function`, () => {
       })
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://example.com/stream?offset=-1&live=long-poll`,
+        `https://example.com/stream?offset=-1`,
         expect.anything()
       )
     })

--- a/packages/client/test/stream.test.ts
+++ b/packages/client/test/stream.test.ts
@@ -238,7 +238,7 @@ describe(`DurableStream`, () => {
       await handle.stream({ live: `long-poll` })
 
       const calledUrl = mockFetch.mock.calls[0]![0] as string
-      expect(calledUrl).toContain(`live=long-poll`)
+      expect(calledUrl).not.toContain(`live=`)
     })
 
     it(`should expose upToDate on response`, async () => {

--- a/packages/client/test/visibility.test.ts
+++ b/packages/client/test/visibility.test.ts
@@ -279,8 +279,8 @@ describe(`visibility handling`, () => {
       // Verify we have at least 4 requests
       expect(capturedUrls.length).toBeGreaterThanOrEqual(4)
 
-      // First request (initial) has live=long-poll
-      expect(capturedUrls[0]).toContain(`live=long-poll`)
+      // First request (initial) has no live param (cacheable catch-up)
+      expect(capturedUrls[0]).not.toContain(`live=`)
 
       // Second request (subsequent long-poll) has live=long-poll
       expect(capturedUrls[1]).toContain(`live=long-poll`)

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1187,8 +1187,10 @@ export class DurableStreamTestServer {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (this.isShuttingDown || !isConnected) break
 
-        // Check if stream was closed during wait
-        if (result.streamClosed) {
+        // Check if stream was closed during wait. If the close also appended
+        // final data, let the next loop iteration deliver those messages
+        // before emitting the streamClosed control event.
+        if (result.streamClosed && result.messages.length === 0) {
           const finalControlData: Record<string, string | boolean> = {
             [SSE_OFFSET_FIELD]: currentOffset,
             [SSE_CLOSED_FIELD]: true,

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -723,12 +723,16 @@ export class StreamStore {
           seq: options.producerSeq!,
         }
       }
-      // Notify pending long-polls that stream is closed
-      this.notifyLongPollsClosed(path)
     }
 
-    // Notify any pending long-polls of new messages
+    // Notify pending long-polls of new messages before empty close signals.
+    // Append-and-close must deliver the final message with streamClosed
+    // metadata instead of waking readers with an empty close event first.
     this.notifyLongPolls(path)
+
+    if (options.close) {
+      this.notifyLongPollsClosed(path)
+    }
 
     // Return AppendResult if producer headers were used or stream was closed
     if (producerResult || options.close) {


### PR DESCRIPTION
## Summary

- Initial requests no longer include the `live` query parameter, making catch-up responses cacheable by CDNs and browsers
- Live mode (long-poll or SSE) activates only after the client reaches `upToDate`, splitting the stream lifecycle into a cacheable catch-up phase and a live tail phase
- All three client implementations (TypeScript, Python, Go) updated with consistent fetch-then-live transitions
- SSE mode now uses a dedicated `startSSE` path that opens a persistent connection only after HTTP catch-up completes

### TypeScript (`packages/client/`)
- `stream-api.ts`: Removed `live` param from initial request; `fetchNext` gates `live=long-poll` behind `upToDate && !resumingFromPause`; separate `startSSE` function explicitly sets `live=sse`
- `response.ts`: New SSE transition block (lines 689-721) starts SSE after catching up, with pause handling

### Python (`packages/client-py/`)
- `stream.py` / `astream.py`: Removed `live` from initial request; added `start_sse()` function for SSE transition; `fetch_next` takes `up_to_date` param to gate live mode
- `_response.py`: All SSE iteration paths (`iter_text`, `iter_json_batches`, `iter_events` + async variants) now catch up via regular HTTP then transition to SSE via `start_sse`

### Go (`packages/client-go/`)
- `iterator.go`: Added `sseStarted` flag to persist SSE mode across reconnects; `nextHTTP` gates `live` behind `UpToDate`

### Conformance tests
- `read-sse.yaml`: Updated leading-space test — catch-up preserves spaces (no SSE data-line normalization)
- `sse-parsing-errors.yaml`: Bumped inject-error count to 2 (one consumed by catch-up, one by SSE)
- `streaming-equivalence.yaml`: Added `maxChunks: 1` to background reads
- TypeScript adapter: Added `subscribeJson` branch for JSON SSE conformance testing

## Test plan

- [ ] `pnpm test:run` — full conformance test suite
- [ ] `pnpm test:run -- --client typescript` — TypeScript client conformance
- [ ] `pnpm test:run -- --client python` — Python client conformance  
- [ ] `pnpm test:run -- --client go` — Go client conformance
- [ ] Verify initial requests have no `live` query param (CDN-cacheable)
- [ ] Verify SSE mode transitions correctly after catch-up in all clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)