### PR TITLE
fix(client): restore producer offset surface

### DIFF
--- a/.changeset/sour-waves-fix.md
+++ b/.changeset/sour-waves-fix.md
@@ -1,0 +1,11 @@
+---
+"@durable-streams/client": patch
+"@durable-streams/server": patch
+---
+
+Restore the TypeScript client surface expected by Durable Streams consumers:
+publish the SSE control-event constants from the package entrypoint and expose
+`IdempotentProducer.lastSuccessfulOffset` after successful writes or closes.
+
+Republish the server against the fixed client package so `DurableStreamTestServer`
+can import the SSE constants from `@durable-streams/client`.

--- a/packages/client/src/idempotent-producer.ts
+++ b/packages/client/src/idempotent-producer.ts
@@ -148,6 +148,7 @@ export class IdempotentProducer {
   #closed = false
   #closeResult: CloseResult | null = null
   #pendingFinalMessage?: Uint8Array | string
+  #lastSuccessfulOffset: Offset | undefined
 
   // When autoClaim is true, we must wait for the first batch to complete
   // before allowing pipelining (to know what epoch was claimed)
@@ -443,6 +444,7 @@ export class IdempotentProducer {
       // Only increment seq on success (retry-safe)
       this.#nextSeq = seqForThisRequest + 1
       const finalOffset = response.headers.get(STREAM_OFFSET_HEADER) ?? ``
+      this.#recordSuccessfulOffset(finalOffset)
       return { finalOffset }
     }
 
@@ -451,6 +453,7 @@ export class IdempotentProducer {
       // Only increment seq on success (retry-safe)
       this.#nextSeq = seqForThisRequest + 1
       const finalOffset = response.headers.get(STREAM_OFFSET_HEADER) ?? ``
+      this.#recordSuccessfulOffset(finalOffset)
       return { finalOffset }
     }
 
@@ -520,6 +523,14 @@ export class IdempotentProducer {
     return this.#queue.length()
   }
 
+  /**
+   * The greatest non-empty stream offset returned by a successful producer
+   * append or close request.
+   */
+  get lastSuccessfulOffset(): Offset | undefined {
+    return this.#lastSuccessfulOffset
+  }
+
   // ============================================================================
   // Private implementation
   // ============================================================================
@@ -564,7 +575,8 @@ export class IdempotentProducer {
     const epoch = this.#epoch
 
     try {
-      await this.#doSendBatch(batch, seq, epoch)
+      const result = await this.#doSendBatch(batch, seq, epoch)
+      this.#recordSuccessfulOffset(result.offset)
 
       // Mark epoch as claimed after first successful batch
       // This enables full pipelining for subsequent batches
@@ -583,6 +595,15 @@ export class IdempotentProducer {
         this.#onError(error as Error)
       }
       throw error
+    }
+  }
+
+  #recordSuccessfulOffset(offset: Offset | undefined): void {
+    if (
+      offset &&
+      (!this.#lastSuccessfulOffset || offset > this.#lastSuccessfulOffset)
+    ) {
+      this.#lastSuccessfulOffset = offset
     }
   }
 

--- a/packages/client/test/idempotent-producer.test.ts
+++ b/packages/client/test/idempotent-producer.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  SSE_CLOSED_FIELD,
+  SSE_CURSOR_FIELD,
+  SSE_OFFSET_FIELD,
+  STREAM_OFFSET_HEADER,
+} from "../src"
+import { IdempotentProducer } from "../src/idempotent-producer"
+import { DurableStream } from "../src/stream"
+
+describe(`IdempotentProducer`, () => {
+  const offset = (chunk: number, byte: number): string =>
+    `${String(chunk).padStart(16, `0`)}_${String(byte).padStart(16, `0`)}`
+
+  it(`tracks the last successful append offset`, async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { [STREAM_OFFSET_HEADER]: `1_5` },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { [STREAM_OFFSET_HEADER]: `2_10` },
+        })
+      )
+    const stream = new DurableStream({
+      url: `https://example.com/stream`,
+      contentType: `application/json`,
+    })
+    const producer = new IdempotentProducer(stream, `test-producer`, {
+      fetch: mockFetch,
+    })
+
+    expect(producer.lastSuccessfulOffset).toBeUndefined()
+
+    producer.append(JSON.stringify({ message: `first` }))
+    await producer.flush()
+    expect(producer.lastSuccessfulOffset).toBe(`1_5`)
+
+    producer.append(JSON.stringify({ message: `second` }))
+    await producer.flush()
+    expect(producer.lastSuccessfulOffset).toBe(`2_10`)
+  })
+
+  it(`does not clear the last successful offset on duplicate writes`, async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { [STREAM_OFFSET_HEADER]: `1_5` },
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const stream = new DurableStream({
+      url: `https://example.com/stream`,
+      contentType: `application/json`,
+    })
+    const producer = new IdempotentProducer(stream, `test-producer`, {
+      fetch: mockFetch,
+    })
+
+    producer.append(JSON.stringify({ message: `first` }))
+    await producer.flush()
+    producer.append(JSON.stringify({ message: `duplicate` }))
+    await producer.flush()
+
+    expect(producer.lastSuccessfulOffset).toBe(`1_5`)
+  })
+
+  it(`does not move the last successful offset backward when writes complete out of order`, async () => {
+    let resolveFirst: ((response: Response) => void) | undefined
+    const first = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const mockFetch = vi
+      .fn()
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { [STREAM_OFFSET_HEADER]: offset(0, 10) },
+        })
+      )
+    const stream = new DurableStream({
+      url: `https://example.com/stream`,
+      contentType: `text/plain`,
+    })
+    const producer = new IdempotentProducer(stream, `test-producer`, {
+      fetch: mockFetch,
+      maxBatchBytes: 1,
+    })
+
+    producer.append(`a`)
+    producer.append(`b`)
+    const flushed = producer.flush()
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(producer.lastSuccessfulOffset).toBe(offset(0, 10))
+    )
+
+    resolveFirst!(
+      new Response(null, {
+        status: 200,
+        headers: { [STREAM_OFFSET_HEADER]: offset(0, 5) },
+      })
+    )
+    await flushed
+
+    expect(producer.lastSuccessfulOffset).toBe(offset(0, 10))
+  })
+
+  it(`tracks the final close offset`, async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: { [STREAM_OFFSET_HEADER]: `3_15` },
+      })
+    )
+    const stream = new DurableStream({
+      url: `https://example.com/stream`,
+      contentType: `text/plain`,
+    })
+    const producer = new IdempotentProducer(stream, `test-producer`, {
+      fetch: mockFetch,
+    })
+
+    const result = await producer.close(`final`)
+
+    expect(result.finalOffset).toBe(`3_15`)
+    expect(producer.lastSuccessfulOffset).toBe(`3_15`)
+  })
+
+  it(`exports SSE control event field constants from the public entrypoint`, () => {
+    expect(SSE_OFFSET_FIELD).toBe(`streamNextOffset`)
+    expect(SSE_CURSOR_FIELD).toBe(`streamCursor`)
+    expect(SSE_CLOSED_FIELD).toBe(`streamClosed`)
+  })
+})


### PR DESCRIPTION
## Summary

- Expose `IdempotentProducer.lastSuccessfulOffset` from the TypeScript client so consumers can observe the acknowledged stream offset after successful producer writes.
- Keep the tracked offset monotonic so pipelined writes that complete out of order cannot move the observed offset backward.
- Add focused regression coverage for append, duplicate, out-of-order, close, and SSE constant export behavior.
- Add a patch changeset for `@durable-streams/client` and `@durable-streams/server` so the server republishes against the fixed client package.

## Motivation and decisions

Electric consumers need the published Durable Streams packages to provide the same client surface used by the current source: the server imports SSE control-event constants from `@durable-streams/client`, and the runtime needs a successful producer offset after flushing writes. This fixes the missing pieces in the library instead of requiring downstream workarounds.

`lastSuccessfulOffset` records the greatest non-empty offset returned by successful append or close responses. Duplicate `204` responses do not clear it, and later completion of an earlier pipelined request cannot regress it.