### PR TITLE
fix(caddy-plugin): auto-truncate corrupt segment tails during recovery

### DIFF
--- a/packages/caddy-plugin/module.go
+++ b/packages/caddy-plugin/module.go
@@ -66,6 +66,16 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 		h.logger.Info("using in-memory store (no data_dir configured)")
 	} else {
 		// Use file-backed store
+		if err := store.RecoverStoreWithEvents(h.DataDir, func(event store.RecoveryEvent) {
+			h.logger.Warn("truncated corrupt segment tail during recovery",
+				zap.String("stream", event.StreamPath),
+				zap.String("segment", event.SegmentPath),
+				zap.Uint64("original_size", event.OriginalSize),
+				zap.Uint64("recovered_size", event.RecoveredSize),
+				zap.Uint64("discarded_bytes", event.DiscardedBytes))
+		}); err != nil {
+			return fmt.Errorf("failed to recover store: %w", err)
+		}
 		fileStore, err := store.NewFileStore(store.FileStoreConfig{
 			DataDir:        h.DataDir,
 			MaxFileHandles: h.MaxFileHandles,

--- a/packages/caddy-plugin/store/file_store.go
+++ b/packages/caddy-plugin/store/file_store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -1204,8 +1205,22 @@ func generateDirectoryName(path string) (string, error) {
 
 // Recovery functions
 
+// RecoveryEvent describes a repair made during store recovery.
+type RecoveryEvent struct {
+	StreamPath     string
+	SegmentPath    string
+	OriginalSize   uint64
+	RecoveredSize  uint64
+	DiscardedBytes uint64
+}
+
 // RecoverStore performs recovery on a file store, reconciling bbolt with segment files
 func RecoverStore(dataDir string) error {
+	return RecoverStoreWithEvents(dataDir, nil)
+}
+
+// RecoverStoreWithEvents performs recovery and calls onEvent for each repair.
+func RecoverStoreWithEvents(dataDir string, onEvent func(RecoveryEvent)) error {
 	metaDir := filepath.Join(dataDir, "metadata")
 	metaStore, err := NewBboltMetadataStore(metaDir)
 	if err != nil {
@@ -1218,16 +1233,13 @@ func RecoverStore(dataDir string) error {
 	return metaStore.ForEach(func(meta *StreamMetadata, dirName string) error {
 		segPath := filepath.Join(streamsDir, dirName, SegmentFileName)
 
-		// Check if segment exists
-		if _, err := os.Stat(segPath); os.IsNotExist(err) {
-			// Orphaned metadata - delete it
-			return metaStore.Delete(meta.Path)
-		}
-
-		// Scan segment to get true offset
-		trueOffset, err := ScanSegment(segPath)
+		trueOffset, err := recoverSegment(segPath, meta.Path, onEvent)
 		if err != nil {
-			return fmt.Errorf("failed to scan segment for %s: %w", meta.Path, err)
+			if errors.Is(err, os.ErrNotExist) {
+				// Orphaned metadata - delete it
+				return metaStore.Delete(meta.Path)
+			}
+			return err
 		}
 
 		// Reconcile if mismatch
@@ -1239,6 +1251,49 @@ func RecoverStore(dataDir string) error {
 
 		return nil
 	})
+}
+
+func recoverSegment(segPath, streamPath string, onEvent func(RecoveryEvent)) (offset Offset, err error) {
+	f, err := os.OpenFile(segPath, os.O_RDWR, 0644)
+	if err != nil {
+		return Offset{}, fmt.Errorf("failed to open segment for recovery %s: %w", streamPath, err)
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("failed to close segment for %s: %w", streamPath, closeErr)
+		}
+	}()
+
+	trueOffset, err := ScanSegmentFile(f)
+	if err != nil {
+		return Offset{}, fmt.Errorf("failed to scan segment for %s: %w", streamPath, err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		return Offset{}, fmt.Errorf("failed to stat segment for %s: %w", streamPath, err)
+	}
+
+	originalSize := uint64(info.Size())
+	if originalSize > trueOffset.ByteOffset {
+		if err := f.Truncate(int64(trueOffset.ByteOffset)); err != nil {
+			return Offset{}, fmt.Errorf("failed to truncate segment for %s: %w", streamPath, err)
+		}
+		if err := f.Sync(); err != nil {
+			return Offset{}, fmt.Errorf("failed to sync segment for %s: %w", streamPath, err)
+		}
+		if onEvent != nil {
+			onEvent(RecoveryEvent{
+				StreamPath:     streamPath,
+				SegmentPath:    segPath,
+				OriginalSize:   originalSize,
+				RecoveredSize:  trueOffset.ByteOffset,
+				DiscardedBytes: originalSize - trueOffset.ByteOffset,
+			})
+		}
+	}
+
+	return trueOffset, nil
 }
 
 // Note: longPollManager and processJSONAppend are defined in memory_store.go

--- a/packages/caddy-plugin/store/file_store_test.go
+++ b/packages/caddy-plugin/store/file_store_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -330,6 +332,159 @@ func TestFileStore_Persistence(t *testing.T) {
 		if !bytes.Equal(messages[0].Data, []byte("hello")) {
 			t.Error("data mismatch after reopen")
 		}
+	}
+}
+
+func TestRecoverStore_TruncatesCorruptSegmentTail(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filestore-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var segPath string
+	{
+		store, err := NewFileStore(FileStoreConfig{DataDir: tmpDir})
+		if err != nil {
+			t.Fatalf("failed to create store: %v", err)
+		}
+
+		if _, _, err := store.Create("/test", CreateOptions{ContentType: "text/plain"}); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+		if _, err := store.Append("/test", []byte("before"), AppendOptions{}); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+
+		segPath = filepath.Join(tmpDir, "streams", store.dirCache["/test"], SegmentFileName)
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	}
+
+	validInfo, err := os.Stat(segPath)
+	if err != nil {
+		t.Fatalf("failed to stat clean segment: %v", err)
+	}
+	validSize := validInfo.Size()
+
+	file, err := os.OpenFile(segPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("failed to open segment for corruption: %v", err)
+	}
+	var corruptLen [LengthPrefixSize]byte
+	binary.BigEndian.PutUint32(corruptLen[:], MaxMessageSize+1)
+	if _, err := file.Write(corruptLen[:]); err != nil {
+		file.Close()
+		t.Fatalf("failed to append corrupt length: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close corrupted segment: %v", err)
+	}
+
+	if err := RecoverStore(tmpDir); err != nil {
+		t.Fatalf("RecoverStore failed: %v", err)
+	}
+
+	recoveredInfo, err := os.Stat(segPath)
+	if err != nil {
+		t.Fatalf("failed to stat recovered segment: %v", err)
+	}
+	if recoveredInfo.Size() != validSize {
+		t.Fatalf("expected segment size %d after recovery, got %d", validSize, recoveredInfo.Size())
+	}
+
+	store, err := NewFileStore(FileStoreConfig{DataDir: tmpDir})
+	if err != nil {
+		t.Fatalf("failed to reopen store: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.Append("/test", []byte("after"), AppendOptions{}); err != nil {
+		t.Fatalf("Append after recovery failed: %v", err)
+	}
+
+	messages, _, err := store.Read("/test", ZeroOffset)
+	if err != nil {
+		t.Fatalf("Read after recovery failed: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages after recovery append, got %d", len(messages))
+	}
+	if !bytes.Equal(messages[0].Data, []byte("before")) || !bytes.Equal(messages[1].Data, []byte("after")) {
+		t.Fatalf("unexpected messages after recovery: %q, %q", messages[0].Data, messages[1].Data)
+	}
+}
+
+func TestRecoverStoreWithEvents_ReportsTruncation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filestore-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var segPath string
+	{
+		store, err := NewFileStore(FileStoreConfig{DataDir: tmpDir})
+		if err != nil {
+			t.Fatalf("failed to create store: %v", err)
+		}
+
+		if _, _, err := store.Create("/test", CreateOptions{ContentType: "text/plain"}); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+		if _, err := store.Append("/test", []byte("before"), AppendOptions{}); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+
+		segPath = filepath.Join(tmpDir, "streams", store.dirCache["/test"], SegmentFileName)
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	}
+
+	validInfo, err := os.Stat(segPath)
+	if err != nil {
+		t.Fatalf("failed to stat clean segment: %v", err)
+	}
+
+	file, err := os.OpenFile(segPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("failed to open segment for corruption: %v", err)
+	}
+	corruptTail := []byte{0xff, 0xff, 0xff, 0xff}
+	if _, err := file.Write(corruptTail); err != nil {
+		file.Close()
+		t.Fatalf("failed to append corrupt tail: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close corrupted segment: %v", err)
+	}
+
+	var events []RecoveryEvent
+	if err := RecoverStoreWithEvents(tmpDir, func(event RecoveryEvent) {
+		events = append(events, event)
+	}); err != nil {
+		t.Fatalf("RecoverStoreWithEvents failed: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 recovery event, got %d", len(events))
+	}
+	if events[0].StreamPath != "/test" {
+		t.Fatalf("expected stream path /test, got %q", events[0].StreamPath)
+	}
+	if events[0].SegmentPath != segPath {
+		t.Fatalf("expected segment path %q, got %q", segPath, events[0].SegmentPath)
+	}
+	if events[0].OriginalSize != uint64(validInfo.Size()+int64(len(corruptTail))) {
+		t.Fatalf("unexpected original size: %d", events[0].OriginalSize)
+	}
+	if events[0].RecoveredSize != uint64(validInfo.Size()) {
+		t.Fatalf("unexpected recovered size: %d", events[0].RecoveredSize)
+	}
+	if events[0].DiscardedBytes != uint64(len(corruptTail)) {
+		t.Fatalf("expected %d discarded bytes, got %d", len(corruptTail), events[0].DiscardedBytes)
 	}
 }
 

--- a/packages/caddy-plugin/store/segment.go
+++ b/packages/caddy-plugin/store/segment.go
@@ -241,6 +241,16 @@ func ScanSegment(path string) (Offset, error) {
 	}
 	defer file.Close()
 
+	return ScanSegmentFile(file)
+}
+
+// ScanSegmentFile scans an open segment file and returns the final valid offset.
+// The caller owns and closes the file.
+func ScanSegmentFile(file *os.File) (Offset, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return Offset{}, err
+	}
+
 	reader := bufio.NewReader(file)
 	var offset uint64
 


### PR DESCRIPTION
## Summary

`RecoverStore` now truncates trailing corrupt bytes from segment files during startup recovery. Previously, partial writes from crashes left bogus length prefixes that caused `ErrCorruptedSegment` on subsequent reads — even though all valid data before the corruption was perfectly recoverable.

**User-visible impact**: Servers that crash mid-write now self-heal on restart instead of failing with corrupted segment errors.

## Root cause

The segment file format is `[4-byte length][data bytes]` repeated. A crash mid-write can leave a partial length prefix or truncated message body at the tail. `ScanSegment()` already correctly identifies the last valid byte offset by re-reading frames from the start, but `RecoverStore` never acted on a size mismatch — it reconciled the metadata offset but left the corrupt tail bytes on disk. The next `Append` or `Read` would then hit the garbage bytes and return `ErrCorruptedSegment`.

## Approach

1. **Wire `RecoverStore` into production** — Called from `Provision()` before `NewFileStore` so recovery actually runs on server startup (it was previously dead code)
2. **Single file descriptor** — `recoverSegment()` opens the segment once, scans via `ScanSegmentFile()`, stats, truncates, and syncs through the same fd — eliminating the TOCTOU race between stat and truncate
3. **Structured recovery events** — `RecoverStoreWithEvents()` accepts an `onEvent` callback. The Caddy module logs truncations through zap with stream path, segment path, original/recovered sizes, and discarded byte count
4. **Defensive guard** — Uses `>` not `!=` so truncation only removes excess bytes, never zero-extends a smaller-than-expected file

## Key invariants

- `ScanSegment` can never return a `ByteOffset` larger than the file size (it breaks on EOF/short reads)
- Truncation is idempotent — re-running recovery on an already-recovered store is a no-op
- `f.Sync()` after truncate ensures the repair survives a subsequent crash before the OS flushes

## Non-goals

- **Graceful degradation in `ReadMessages`**: The existing reader still returns `ErrCorruptedSegment` on corrupt data rather than returning the valid prefix. That's a separate concern — this PR ensures corruption is cleaned up before the reader ever sees it.
- **Additional corruption patterns in tests**: The two tests cover the core scenario (bogus length prefix) and structured event reporting. `ScanSegment` already handles all corruption variants (partial length, truncated body, etc.) — the truncation logic doesn't care *how much* garbage is at the tail.

## Verification

```bash
cd packages/caddy-plugin && go test ./... -v
```

The `TestRecoverStore_TruncatesCorruptSegmentTail` test creates a valid segment, appends a corrupt length prefix, runs recovery, verifies the file was truncated to the valid size, then confirms the store accepts new appends and reads back all messages. `TestRecoverStoreWithEvents_ReportsTruncation` verifies the structured event callback reports correct sizes.

## Files changed

| File | Change |
|------|--------|
| `store/segment.go` | Extract `ScanSegmentFile()` so recovery can scan via an open fd |
| `store/file_store.go` | `RecoveryEvent` struct, `RecoverStoreWithEvents()`, `recoverSegment()` helper |
| `module.go` | Call `RecoverStoreWithEvents` in `Provision` before `NewFileStore` |
| `store/file_store_test.go` | Two tests: truncation + read-after-recovery, and event reporting |

🤖 Generated with [Claude Code](https://claude.com/claude-code)