### PR TITLE
docs: add livetrace integration sidebar link

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,10 @@ export default defineConfig({
             text: "AnyCable",
             link: "https://docs.anycable.io/anycable-go/durable_streams",
           },
+          {
+            text: "livetrace",
+            link: "https://livetrace.necmttn.com/durable-streams",
+          },
         ],
       },
       {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -94,7 +94,7 @@ export default defineConfig({
           },
           {
             text: "livetrace",
-            link: "https://livetrace.necmttn.com/durable-streams",
+            link: "https://livetrace.necmttn.com/docs/integrations/durable-streams",
           },
         ],
       },


### PR DESCRIPTION
## Summary

Adds an external sidebar link under **Integrations → livetrace**, mirroring the AnyCable pattern. The integration docs live on the livetrace site (https://livetrace.necmttn.com/durable-streams), so this PR is a one-line `config.mts` change — no markdown, no asset, no styling.

### What livetrace is

[livetrace](https://livetrace.necmttn.com) turns the [Effect](https://effect.website) tracer into a live UI feed. Wrap a workflow in `withTrace`, mount any-framework bindings, and the user sees every span — start, end, log event — as it happens. Built for **user-facing progress UIs** (agent runs, document pipelines, long workflows), not ops dashboards.

### Why Durable Streams

The package ships `livetrace/transports/durable-streams`. Composed into the Effect layer, every span emitted inside a `withTrace` scope is grouped by `TraceScope` and appended as NDJSON to one stream per scope (`trace/{scope.type}/{scope.id}` by default). This gives live-trace UIs three properties they don't get from ephemeral SSE / WebSocket brokers:

- **Resumable** across tab reloads via saved offsets
- **Multi-pod safe** — any backend pod appends, any browser tails
- **CDN-friendly historical reads** for offset-based replays

### What's on the linked page

Server (Effect) + browser quick start, **framework-agnostic** store usage (React / Vue / Svelte / Solid / vanilla — the store is just `subscribe` + `getSnapshot` + `dispatchBatch`), resume-across-reloads, multi-pod / multi-tab, the abstract appender form (BYO Effect service wrapping `@durable-streams/client`), wire format, and deployment (dev `DurableStreamTestServer` → Caddy self-host → Electric Cloud).

### Verifying

Runnable end-to-end example: https://github.com/necmttn/livetrace/tree/main/examples/demo-durable-streams

It boots `DurableStreamTestServer` on `:4437`, an Effect workflow server on `:8789`, and a Vite + React frontend on `:5175` that reads the durable stream back via `@durable-streams/client`'s `stream()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)