### PR TITLE
fix(client): serialize auto-claim producer batches

### DIFF
--- a/.changeset/steady-claims-wait.md
+++ b/.changeset/steady-claims-wait.md
@@ -1,0 +1,10 @@
+---
+"@durable-streams/client": patch
+"@durable-streams/server": patch
+"@durable-streams/state": patch
+---
+
+Fix idempotent producer auto-claim sequencing so later batches wait for the
+first running batch to claim its epoch before reserving and sending subsequent
+sequence numbers. `flush()` now also waits for batches held behind the initial
+auto-claim barrier.

--- a/packages/client/src/idempotent-producer.ts
+++ b/packages/client/src/idempotent-producer.ts
@@ -145,6 +145,7 @@ export class IdempotentProducer {
   // Pipelining via fastq
   readonly #queue: queueAsPromised<BatchTask>
   readonly #maxInFlight: number
+  readonly #deferredEnqueues = new Set<Promise<void>>()
   #closed = false
   #closeResult: CloseResult | null = null
   #pendingFinalMessage?: Uint8Array | string
@@ -325,8 +326,12 @@ export class IdempotentProducer {
       this.#enqueuePendingBatch()
     }
 
-    // Wait for queue to drain
-    await this.#queue.drained()
+    // Wait for the queue and any batches deferred behind the auto-claim
+    // barrier. A deferred enqueue can push more queue work after a drain.
+    do {
+      await this.#queue.drained()
+      await Promise.all(this.#deferredEnqueues)
+    } while (this.#deferredEnqueues.size > 0 || this.inFlightCount > 0)
   }
 
   /**
@@ -520,7 +525,7 @@ export class IdempotentProducer {
    * Number of batches currently in flight.
    */
   get inFlightCount(): number {
-    return this.#queue.length()
+    return this.#queue.length() + this.#queue.running()
   }
 
   /**
@@ -543,28 +548,39 @@ export class IdempotentProducer {
 
     // Take the current batch
     const batch = this.#pendingBatch
-    const seq = this.#nextSeq
-
     this.#pendingBatch = []
     this.#batchBytes = 0
-    this.#nextSeq++
 
     // When autoClaim is enabled and epoch hasn't been claimed yet,
     // we must wait for any in-flight batch to complete before sending more.
     // This ensures the first batch claims the epoch before pipelining begins.
-    if (this.#autoClaim && !this.#epochClaimed && this.#queue.length() > 0) {
-      // Wait for queue to drain, then push
-      this.#queue.drained().then(() => {
-        this.#queue.push({ batch, seq }).catch(() => {
-          // Error handling is done in #batchWorker
+    if (this.#autoClaim && !this.#epochClaimed && this.inFlightCount > 0) {
+      // Wait for queue to drain, then reserve the next sequence number. Do not
+      // reserve the sequence before the first auto-claiming batch can reset it.
+      const deferred = this.#queue
+        .drained()
+        .then(() => {
+          this.#pushBatch(batch)
         })
+        .finally(() => {
+          this.#deferredEnqueues.delete(deferred)
+        })
+      this.#deferredEnqueues.add(deferred)
+      deferred.catch(() => {
+        // Error handling is done by the queue and flush awaits this promise.
       })
     } else {
       // Push to fastq - it handles concurrency automatically
-      this.#queue.push({ batch, seq }).catch(() => {
-        // Error handling is done in #batchWorker
-      })
+      this.#pushBatch(batch)
     }
+  }
+
+  #pushBatch(batch: Array<PendingEntry>): void {
+    const seq = this.#nextSeq
+    this.#nextSeq++
+    this.#queue.push({ batch, seq }).catch(() => {
+      // Error handling is done in #batchWorker
+    })
   }
 
   /**

--- a/packages/client/test/idempotent-producer.test.ts
+++ b/packages/client/test/idempotent-producer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import {
+  PRODUCER_SEQ_HEADER,
   SSE_CLOSED_FIELD,
   SSE_CURSOR_FIELD,
   SSE_OFFSET_FIELD,
@@ -111,6 +112,60 @@ describe(`IdempotentProducer`, () => {
     )
     await flushed
 
+    expect(producer.lastSuccessfulOffset).toBe(offset(0, 10))
+  })
+
+  it(`waits for the first auto-claiming batch before sending later batches`, async () => {
+    let resolveFirst: ((response: Response) => void) | undefined
+    const first = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const mockFetch = vi
+      .fn()
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { [STREAM_OFFSET_HEADER]: offset(0, 10) },
+        })
+      )
+    const stream = new DurableStream({
+      url: `https://example.com/stream`,
+      contentType: `text/plain`,
+    })
+    const producer = new IdempotentProducer(stream, `test-producer`, {
+      autoClaim: true,
+      fetch: mockFetch,
+      maxBatchBytes: 1,
+    })
+
+    producer.append(`a`)
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    producer.append(`b`)
+    let flushResolved = false
+    const flushed = producer.flush().then(() => {
+      flushResolved = true
+    })
+    await Promise.resolve()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(flushResolved).toBe(false)
+
+    resolveFirst!(
+      new Response(null, {
+        status: 200,
+        headers: { [STREAM_OFFSET_HEADER]: offset(0, 5) },
+      })
+    )
+    await flushed
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(
+      new Headers(mockFetch.mock.calls[0]![1]?.headers).get(PRODUCER_SEQ_HEADER)
+    ).toBe(`0`)
+    expect(
+      new Headers(mockFetch.mock.calls[1]![1]?.headers).get(PRODUCER_SEQ_HEADER)
+    ).toBe(`1`)
     expect(producer.lastSuccessfulOffset).toBe(offset(0, 10))
   })
 


### PR DESCRIPTION
## Summary

Fixes an idempotent producer race when autoClaim is enabled and multiple batches are appended before the first request has finished claiming its epoch.

Previously, the producer only checked queued work with fastq.length, which does not include the currently running batch. A later batch could therefore be sent while the initial auto-claim request was still in flight. Because sequence numbers were reserved before the claim completed, the later request could become the first request seen for the newly claimed epoch with a non-zero sequence number, causing the server to reject it with New epoch must start with sequence 0.

This change:

- Counts both queued and running fastq work in inFlightCount.
- Defers later auto-claim batches until the first running batch has completed the epoch claim.
- Reserves sequence numbers only when a deferred batch is actually pushed.
- Makes flush wait for batches held behind the initial auto-claim barrier.
- Adds a regression test that verifies later batches are not sent before the first auto-claiming batch completes, and that flush waits for the delayed batch.

This was found while validating Electric Agents against the latest published Durable Streams packages.