### PR TITLE
[DRAFT] CI check: PR #347 rebased on latest main

### DIFF
--- a/.changeset/feat-fork-sub-offset.md
+++ b/.changeset/feat-fork-sub-offset.md
@@ -1,0 +1,25 @@
+---
+"@durable-streams/server": patch
+---
+
+feat(server): support `Stream-Fork-Sub-Offset` for arbitrary-position forks
+
+Adds a new optional header on fork-creation `PUT` requests that refines
+the divergence point past `Stream-Fork-Offset` to a sub-position the
+server has not previously minted. The integer is interpreted per the
+source stream's content type:
+
+- `application/json` — number of flattened messages to inherit past the
+  anchor offset.
+- All other content types — number of decoded entity body bytes to
+  inherit past the anchor offset.
+
+Sub-offset is a separate addressing dimension alongside the opaque
+offset and does not violate offset opacity, uniqueness, or
+strict-monotonicity (PROTOCOL.md §6). Servers materialize the resolved
+prefix into the fork's segment at creation time; reads on the resulting
+fork are unchanged.
+
+See PROTOCOL.md §4.2 for full semantics. This change ships fork-only;
+sub-offset support for read operations is reserved for a future
+revision.

--- a/.gitignore
+++ b/.gitignore
@@ -201,5 +201,8 @@ examples/yjs-demo/.tanstack
 .netlify
 .claude/
 
+# Caddy plugin conformance test output (data_dir from packages/caddy-plugin/test/Caddyfile)
+/data/
+
 # MacOS
 .DS_Store

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -158,6 +158,11 @@ These headers are used on `PUT` requests to create a forked stream:
 
 - `Stream-Forked-From: <source-path>`: The path component of the source stream's URL, relative to the same server. When present, the `PUT` creates a fork rather than a new empty stream. Cross-service forking is not supported — the source stream must be on the same server as the fork.
 - `Stream-Fork-Offset: <offset>`: The divergence point in the source stream. The fork inherits all data from the source up to (but not including) this offset. If omitted, defaults to the source stream's current tail offset.
+- `Stream-Fork-Sub-Offset: <integer>` (optional): A non-negative integer that refines the divergence point to a sub-position past `Stream-Fork-Offset`. Interpreted per the source stream's content type:
+  - For `application/json` streams: number of flattened messages (Section 7.1) to inherit past the anchor.
+  - For all other content types: number of decoded entity body bytes to inherit past the anchor, exclusive of any framing the server uses internally and independent of any HTTP transfer or content encoding used in transit.
+  - Default `0`. A request with sub-offset `0` is equivalent to a request with the header omitted.
+  - The sub-offset is a separate addressing dimension and is not part of the offset value (see Section 6).
 
 When forking, the `Content-Type` header is optional — if omitted, the fork inherits the source stream's content type. If provided, it **MUST** match the source stream's content type; servers **MUST** return `409 Conflict` if it differs. Forks have independent lifetimes and can outlive their source stream. Fork TTL/expiry follows this table:
 
@@ -177,14 +182,15 @@ When forking, the `Content-Type` header is optional — if omitted, the fork inh
 
 Fork creation may return the standard stream creation errors from Section 5.1 (such as `409 Conflict` for content-type mismatch or `400 Bad Request` for invalid TTL/expiry), plus the following fork-specific errors:
 
-| Condition                         | Status          | Description                                                       |
-| --------------------------------- | --------------- | ----------------------------------------------------------------- |
-| Source stream not found           | 404 Not Found   | The `Stream-Forked-From` path does not exist                      |
-| Fork offset beyond stream length  | 400 Bad Request | The `Stream-Fork-Offset` exceeds the source stream's current tail |
-| Invalid offset format             | 400 Bad Request | The `Stream-Fork-Offset` value is malformed                       |
-| Content-Type mismatch with source | 409 Conflict    | Provided `Content-Type` differs from the source stream's type     |
-| Target path already in use        | 409 Conflict    | A stream already exists at the target URL with different config   |
-| Source is soft-deleted            | 409 Conflict    | The source stream has been deleted but still has forks            |
+| Condition                         | Status          | Description                                                                                          |
+| --------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| Source stream not found           | 404 Not Found   | The `Stream-Forked-From` path does not exist                                                         |
+| Fork offset beyond stream length  | 400 Bad Request | The `Stream-Fork-Offset` exceeds the source stream's current tail                                    |
+| Invalid offset format             | 400 Bad Request | The `Stream-Fork-Offset` value is malformed                                                          |
+| Sub-offset overshoot or invalid   | 400 Bad Request | The `Stream-Fork-Sub-Offset` is malformed, negative, or names a position past the next data boundary |
+| Content-Type mismatch with source | 409 Conflict    | Provided `Content-Type` differs from the source stream's type                                        |
+| Target path already in use        | 409 Conflict    | A stream already exists at the target URL with different config                                      |
+| Source is soft-deleted            | 409 Conflict    | The source stream has been deleted but still has forks                                               |
 
 #### Idempotent fork creation
 
@@ -193,6 +199,10 @@ Fork creation follows the same idempotency rules as regular stream creation (Sec
 #### Closed stream forking
 
 Closed streams **MAY** be forked. The resulting fork starts in the open state regardless of the source stream's closed status. This enables forking from historical points in completed streams.
+
+#### Producer state and fork boundaries
+
+Forks **MUST NOT** inherit idempotent producer state (Section 5.2.1) or per-writer `Stream-Seq` state (Section 5.2) from the source. A fork is a new stream from a writer-state perspective; producers writing to the fork **MUST** re-bootstrap their state on the fork (typically by bumping their epoch). This applies to all forks, including those created with `Stream-Fork-Sub-Offset` whose boundary lies inside a producer batch on the source — the source's producer state is unchanged, and the fork's writer-state-fresh shape ensures retries against the fork cannot collide with the partial inherited data.
 
 #### Soft-delete and lifecycle
 
@@ -255,6 +265,7 @@ This provides idempotent "create or ensure exists" semantics aligned with HTTP P
 
 - `Stream-Forked-From` (optional): When present, the `PUT` creates a fork rather than a new empty stream. The value is the URL path of the source stream. See Section 4.2 for fork semantics.
 - `Stream-Fork-Offset` (optional, requires `Stream-Forked-From`): The divergence point in the source stream. If omitted, defaults to the source stream's current tail offset. Servers **MUST** return `400 Bad Request` if the offset exceeds the source stream's tail.
+- `Stream-Fork-Sub-Offset` (optional, requires `Stream-Forked-From`): A non-negative integer refining the divergence point past `Stream-Fork-Offset`. See Section 4.2 for content-type-driven semantics.
 
 #### Request Body (Optional)
 
@@ -1222,6 +1233,8 @@ Offsets are opaque tokens that identify positions within a stream. They are also
 
 **Reserved Values**: The sentinel values `-1` and `now` are reserved by the protocol. Server implementations **MUST NOT** generate these strings as actual stream offsets (in `Stream-Next-Offset` headers or SSE control events). This ensures clients can always distinguish between sentinel requests and real offset values.
 
+**Sub-offset addressing**: For operations that accept a `Stream-Fork-Sub-Offset` header (Section 4.2), the sub-offset is a separate addressing dimension alongside the opaque offset. It is not part of the offset value, does not appear in any response, and does not violate the offset opacity, uniqueness, or strict-monotonicity properties above. Servers internally resolve `(offset, suboffset)` to a precise position; all offset values returned to clients remain server-minted opaque tokens conforming to the properties in this section. Future protocol revisions **MAY** extend sub-offset addressing to read operations using the same content-type-driven semantics.
+
 The opaque nature of offsets enables important server-side optimizations. For example, offsets may encode chunk file identifiers, allowing catch-up requests to be served directly from object storage without touching the main database.
 
 Clients **MUST** use the `Stream-Next-Offset` value returned in responses for subsequent read requests. They **SHOULD** persist offsets locally (e.g., in browser local storage or a database) to enable resumability after disconnection or restart.
@@ -1483,18 +1496,19 @@ This port was selected from the IANA unassigned range 4434-4440. Standalone serv
 
 This document requests registration of the following HTTP headers in the "Permanent Message Header Field Names" registry:
 
-| Field Name           | Status    | Reference     |
-| -------------------- | --------- | ------------- |
-| `Stream-TTL`         | permanent | This document |
-| `Stream-Expires-At`  | permanent | This document |
-| `Stream-Seq`         | permanent | This document |
-| `Stream-Cursor`      | permanent | This document |
-| `Stream-Next-Offset` | permanent | This document |
-| `Stream-Up-To-Date`  | permanent | This document |
-| `Stream-Closed`      | permanent | This document |
-| `Stream-Forked-From` | permanent | This document |
-| `Stream-Fork-Offset` | permanent | This document |
-| `Webhook-Signature`  | permanent | This document |
+| Field Name               | Status    | Reference     |
+| ------------------------ | --------- | ------------- |
+| `Stream-TTL`             | permanent | This document |
+| `Stream-Expires-At`      | permanent | This document |
+| `Stream-Seq`             | permanent | This document |
+| `Stream-Cursor`          | permanent | This document |
+| `Stream-Next-Offset`     | permanent | This document |
+| `Stream-Up-To-Date`      | permanent | This document |
+| `Stream-Closed`          | permanent | This document |
+| `Stream-Forked-From`     | permanent | This document |
+| `Stream-Fork-Offset`     | permanent | This document |
+| `Stream-Fork-Sub-Offset` | permanent | This document |
+| `Webhook-Signature`      | permanent | This document |
 
 **Descriptions:**
 
@@ -1507,6 +1521,7 @@ This document requests registration of the following HTTP headers in the "Perman
 - `Stream-Closed`: Indicates stream is closed / end-of-stream (presence header, value `true`)
 - `Stream-Forked-From`: Source stream path for forked streams, used on `PUT` requests (opaque string)
 - `Stream-Fork-Offset`: Divergence point offset for forked streams, used on `PUT` requests (opaque string)
+- `Stream-Fork-Sub-Offset`: Sub-position refinement past `Stream-Fork-Offset`, used on `PUT` requests (non-negative integer; bytes for non-JSON, message count for JSON)
 - `Webhook-Signature`: Ed25519 signature for webhook notification verification (Section 7.1)
 
 ## 14. References

--- a/packages/caddy-plugin/handler.go
+++ b/packages/caddy-plugin/handler.go
@@ -39,8 +39,9 @@ const (
 
 // Fork headers (request headers only — not set on responses)
 const (
-	HeaderStreamForkedFrom = "Stream-Forked-From"
-	HeaderStreamForkOffset = "Stream-Fork-Offset"
+	HeaderStreamForkedFrom    = "Stream-Forked-From"
+	HeaderStreamForkOffset    = "Stream-Fork-Offset"
+	HeaderStreamForkSubOffset = "Stream-Fork-Sub-Offset"
 )
 
 // sseLineTerminators matches all valid SSE line terminators: CRLF, CR, or LF
@@ -52,7 +53,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	// Set CORS headers
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, HEAD, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Stream-Seq, Stream-TTL, Stream-Expires-At, Stream-Closed, If-None-Match, Producer-Id, Producer-Epoch, Producer-Seq, Stream-Forked-From, Stream-Fork-Offset, Authorization")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Stream-Seq, Stream-TTL, Stream-Expires-At, Stream-Closed, If-None-Match, Producer-Id, Producer-Epoch, Producer-Seq, Stream-Forked-From, Stream-Fork-Offset, Stream-Fork-Sub-Offset, Authorization")
 	w.Header().Set("Access-Control-Expose-Headers", "Stream-Next-Offset, Stream-Cursor, Stream-Up-To-Date, Stream-Closed, ETag, Location, Producer-Epoch, Producer-Seq, Producer-Expected-Seq, Producer-Received-Seq")
 
 	// Browser security headers (Protocol Section 10.7)
@@ -117,6 +118,13 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, path stri
 	// Parse fork headers
 	forkedFromStr := r.Header.Get(HeaderStreamForkedFrom)
 	forkOffsetStr := r.Header.Get(HeaderStreamForkOffset)
+	// Use Values() to distinguish "header present but empty" from "absent"
+	forkSubOffsetVals := r.Header.Values(HeaderStreamForkSubOffset)
+	forkSubOffsetPresent := len(forkSubOffsetVals) > 0
+	forkSubOffsetStr := ""
+	if forkSubOffsetPresent {
+		forkSubOffsetStr = forkSubOffsetVals[0]
+	}
 
 	// Validate TTL and ExpiresAt aren't both provided
 	if ttlStr != "" && expiresAtStr != "" {
@@ -171,6 +179,18 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, path stri
 		opts.ForkOffset = &forkOffset
 	}
 
+	// Parse fork sub-offset if header was present (including empty value)
+	if forkSubOffsetPresent {
+		if forkedFromStr == "" {
+			return newHTTPError(http.StatusBadRequest, "Stream-Fork-Sub-Offset requires Stream-Forked-From")
+		}
+		subOffset, err := parseSubOffset(forkSubOffsetStr)
+		if err != nil {
+			return newHTTPError(http.StatusBadRequest, err.Error())
+		}
+		opts.ForkSubOffset = &subOffset
+	}
+
 	meta, wasCreated, err := h.store.Create(path, opts)
 	if err != nil {
 		if errors.Is(err, store.ErrStreamNotFound) {
@@ -178,6 +198,9 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, path stri
 		}
 		if errors.Is(err, store.ErrInvalidForkOffset) {
 			return newHTTPError(http.StatusBadRequest, "fork offset beyond source stream length")
+		}
+		if errors.Is(err, store.ErrInvalidForkSubOffset) {
+			return newHTTPError(http.StatusBadRequest, "fork sub-offset overshoots or is invalid")
 		}
 		if errors.Is(err, store.ErrStreamSoftDeleted) {
 			return newHTTPError(http.StatusConflict, "source stream was deleted but still has active forks")
@@ -1051,4 +1074,20 @@ func parseTTL(s string) (int64, error) {
 	}
 
 	return ttl, nil
+}
+
+// subOffsetRegex matches the same digit-only format as TTL.
+var subOffsetRegex = regexp.MustCompile(`^[1-9][0-9]*$|^0$`)
+
+// parseSubOffset parses a Stream-Fork-Sub-Offset value: a non-negative integer
+// without leading zeros, sign, or whitespace.
+func parseSubOffset(s string) (uint64, error) {
+	if !subOffsetRegex.MatchString(s) {
+		return 0, fmt.Errorf("invalid Stream-Fork-Sub-Offset format: must be a non-negative integer without leading zeros")
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid Stream-Fork-Sub-Offset: %w", err)
+	}
+	return v, nil
 }

--- a/packages/caddy-plugin/store/bbolt.go
+++ b/packages/caddy-plugin/store/bbolt.go
@@ -35,11 +35,12 @@ type bboltMetadata struct {
 	Closed   bool                   `json:"closed,omitempty"`
 	ClosedBy *bboltClosedByProducer `json:"closed_by,omitempty"`
 	// Fork state
-	ForkedFrom         string `json:"forked_from,omitempty"`
-	ForkOffset         string `json:"fork_offset,omitempty"`
-	ForkSubOffsetBytes uint64 `json:"fork_sub_offset_bytes,omitempty"`
-	RefCount           int32  `json:"ref_count,omitempty"`
-	SoftDeleted        bool   `json:"soft_deleted,omitempty"`
+	ForkedFrom          string `json:"forked_from,omitempty"`
+	ForkOffset          string `json:"fork_offset,omitempty"`
+	ForkOffsetRequested string `json:"fork_offset_requested,omitempty"` // User-supplied original; empty if user omitted ForkOffset on creation. Differs from ForkOffset for JSON forks created with sub-offset > 0.
+	ForkSubOffset       uint64 `json:"fork_sub_offset,omitempty"`       // User-supplied Stream-Fork-Sub-Offset value (count for JSON, bytes for binary).
+	RefCount            int32  `json:"ref_count,omitempty"`
+	SoftDeleted         bool   `json:"soft_deleted,omitempty"`
 }
 
 // bboltClosedByProducer is the serialized form of ClosedByProducer
@@ -140,7 +141,10 @@ func (s *BboltMetadataStore) Put(meta *StreamMetadata, directoryName string) err
 	bm.ForkedFrom = meta.ForkedFrom
 	if meta.ForkedFrom != "" {
 		bm.ForkOffset = meta.ForkOffset.String()
-		bm.ForkSubOffsetBytes = meta.ForkSubOffsetBytes
+		if meta.ForkOffsetRequested != nil {
+			bm.ForkOffsetRequested = meta.ForkOffsetRequested.String()
+		}
+		bm.ForkSubOffset = meta.ForkSubOffset
 	}
 	bm.RefCount = meta.RefCount
 	bm.SoftDeleted = meta.SoftDeleted
@@ -235,7 +239,14 @@ func (s *BboltMetadataStore) Get(path string) (*StreamMetadata, string, error) {
 			}
 			meta.ForkOffset = forkOffset
 		}
-		meta.ForkSubOffsetBytes = bm.ForkSubOffsetBytes
+		if bm.ForkOffsetRequested != "" {
+			forkOffsetRequested, err := ParseOffset(bm.ForkOffsetRequested)
+			if err != nil {
+				return fmt.Errorf("invalid fork offset requested: %w", err)
+			}
+			meta.ForkOffsetRequested = &forkOffsetRequested
+		}
+		meta.ForkSubOffset = bm.ForkSubOffset
 		meta.RefCount = bm.RefCount
 		meta.SoftDeleted = bm.SoftDeleted
 
@@ -488,7 +499,14 @@ func (s *BboltMetadataStore) ForEach(fn func(meta *StreamMetadata, directoryName
 				}
 				meta.ForkOffset = forkOffset
 			}
-			meta.ForkSubOffsetBytes = bm.ForkSubOffsetBytes
+			if bm.ForkOffsetRequested != "" {
+				forkOffsetRequested, err := ParseOffset(bm.ForkOffsetRequested)
+				if err != nil {
+					return fmt.Errorf("invalid fork offset requested: %w", err)
+				}
+				meta.ForkOffsetRequested = &forkOffsetRequested
+			}
+			meta.ForkSubOffset = bm.ForkSubOffset
 			meta.RefCount = bm.RefCount
 			meta.SoftDeleted = bm.SoftDeleted
 

--- a/packages/caddy-plugin/store/bbolt.go
+++ b/packages/caddy-plugin/store/bbolt.go
@@ -35,10 +35,11 @@ type bboltMetadata struct {
 	Closed   bool                   `json:"closed,omitempty"`
 	ClosedBy *bboltClosedByProducer `json:"closed_by,omitempty"`
 	// Fork state
-	ForkedFrom  string `json:"forked_from,omitempty"`
-	ForkOffset  string `json:"fork_offset,omitempty"`
-	RefCount    int32  `json:"ref_count,omitempty"`
-	SoftDeleted bool   `json:"soft_deleted,omitempty"`
+	ForkedFrom         string `json:"forked_from,omitempty"`
+	ForkOffset         string `json:"fork_offset,omitempty"`
+	ForkSubOffsetBytes uint64 `json:"fork_sub_offset_bytes,omitempty"`
+	RefCount           int32  `json:"ref_count,omitempty"`
+	SoftDeleted        bool   `json:"soft_deleted,omitempty"`
 }
 
 // bboltClosedByProducer is the serialized form of ClosedByProducer
@@ -139,6 +140,7 @@ func (s *BboltMetadataStore) Put(meta *StreamMetadata, directoryName string) err
 	bm.ForkedFrom = meta.ForkedFrom
 	if meta.ForkedFrom != "" {
 		bm.ForkOffset = meta.ForkOffset.String()
+		bm.ForkSubOffsetBytes = meta.ForkSubOffsetBytes
 	}
 	bm.RefCount = meta.RefCount
 	bm.SoftDeleted = meta.SoftDeleted
@@ -233,6 +235,7 @@ func (s *BboltMetadataStore) Get(path string) (*StreamMetadata, string, error) {
 			}
 			meta.ForkOffset = forkOffset
 		}
+		meta.ForkSubOffsetBytes = bm.ForkSubOffsetBytes
 		meta.RefCount = bm.RefCount
 		meta.SoftDeleted = bm.SoftDeleted
 
@@ -485,6 +488,7 @@ func (s *BboltMetadataStore) ForEach(fn func(meta *StreamMetadata, directoryName
 				}
 				meta.ForkOffset = forkOffset
 			}
+			meta.ForkSubOffsetBytes = bm.ForkSubOffsetBytes
 			meta.RefCount = bm.RefCount
 			meta.SoftDeleted = bm.SoftDeleted
 

--- a/packages/caddy-plugin/store/file_store.go
+++ b/packages/caddy-plugin/store/file_store.go
@@ -270,6 +270,17 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 		meta.ForkedFrom = opts.ForkedFrom
 		meta.TTLSeconds = forkTTL
 		meta.ExpiresAt = forkExpiresAt
+		// Persist the user-supplied ForkOffset (may be nil if omitted) and
+		// the user-supplied ForkSubOffset for idempotent re-creation matching.
+		// These differ from meta.ForkOffset for JSON forks created with
+		// sub-offset > 0 (where meta.ForkOffset is advanced internally).
+		if opts.ForkOffset != nil {
+			requested := *opts.ForkOffset
+			meta.ForkOffsetRequested = &requested
+		}
+		if opts.ForkSubOffset != nil {
+			meta.ForkSubOffset = *opts.ForkSubOffset
+		}
 
 		// Materialize binary sub-offset prefix into the fork's segment.
 		// This must happen before any client-supplied initial data so the
@@ -298,10 +309,7 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 			}
 			writer.Close()
 
-			// Store the user-supplied sub-offset (content bytes) for idempotent
-			// re-creation matching. The physical advance includes the length
-			// prefix written by WriteMessage.
-			meta.ForkSubOffsetBytes = uint64(len(binarySubOffsetPrefix))
+			// Advance the fork's currentOffset past the materialized prefix.
 			meta.CurrentOffset = forkOffset.Add(uint64(LengthPrefixSize + len(binarySubOffsetPrefix)))
 		}
 	} else {

--- a/packages/caddy-plugin/store/file_store.go
+++ b/packages/caddy-plugin/store/file_store.go
@@ -150,6 +150,7 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 	var forkOffset Offset
 	var sourceContentType string
 	var sourceMeta *StreamMetadata
+	var binarySubOffsetPrefix []byte // For binary forks with sub-offset: bytes to materialize into the fork's segment
 	isFork := opts.ForkedFrom != ""
 
 	if isFork {
@@ -177,6 +178,26 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 		// Validate: ZeroOffset <= forkOffset <= source.CurrentOffset
 		if forkOffset.LessThan(ZeroOffset) || sourceMeta.CurrentOffset.LessThan(forkOffset) {
 			return nil, false, ErrInvalidForkOffset
+		}
+
+		// Resolve sub-offset (if any) against the source. For JSON, this
+		// advances forkOffset to a server-minted message-boundary offset; the
+		// fork's metadata then stores no synthetic prefix. For binary, this
+		// returns the prefix bytes to materialize into the fork's segment.
+		if opts.ForkSubOffset != nil && *opts.ForkSubOffset > 0 {
+			sourceDirName, ok := s.dirCache[opts.ForkedFrom]
+			if !ok {
+				return nil, false, ErrStreamNotFound
+			}
+			resolvedOffset, prefixBytes, err := s.resolveForkSubOffset(sourceMeta, sourceDirName, forkOffset, *opts.ForkSubOffset)
+			if err != nil {
+				return nil, false, err
+			}
+			if IsJSONContentType(sourceMeta.ContentType) {
+				forkOffset = resolvedOffset
+			} else {
+				binarySubOffsetPrefix = prefixBytes
+			}
 		}
 
 		// Atomically increment source refcount in bbolt
@@ -249,6 +270,40 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 		meta.ForkedFrom = opts.ForkedFrom
 		meta.TTLSeconds = forkTTL
 		meta.ExpiresAt = forkExpiresAt
+
+		// Materialize binary sub-offset prefix into the fork's segment.
+		// This must happen before any client-supplied initial data so the
+		// inherited prefix appears first in the fork's read order.
+		if len(binarySubOffsetPrefix) > 0 {
+			writer, err := NewSegmentWriter(segPath)
+			if err != nil {
+				os.RemoveAll(streamDir)
+				s.metaStore.DecrementRefCount(opts.ForkedFrom)
+				sourceMeta.RefCount--
+				return nil, false, fmt.Errorf("failed to open fork segment for sub-offset materialization: %w", err)
+			}
+			if _, err := writer.WriteMessage(binarySubOffsetPrefix); err != nil {
+				writer.Close()
+				os.RemoveAll(streamDir)
+				s.metaStore.DecrementRefCount(opts.ForkedFrom)
+				sourceMeta.RefCount--
+				return nil, false, fmt.Errorf("failed to materialize sub-offset prefix: %w", err)
+			}
+			if err := writer.Sync(); err != nil {
+				writer.Close()
+				os.RemoveAll(streamDir)
+				s.metaStore.DecrementRefCount(opts.ForkedFrom)
+				sourceMeta.RefCount--
+				return nil, false, fmt.Errorf("failed to sync fork segment: %w", err)
+			}
+			writer.Close()
+
+			// Store the user-supplied sub-offset (content bytes) for idempotent
+			// re-creation matching. The physical advance includes the length
+			// prefix written by WriteMessage.
+			meta.ForkSubOffsetBytes = uint64(len(binarySubOffsetPrefix))
+			meta.CurrentOffset = forkOffset.Add(uint64(LengthPrefixSize + len(binarySubOffsetPrefix)))
+		}
 	} else {
 		meta.CurrentOffset = ZeroOffset
 		meta.TTLSeconds = opts.TTLSeconds
@@ -728,6 +783,47 @@ func (s *FileStore) appendToStream(meta *StreamMetadata, dirName string, data []
 	}
 
 	return meta.CurrentOffset.Add(uint64(n)), nil
+}
+
+// resolveForkSubOffset walks the source stream from forkOffset and resolves a
+// non-zero sub-offset.
+//
+// For JSON sources, it returns the offset that lies subOffset flattened
+// messages past forkOffset; the second return value is unused.
+//
+// For non-JSON (binary) sources, it returns the original forkOffset and a
+// byte slice containing the first subOffset content bytes of the message
+// that begins at forkOffset. The caller materializes those bytes as the
+// first message of the fork's own segment.
+//
+// Errors with ErrInvalidForkSubOffset if the resolution overshoots available
+// data.
+func (s *FileStore) resolveForkSubOffset(sourceMeta *StreamMetadata, sourceDirName string, forkOffset Offset, subOffset uint64) (Offset, []byte, error) {
+	// Read the source from forkOffset onward (across its own fork chain if any)
+	sourceMessages, err := s.readForkedStream(sourceMeta, sourceDirName, forkOffset)
+	if err != nil {
+		return Offset{}, nil, fmt.Errorf("failed to read source for sub-offset resolution: %w", err)
+	}
+
+	if IsJSONContentType(sourceMeta.ContentType) {
+		// Walk subOffset flattened messages from forkOffset.
+		if uint64(len(sourceMessages)) < subOffset {
+			return Offset{}, nil, ErrInvalidForkSubOffset
+		}
+		return sourceMessages[subOffset-1].Offset, nil, nil
+	}
+
+	// Binary: there must be at least one message past forkOffset to slice.
+	if len(sourceMessages) == 0 {
+		return Offset{}, nil, ErrInvalidForkSubOffset
+	}
+	first := sourceMessages[0].Data
+	if uint64(len(first)) < subOffset {
+		return Offset{}, nil, ErrInvalidForkSubOffset
+	}
+	prefix := make([]byte, subOffset)
+	copy(prefix, first[:subOffset])
+	return forkOffset, prefix, nil
 }
 
 // readFromSegment reads messages from a segment file starting at the given physical offset.

--- a/packages/caddy-plugin/store/memory_store.go
+++ b/packages/caddy-plugin/store/memory_store.go
@@ -174,21 +174,24 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 	var forkOffset Offset
 	var sourceContentType string
 	var sourceMeta *StreamMetadata
+	var sourceStream *memoryStream
+	var binarySubOffsetPrefix []byte
 	isFork := opts.ForkedFrom != ""
 
 	if isFork {
-		sourceStream, ok := s.streams[opts.ForkedFrom]
+		ss, ok := s.streams[opts.ForkedFrom]
 		if !ok {
 			return nil, false, ErrStreamNotFound
 		}
-		if sourceStream.metadata.SoftDeleted {
+		if ss.metadata.SoftDeleted {
 			return nil, false, ErrStreamSoftDeleted
 		}
-		if sourceStream.metadata.IsExpired() {
+		if ss.metadata.IsExpired() {
 			return nil, false, ErrStreamNotFound
 		}
 
-		sourceMeta = &sourceStream.metadata
+		sourceStream = ss
+		sourceMeta = &ss.metadata
 		sourceContentType = sourceMeta.ContentType
 
 		// Resolve fork offset: use opts.ForkOffset if set, else source's CurrentOffset
@@ -201,6 +204,19 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		// Validate: ZeroOffset <= forkOffset <= source.CurrentOffset
 		if forkOffset.LessThan(ZeroOffset) || sourceMeta.CurrentOffset.LessThan(forkOffset) {
 			return nil, false, ErrInvalidForkOffset
+		}
+
+		// Resolve sub-offset against the source stream
+		if opts.ForkSubOffset != nil && *opts.ForkSubOffset > 0 {
+			resolvedOffset, prefixBytes, err := s.resolveForkSubOffset(sourceStream, forkOffset, *opts.ForkSubOffset)
+			if err != nil {
+				return nil, false, err
+			}
+			if isJSONContentType(sourceMeta.ContentType) {
+				forkOffset = resolvedOffset
+			} else {
+				binarySubOffsetPrefix = prefixBytes
+			}
 		}
 
 		// Increment source refcount
@@ -246,6 +262,18 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		metadata: meta,
 		messages: make([]Message, 0),
 		data:     make([]byte, 0),
+	}
+
+	// Materialize binary sub-offset prefix as the fork's first own message.
+	if isFork && len(binarySubOffsetPrefix) > 0 {
+		newOffset := stream.metadata.CurrentOffset.Add(uint64(len(binarySubOffsetPrefix)))
+		stream.messages = append(stream.messages, Message{
+			Data:   binarySubOffsetPrefix,
+			Offset: newOffset,
+		})
+		stream.data = append(stream.data, binarySubOffsetPrefix...)
+		stream.metadata.CurrentOffset = newOffset
+		stream.metadata.ForkSubOffsetBytes = uint64(len(binarySubOffsetPrefix))
 	}
 
 	// Handle initial data
@@ -700,6 +728,32 @@ func readOwnMessages(stream *memoryStream, offset Offset, capAtOffset *Offset) [
 		}
 	}
 	return messages
+}
+
+// resolveForkSubOffset walks the source stream from forkOffset and resolves a
+// non-zero sub-offset. See FileStore.resolveForkSubOffset for semantics.
+func (s *MemoryStore) resolveForkSubOffset(sourceStream *memoryStream, forkOffset Offset, subOffset uint64) (Offset, []byte, error) {
+	// Read the source from forkOffset onward (across its fork chain if any)
+	sourceMessages := s.readForkedStream(sourceStream, forkOffset)
+
+	if isJSONContentType(sourceStream.metadata.ContentType) {
+		if uint64(len(sourceMessages)) < subOffset {
+			return Offset{}, nil, ErrInvalidForkSubOffset
+		}
+		return sourceMessages[subOffset-1].Offset, nil, nil
+	}
+
+	// Binary: at least one message must follow forkOffset
+	if len(sourceMessages) == 0 {
+		return Offset{}, nil, ErrInvalidForkSubOffset
+	}
+	first := sourceMessages[0].Data
+	if uint64(len(first)) < subOffset {
+		return Offset{}, nil, ErrInvalidForkSubOffset
+	}
+	prefix := make([]byte, subOffset)
+	copy(prefix, first[:subOffset])
+	return forkOffset, prefix, nil
 }
 
 // readForkedStream reads messages across the fork chain. For non-forks it delegates

--- a/packages/caddy-plugin/store/memory_store.go
+++ b/packages/caddy-plugin/store/memory_store.go
@@ -252,6 +252,17 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		meta.ForkedFrom = opts.ForkedFrom
 		meta.TTLSeconds = forkTTL
 		meta.ExpiresAt = forkExpiresAt
+		// Persist the user-supplied ForkOffset (may be nil if omitted) and
+		// the user-supplied ForkSubOffset for idempotent re-creation matching.
+		// These differ from meta.ForkOffset for JSON forks created with
+		// sub-offset > 0 (where meta.ForkOffset is advanced internally).
+		if opts.ForkOffset != nil {
+			requested := *opts.ForkOffset
+			meta.ForkOffsetRequested = &requested
+		}
+		if opts.ForkSubOffset != nil {
+			meta.ForkSubOffset = *opts.ForkSubOffset
+		}
 	} else {
 		meta.CurrentOffset = ZeroOffset
 		meta.TTLSeconds = opts.TTLSeconds
@@ -273,7 +284,6 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		})
 		stream.data = append(stream.data, binarySubOffsetPrefix...)
 		stream.metadata.CurrentOffset = newOffset
-		stream.metadata.ForkSubOffsetBytes = uint64(len(binarySubOffsetPrefix))
 	}
 
 	// Handle initial data

--- a/packages/caddy-plugin/store/store.go
+++ b/packages/caddy-plugin/store/store.go
@@ -195,22 +195,23 @@ type Message struct {
 
 // StreamMetadata contains metadata about a stream
 type StreamMetadata struct {
-	Path               string
-	ContentType        string
-	CurrentOffset      Offset
-	LastSeq            string // Last Stream-Seq value
-	TTLSeconds         *int64
-	ExpiresAt          *time.Time
-	CreatedAt          time.Time
-	LastAccessedAt     time.Time
-	Producers          map[string]*ProducerState // Producer ID -> state
-	Closed             bool                      // Stream is closed (no more appends allowed)
-	ClosedBy           *ClosedByProducer         // Producer that closed the stream (for idempotent duplicate detection)
-	ForkedFrom         string                    // Source stream path (empty if not a fork)
-	ForkOffset         Offset                    // Divergence point: offsets < ForkOffset come from source
-	ForkSubOffsetBytes uint64                    // Materialized prefix bytes from the source's message at ForkOffset (0 = no sub-offset slice). Non-JSON forks only.
-	RefCount           int32                     // Number of forks referencing this stream
-	SoftDeleted        bool                      // Logically deleted but retained for fork readers
+	Path                string
+	ContentType         string
+	CurrentOffset       Offset
+	LastSeq             string // Last Stream-Seq value
+	TTLSeconds          *int64
+	ExpiresAt           *time.Time
+	CreatedAt           time.Time
+	LastAccessedAt      time.Time
+	Producers           map[string]*ProducerState // Producer ID -> state
+	Closed              bool                      // Stream is closed (no more appends allowed)
+	ClosedBy            *ClosedByProducer         // Producer that closed the stream (for idempotent duplicate detection)
+	ForkedFrom          string                    // Source stream path (empty if not a fork)
+	ForkOffset          Offset                    // Internal divergence point: offsets < ForkOffset come from source. For JSON forks created with a sub-offset this is advanced past the user-supplied offset; ForkOffsetRequested holds the original.
+	ForkOffsetRequested *Offset                   // The user-supplied Stream-Fork-Offset (nil if omitted). Differs from ForkOffset only for JSON forks created with sub-offset > 0; used for idempotent re-creation matching.
+	ForkSubOffset       uint64                    // User-supplied Stream-Fork-Sub-Offset value: bytes for non-JSON forks, flattened message count for JSON forks (0 = no sub-offset slice). Stored verbatim for idempotent re-creation matching.
+	RefCount            int32                     // Number of forks referencing this stream
+	SoftDeleted         bool                      // Logically deleted but retained for fork readers
 }
 
 // IsExpired checks if the stream has expired based on TTL or ExpiresAt
@@ -266,18 +267,31 @@ func (m *StreamMetadata) ConfigMatches(opts CreateOptions) bool {
 		return false
 	}
 	if opts.ForkedFrom != "" {
-		if opts.ForkOffset != nil && !m.ForkOffset.Equal(*opts.ForkOffset) {
-			return false
+		// Compare against the user-supplied ForkOffset (ForkOffsetRequested),
+		// not the internally-resolved ForkOffset. The two differ for JSON
+		// forks created with a sub-offset (where ForkOffset is advanced past
+		// the user-supplied value).
+		if opts.ForkOffset != nil {
+			storedRequested := m.ForkOffsetRequested
+			if storedRequested == nil {
+				// Backward-compat: pre-PR metadata wasn't tracking the
+				// requested offset; fall back to the internal ForkOffset
+				// (correct for non-JSON-sub-offset forks, which is the
+				// only case the old code wrote).
+				storedRequested = &m.ForkOffset
+			}
+			if !storedRequested.Equal(*opts.ForkOffset) {
+				return false
+			}
 		}
-		// Sub-offset: nil and 0 are equivalent.
+		// Sub-offset: nil and 0 are equivalent. Compare the raw user-supplied
+		// integer (count for JSON, bytes for binary) so the comparison is
+		// independent of how it was resolved internally.
 		var requestedSub uint64
 		if opts.ForkSubOffset != nil {
 			requestedSub = *opts.ForkSubOffset
 		}
-		// For JSON forks, ForkSubOffsetBytes is always 0; sub-offset is
-		// resolved into ForkOffset itself, so config match is on offset alone.
-		// For binary forks, the materialized prefix length must match.
-		if !IsJSONContentType(m.ContentType) && m.ForkSubOffsetBytes != requestedSub {
+		if m.ForkSubOffset != requestedSub {
 			return false
 		}
 	}

--- a/packages/caddy-plugin/store/store.go
+++ b/packages/caddy-plugin/store/store.go
@@ -31,9 +31,10 @@ var (
 
 // Fork-related errors
 var (
-	ErrStreamSoftDeleted = errors.New("stream is soft-deleted")
-	ErrInvalidForkOffset = errors.New("fork offset beyond source stream length")
-	ErrRefCountUnderflow = errors.New("reference count underflow")
+	ErrStreamSoftDeleted    = errors.New("stream is soft-deleted")
+	ErrInvalidForkOffset    = errors.New("fork offset beyond source stream length")
+	ErrInvalidForkSubOffset = errors.New("fork sub-offset overshoots or is invalid")
+	ErrRefCountUnderflow    = errors.New("reference count underflow")
 )
 
 // ProducerState tracks the epoch and sequence for an idempotent producer
@@ -154,13 +155,14 @@ type ClosedByProducer struct {
 
 // CreateOptions contains options for creating a stream
 type CreateOptions struct {
-	ContentType string
-	TTLSeconds  *int64
-	ExpiresAt   *time.Time
-	InitialData []byte
-	Closed      bool    // Create stream in closed state
-	ForkedFrom  string  // Source stream path (fork creation)
-	ForkOffset  *Offset // Fork offset (nil = source's current tail)
+	ContentType   string
+	TTLSeconds    *int64
+	ExpiresAt     *time.Time
+	InitialData   []byte
+	Closed        bool    // Create stream in closed state
+	ForkedFrom    string  // Source stream path (fork creation)
+	ForkOffset    *Offset // Fork offset (nil = source's current tail)
+	ForkSubOffset *uint64 // Sub-position past ForkOffset (nil = 0). Bytes for non-JSON, message count for JSON.
 }
 
 // AppendOptions contains options for appending to a stream
@@ -193,21 +195,22 @@ type Message struct {
 
 // StreamMetadata contains metadata about a stream
 type StreamMetadata struct {
-	Path           string
-	ContentType    string
-	CurrentOffset  Offset
-	LastSeq        string // Last Stream-Seq value
-	TTLSeconds     *int64
-	ExpiresAt      *time.Time
-	CreatedAt      time.Time
-	LastAccessedAt time.Time
-	Producers      map[string]*ProducerState // Producer ID -> state
-	Closed         bool                      // Stream is closed (no more appends allowed)
-	ClosedBy       *ClosedByProducer         // Producer that closed the stream (for idempotent duplicate detection)
-	ForkedFrom     string                    // Source stream path (empty if not a fork)
-	ForkOffset     Offset                    // Divergence point: offsets < ForkOffset come from source
-	RefCount       int32                     // Number of forks referencing this stream
-	SoftDeleted    bool                      // Logically deleted but retained for fork readers
+	Path               string
+	ContentType        string
+	CurrentOffset      Offset
+	LastSeq            string // Last Stream-Seq value
+	TTLSeconds         *int64
+	ExpiresAt          *time.Time
+	CreatedAt          time.Time
+	LastAccessedAt     time.Time
+	Producers          map[string]*ProducerState // Producer ID -> state
+	Closed             bool                      // Stream is closed (no more appends allowed)
+	ClosedBy           *ClosedByProducer         // Producer that closed the stream (for idempotent duplicate detection)
+	ForkedFrom         string                    // Source stream path (empty if not a fork)
+	ForkOffset         Offset                    // Divergence point: offsets < ForkOffset come from source
+	ForkSubOffsetBytes uint64                    // Materialized prefix bytes from the source's message at ForkOffset (0 = no sub-offset slice). Non-JSON forks only.
+	RefCount           int32                     // Number of forks referencing this stream
+	SoftDeleted        bool                      // Logically deleted but retained for fork readers
 }
 
 // IsExpired checks if the stream has expired based on TTL or ExpiresAt
@@ -264,6 +267,17 @@ func (m *StreamMetadata) ConfigMatches(opts CreateOptions) bool {
 	}
 	if opts.ForkedFrom != "" {
 		if opts.ForkOffset != nil && !m.ForkOffset.Equal(*opts.ForkOffset) {
+			return false
+		}
+		// Sub-offset: nil and 0 are equivalent.
+		var requestedSub uint64
+		if opts.ForkSubOffset != nil {
+			requestedSub = *opts.ForkSubOffset
+		}
+		// For JSON forks, ForkSubOffsetBytes is always 0; sub-offset is
+		// resolved into ForkOffset itself, so config match is on offset alone.
+		// For binary forks, the materialized prefix length must match.
+		if !IsJSONContentType(m.ContentType) && m.ForkSubOffsetBytes != requestedSub {
 			return false
 		}
 	}

--- a/packages/server-conformance-tests/src/index.ts
+++ b/packages/server-conformance-tests/src/index.ts
@@ -8194,6 +8194,592 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
       })
       expect(appendRes.status).toBe(204)
     })
+
+    // ------------------------------------------------------------------
+    // Sub-offset forking (Stream-Fork-Sub-Offset)
+    // ------------------------------------------------------------------
+
+    const STREAM_FORK_SUB_OFFSET_HEADER = `Stream-Fork-Sub-Offset`
+
+    test(`should fork at a binary sub-offset within an append`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-bin-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-bin-fork-${id}`
+
+      // Create source with one append of 5 bytes
+      const createRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+      expect(createRes.status).toBe(201)
+
+      // Fork at the start, taking the first 3 bytes of the append
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+
+      // Read fork → should see only "hel"
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(readRes.status).toBe(200)
+      const body = await readRes.text()
+      expect(body).toBe(`hel`)
+    })
+
+    test(`should fork at a JSON sub-offset within a flattened batch`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-json-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-json-fork-${id}`
+
+      // Create JSON source with a 4-element flattened batch
+      const createRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"a":1},{"b":2},{"c":3},{"d":4}]`,
+      })
+      expect(createRes.status).toBe(201)
+
+      // Fork at start, taking only the first 2 flattened messages
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `application/json`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `2`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+
+      // Read fork → should be [{"a":1},{"b":2}]
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(readRes.status).toBe(200)
+      const body = await readRes.json()
+      expect(body).toEqual([{ a: 1 }, { b: 2 }])
+    })
+
+    test(`should treat sub-offset 0 as equivalent to absent header`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-zero-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-zero-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `data`,
+      })
+
+      // First PUT without sub-offset
+      const res1 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+        },
+      })
+      expect(res1.status).toBe(201)
+
+      // Second PUT with sub-offset=0 → idempotent 200
+      const res2 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `0`,
+        },
+      })
+      expect(res2.status).toBe(200)
+    })
+
+    test(`should return 400 when binary sub-offset overshoots message length`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-over-bin-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-over-bin-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hi`, // 2 bytes
+      })
+
+      const res = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `5`,
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    test(`should return 400 when JSON sub-offset overshoots message count`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-over-json-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-over-json-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"a":1},{"b":2},{"c":3}]`,
+      })
+
+      const res = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `application/json`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `4`,
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    test(`should return 400 for malformed sub-offset values`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-bad-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-bad-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `data`,
+      })
+
+      for (const bad of [`-1`, `abc`, `1.5`, `05`, `+1`]) {
+        const res = await fetch(`${getBaseUrl()}${forkPath}`, {
+          method: `PUT`,
+          headers: {
+            "Content-Type": `text/plain`,
+            [STREAM_FORKED_FROM_HEADER]: sourcePath,
+            [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+            [STREAM_FORK_SUB_OFFSET_HEADER]: bad,
+          },
+        })
+        expect(res.status).toBe(400)
+      }
+    })
+
+    test(`should be idempotent when re-creating with matching sub-offset`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-idem-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-idem-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+
+      const headers = {
+        "Content-Type": `text/plain`,
+        [STREAM_FORKED_FROM_HEADER]: sourcePath,
+        [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+        [STREAM_FORK_SUB_OFFSET_HEADER]: `2`,
+      }
+
+      const res1 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers,
+      })
+      expect(res1.status).toBe(201)
+
+      const res2 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers,
+      })
+      expect(res2.status).toBe(200)
+    })
+
+    test(`should return 409 when re-creating with mismatched sub-offset`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-conflict-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-conflict-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+
+      const baseHeaders = {
+        "Content-Type": `text/plain`,
+        [STREAM_FORKED_FROM_HEADER]: sourcePath,
+        [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+      }
+
+      const res1 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: { ...baseHeaders, [STREAM_FORK_SUB_OFFSET_HEADER]: `2` },
+      })
+      expect(res1.status).toBe(201)
+
+      const res2 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: { ...baseHeaders, [STREAM_FORK_SUB_OFFSET_HEADER]: `3` },
+      })
+      expect(res2.status).toBe(409)
+    })
+
+    test(`should support appending to fork after sub-offset boundary`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-append-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-append-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+
+      // Fork inheriting first 3 bytes ("hel")
+      await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+
+      // Append to fork
+      const appendRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `POST`,
+        headers: { "Content-Type": `text/plain` },
+        body: `LO`,
+      })
+      expect(appendRes.status).toBe(204)
+
+      // Read fork → "helLO"
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(readRes.status).toBe(200)
+      const body = await readRes.text()
+      expect(body).toBe(`helLO`)
+    })
+
+    test(`should inherit content-type when sub-offset is supplied without explicit Content-Type`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-ct-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-ct-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"a":1},{"b":2}]`,
+      })
+
+      const res = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `1`,
+        },
+      })
+      expect(res.status).toBe(201)
+      expect(res.headers.get(`content-type`)).toBe(`application/json`)
+    })
+
+    test(`should not inherit producer state across sub-offset fork boundary`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-prod-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-prod-fork-${id}`
+      const producerId = `prod-${id}`
+
+      // Create JSON source (no producer)
+      const src = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+      })
+      expect(src.status).toBe(201)
+
+      // Producer P writes a 3-message batch under (P, 0, 0)
+      const batchRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `POST`,
+        headers: {
+          "Content-Type": `application/json`,
+          "Producer-Id": producerId,
+          "Producer-Epoch": `0`,
+          "Producer-Seq": `0`,
+        },
+        body: `[{"i":1},{"i":2},{"i":3}]`,
+      })
+      // Fresh producer accept is 200 per §5.2.1
+      expect(batchRes.status).toBe(200)
+
+      // Fork mid-batch (sub-offset = 1 message — fork inherits {"i":1} only)
+      const fork = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `1`,
+        },
+      })
+      expect(fork.status).toBe(201)
+
+      // Producer P retries the same (P, 0, 0) tuple against the fork.
+      // The fork has no producer state, so this MUST be treated as a fresh
+      // accept (200), not silently deduplicated as a 204. A 204 here would
+      // mean the fork inherited producer state and is silently dropping
+      // data the producer has not yet seen accepted on the fork.
+      const retry = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `POST`,
+        headers: {
+          "Content-Type": `application/json`,
+          "Producer-Id": producerId,
+          "Producer-Epoch": `0`,
+          "Producer-Seq": `0`,
+        },
+        body: `[{"i":99}]`,
+      })
+      expect(retry.status).toBe(200)
+
+      // Fork now contains: inherited [{"i":1}] + new [{"i":99}]
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      const body = await readRes.json()
+      expect(body).toEqual([{ i: 1 }, { i: 99 }])
+    })
+
+    test(`should fork at a binary sub-offset anchored mid-stream`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-mid-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-mid-fork-${id}`
+
+      // First append — capture its tail offset as the anchor
+      const putRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `first`,
+      })
+      expect(putRes.status).toBe(201)
+      const anchor = putRes.headers.get(`Stream-Next-Offset`)!
+
+      // Second append — this is what sub-offset will slice
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `POST`,
+        headers: { "Content-Type": `text/plain` },
+        body: `second`,
+      })
+
+      // Fork at the mid-anchor with sub-offset = 3 → take "sec" of "second"
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: anchor,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+
+      // Fork contains "first" (inherited) + "sec" (sub-offset slice)
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(await readRes.text()).toBe(`firstsec`)
+    })
+
+    test(`should return 400 when sub-offset > 0 is supplied without Stream-Fork-Offset`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-default-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-default-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `data`,
+      })
+
+      // Default fork offset is the source's tail; sub-offset > 0 past tail
+      // names a position past the next data boundary → 400.
+      const res = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `1`,
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    test(`should return a Stream-Next-Offset on sub-offset fork creation that is consumable by reads`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-next-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-next-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+      const tail = forkRes.headers.get(`Stream-Next-Offset`)
+      expect(tail).toBeTruthy()
+
+      // Reading from the reported tail must return zero data and be up-to-date.
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=${tail!}`)
+      expect(readRes.status).toBe(200)
+      expect(await readRes.text()).toBe(``)
+      expect(readRes.headers.get(STREAM_UP_TO_DATE_HEADER)).toBe(`true`)
+    })
+
+    test(`should return 400 when sub-offset is supplied on an empty source stream`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-empty-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-empty-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+      })
+
+      const res = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `1`,
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    test(`should accept binary sub-offset equal to message length`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-bin-eq-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-bin-eq-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `5`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(await readRes.text()).toBe(`hello`)
+    })
+
+    test(`should accept JSON sub-offset equal to flattened message count`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-json-eq-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-json-eq-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"a":1},{"b":2},{"c":3}]`,
+      })
+
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `application/json`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(await readRes.json()).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }])
+    })
+
+    test(`should append initial body after the materialized sub-offset prefix`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-body-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-body-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `hello`,
+      })
+
+      // PUT with sub-offset AND an initial body — body must land AFTER the
+      // materialized prefix.
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+        body: `XY`,
+      })
+      expect(forkRes.status).toBe(201)
+
+      // Fork: "hel" (sub-offset prefix) + "XY" (initial body) = "helXY"
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(await readRes.text()).toBe(`helXY`)
+    })
+
+    test(`should allow sub-offset fork creation from a closed source stream`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-closed-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-closed-fork-${id}`
+
+      // Create a closed source with data via PUT + Stream-Closed
+      const putRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_CLOSED_HEADER_FORK]: `true`,
+        },
+        body: `hello`,
+      })
+      expect(putRes.status).toBe(201)
+
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+      expect(forkRes.status).toBe(201)
+
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(await readRes.text()).toBe(`hel`)
+    })
   })
 
   // ============================================================================
@@ -8880,6 +9466,63 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
         await fetch(`${getBaseUrl()}${level2}?offset=-1`)
       ).text()
       expect(r2).toBe(`XYZ`)
+    })
+
+    test(`should compose sub-offsets across chained forks`, async () => {
+      const id = uniqueId()
+      const STREAM_FORK_OFFSET_HEADER = `Stream-Fork-Offset`
+      const STREAM_FORK_SUB_OFFSET_HEADER = `Stream-Fork-Sub-Offset`
+      const level0 = `/v1/stream/fork-rec-sub-l0-${id}`
+      const level1 = `/v1/stream/fork-rec-sub-l1-${id}`
+      const level2 = `/v1/stream/fork-rec-sub-l2-${id}`
+
+      // Level 0: 6-byte source
+      await fetch(`${getBaseUrl()}${level0}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `abcdef`,
+      })
+
+      // Level 1: fork at sub-offset 4 → inherits "abcd"
+      await fetch(`${getBaseUrl()}${level1}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: level0,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `4`,
+        },
+      })
+      const r1 = await (
+        await fetch(`${getBaseUrl()}${level1}?offset=-1`)
+      ).text()
+      expect(r1).toBe(`abcd`)
+
+      // Level 2: fork of level1 at sub-offset 2 → inherits "ab"
+      await fetch(`${getBaseUrl()}${level2}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORKED_FROM_HEADER]: level1,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `2`,
+        },
+      })
+      const r2 = await (
+        await fetch(`${getBaseUrl()}${level2}?offset=-1`)
+      ).text()
+      expect(r2).toBe(`ab`)
+
+      // Append to level2 and confirm reads still compose correctly
+      await fetch(`${getBaseUrl()}${level2}`, {
+        method: `POST`,
+        headers: { "Content-Type": `text/plain` },
+        body: `Z`,
+      })
+      const r2b = await (
+        await fetch(`${getBaseUrl()}${level2}?offset=-1`)
+      ).text()
+      expect(r2b).toBe(`abZ`)
     })
   })
 

--- a/packages/server-conformance-tests/src/index.ts
+++ b/packages/server-conformance-tests/src/index.ts
@@ -8432,6 +8432,67 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
       expect(res2.status).toBe(409)
     })
 
+    test(`should be idempotent when re-creating a JSON fork with matching sub-offset`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-json-idem-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-json-idem-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"a":1},{"b":2},{"c":3},{"d":4}]`,
+      })
+
+      const headers = {
+        "Content-Type": `application/json`,
+        [STREAM_FORKED_FROM_HEADER]: sourcePath,
+        [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+        [STREAM_FORK_SUB_OFFSET_HEADER]: `2`,
+      }
+
+      const res1 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers,
+      })
+      expect(res1.status).toBe(201)
+
+      const res2 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers,
+      })
+      expect(res2.status).toBe(200)
+    })
+
+    test(`should return 409 when re-creating a JSON fork with mismatched sub-offset`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-json-conflict-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-json-conflict-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `application/json` },
+        body: `[{"a":1},{"b":2},{"c":3},{"d":4}]`,
+      })
+
+      const baseHeaders = {
+        "Content-Type": `application/json`,
+        [STREAM_FORKED_FROM_HEADER]: sourcePath,
+        [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+      }
+
+      const res1 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: { ...baseHeaders, [STREAM_FORK_SUB_OFFSET_HEADER]: `2` },
+      })
+      expect(res1.status).toBe(201)
+
+      const res2 = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: { ...baseHeaders, [STREAM_FORK_SUB_OFFSET_HEADER]: `3` },
+      })
+      expect(res2.status).toBe(409)
+    })
+
     test(`should support appending to fork after sub-offset boundary`, async () => {
       const id = uniqueId()
       const sourcePath = `/v1/stream/fork-create-suboffset-append-src-${id}`
@@ -8553,6 +8614,64 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
       expect(body).toEqual([{ i: 1 }, { i: 99 }])
     })
 
+    test(`should not inherit producer state across binary sub-offset fork boundary`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-create-suboffset-prod-bin-src-${id}`
+      const forkPath = `/v1/stream/fork-create-suboffset-prod-bin-fork-${id}`
+      const producerId = `prod-${id}`
+
+      // Create binary source (no producer)
+      const src = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+      })
+      expect(src.status).toBe(201)
+
+      // Producer P writes a single message under (P, 0, 0)
+      const writeRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `POST`,
+        headers: {
+          "Content-Type": `text/plain`,
+          "Producer-Id": producerId,
+          "Producer-Epoch": `0`,
+          "Producer-Seq": `0`,
+        },
+        body: `hello`,
+      })
+      // Fresh producer accept is 200 per §5.2.1
+      expect(writeRes.status).toBe(200)
+
+      // Fork mid-message (sub-offset = 3 bytes — fork inherits "hel" only)
+      const fork = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+          [STREAM_FORK_OFFSET_HEADER]: `0000000000000000_0000000000000000`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `3`,
+        },
+      })
+      expect(fork.status).toBe(201)
+
+      // Producer P retries the same (P, 0, 0) tuple against the fork.
+      // The fork has no producer state, so this MUST be treated as a fresh
+      // accept (200), not silently deduplicated as a 204.
+      const retry = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `POST`,
+        headers: {
+          "Content-Type": `text/plain`,
+          "Producer-Id": producerId,
+          "Producer-Epoch": `0`,
+          "Producer-Seq": `0`,
+        },
+        body: `LO`,
+      })
+      expect(retry.status).toBe(200)
+
+      // Fork now contains: inherited "hel" + new "LO"
+      const readRes = await fetch(`${getBaseUrl()}${forkPath}?offset=-1`)
+      expect(await readRes.text()).toBe(`helLO`)
+    })
+
     test(`should fork at a binary sub-offset anchored mid-stream`, async () => {
       const id = uniqueId()
       const sourcePath = `/v1/stream/fork-create-suboffset-mid-src-${id}`
@@ -8610,6 +8729,20 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
           "Content-Type": `text/plain`,
           [STREAM_FORKED_FROM_HEADER]: sourcePath,
           [STREAM_FORK_SUB_OFFSET_HEADER]: `1`,
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    test(`should return 400 when Stream-Fork-Sub-Offset is supplied without Stream-Forked-From (even when value is 0)`, async () => {
+      const id = uniqueId()
+      const targetPath = `/v1/stream/fork-create-suboffset-zero-no-src-${id}`
+
+      const res = await fetch(`${getBaseUrl()}${targetPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `text/plain`,
+          [STREAM_FORK_SUB_OFFSET_HEADER]: `0`,
         },
       })
       expect(res.status).toBe(400)

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -88,6 +88,10 @@ interface StreamMetadata {
    */
   forkOffset?: string
   /**
+   * Sub-offset content bytes refining `forkOffset` (non-JSON forks only).
+   */
+  forkSubOffsetBytes?: number
+  /**
    * Number of forks referencing this stream.
    * Defaults to 0. Optional for backward-compatible deserialization from LMDB.
    */
@@ -726,6 +730,7 @@ export class FileBackedStreamStore {
       closed?: boolean
       forkedFrom?: string
       forkOffset?: string
+      forkSubOffset?: number
     } = {}
   ): Promise<Stream> {
     // Use getMetaIfNotExpired to treat expired streams as non-existent
@@ -762,6 +767,10 @@ export class FileBackedStreamStore {
         const forkOffsetMatches =
           options.forkOffset === undefined ||
           options.forkOffset === existingRaw.forkOffset
+        // Sub-offset: undefined and 0 are equivalent.
+        const requestedSub = options.forkSubOffset ?? 0
+        const existingSub = existingRaw.forkSubOffsetBytes ?? 0
+        const forkSubOffsetMatches = requestedSub === existingSub
 
         if (
           contentTypeMatches &&
@@ -769,7 +778,8 @@ export class FileBackedStreamStore {
           expiresMatches &&
           closedMatches &&
           forkedFromMatches &&
-          forkOffsetMatches
+          forkOffsetMatches &&
+          forkSubOffsetMatches
         ) {
           // Idempotent success - return existing stream
           return this.streamMetaToStream(existingRaw)
@@ -787,6 +797,7 @@ export class FileBackedStreamStore {
     let forkOffset = `0000000000000000_0000000000000000`
     let sourceContentType: string | undefined
     let sourceMeta: StreamMetadata | undefined
+    let forkSubOffsetPrefix: Uint8Array | undefined
 
     if (isFork) {
       const sourceKey = `stream:${options.forkedFrom!}`
@@ -814,6 +825,17 @@ export class FileBackedStreamStore {
       const zeroOffset = `0000000000000000_0000000000000000`
       if (forkOffset < zeroOffset || sourceMeta.currentOffset < forkOffset) {
         throw new Error(`Invalid fork offset: ${forkOffset}`)
+      }
+
+      // Resolve sub-offset against the source. Returns the prefix bytes to
+      // materialize as the fork's first own message.
+      if (options.forkSubOffset && options.forkSubOffset > 0) {
+        forkSubOffsetPrefix = this.resolveForkSubOffset(
+          options.forkedFrom!,
+          forkOffset,
+          options.forkSubOffset,
+          normalizeContentType(sourceContentType) === `application/json`
+        )
       }
 
       // Atomically increment source refcount in LMDB
@@ -871,6 +893,7 @@ export class FileBackedStreamStore {
       closed: false, // Set to false initially, will be updated after initial append if needed
       forkedFrom: isFork ? options.forkedFrom : undefined,
       forkOffset: isFork ? forkOffset : undefined,
+      forkSubOffsetBytes: undefined,
       refCount: 0,
     }
 
@@ -878,6 +901,28 @@ export class FileBackedStreamStore {
 
     const segmentPath = segmentFile(this.dataDir, streamMeta.directoryName)
     try {
+      // Materialize the sub-offset prefix as the first framed message
+      // in the new segment before persisting metadata or opening the
+      // write stream — `openWriteStream` opens with `flags: 'a'` so a
+      // pre-existing file is appended to, not truncated. We also
+      // advance `currentOffset` and stamp `forkSubOffsetBytes` so the
+      // metadata written below reflects the post-prefix state.
+      if (forkSubOffsetPrefix && forkSubOffsetPrefix.length > 0) {
+        const lengthBuf = Buffer.allocUnsafe(4)
+        lengthBuf.writeUInt32BE(forkSubOffsetPrefix.length, 0)
+        const frameBuf = Buffer.concat([
+          lengthBuf,
+          Buffer.from(forkSubOffsetPrefix),
+          Buffer.from(`\n`),
+        ])
+        fs.writeFileSync(segmentPath, frameBuf)
+        const parts = streamMeta.currentOffset.split(`_`).map(Number)
+        const readSeq = parts[0]!
+        const byteOffset = parts[1]!
+        const newByteOffset = byteOffset + forkSubOffsetPrefix.length
+        streamMeta.currentOffset = `${String(readSeq).padStart(16, `0`)}_${String(newByteOffset).padStart(16, `0`)}`
+        streamMeta.forkSubOffsetBytes = forkSubOffsetPrefix.length
+      }
       await this.db.put(key, streamMeta)
     } catch (err) {
       // Rollback source refcount on failure
@@ -1587,6 +1632,57 @@ export class FileBackedStreamStore {
     messages.push(...ownMessages)
 
     return messages
+  }
+
+  /**
+   * Resolve a fork sub-offset against the source: read the message that
+   * starts at forkOffset and return prefix bytes to materialize as the
+   * fork's first own message. For JSON, parses comma-joined values.
+   */
+  private resolveForkSubOffset(
+    sourcePath: string,
+    forkOffset: string,
+    subOffset: number,
+    isJSON: boolean
+  ): Uint8Array {
+    const forkByte = Number(forkOffset.split(`_`)[1] ?? 0)
+    // Read source past forkOffset (cap at source's currentOffset by passing
+    // a large cap; we only care about the first message past forkOffset).
+    const sourceMeta = this.db.get(`stream:${sourcePath}`) as
+      | StreamMetadata
+      | undefined
+    if (!sourceMeta) {
+      throw new Error(`Source stream not found: ${sourcePath}`)
+    }
+    const currentByte = Number(sourceMeta.currentOffset.split(`_`)[1] ?? 0)
+    const messages = this.readForkedMessages(sourcePath, forkByte, currentByte)
+    if (messages.length === 0) {
+      throw new Error(`Invalid fork sub-offset: no data past forkOffset`)
+    }
+    const first = messages[0]!
+    if (isJSON) {
+      const text = new TextDecoder().decode(first.data)
+      const trimmed = text.endsWith(`,`) ? text.slice(0, -1) : text
+      let values: Array<unknown>
+      try {
+        values = JSON.parse(`[${trimmed}]`)
+      } catch {
+        throw new Error(`Invalid fork sub-offset: source JSON is unparseable`)
+      }
+      if (subOffset > values.length) {
+        throw new Error(
+          `Invalid fork sub-offset: overshoots source message count`
+        )
+      }
+      const prefix = values.slice(0, subOffset).map((v) => JSON.stringify(v))
+      return new TextEncoder().encode(prefix.join(`,`) + `,`)
+    }
+    if (subOffset > first.data.length) {
+      throw new Error(
+        `Invalid fork sub-offset: overshoots source message length`
+      )
+    }
+    return first.data.slice(0, subOffset)
   }
 
   read(

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -923,7 +923,10 @@ export class FileBackedStreamStore {
         const parts = streamMeta.currentOffset.split(`_`).map(Number)
         const readSeq = parts[0]!
         const byteOffset = parts[1]!
-        const newByteOffset = byteOffset + forkSubOffsetPrefix.length
+        // Match append()'s frame-inclusive offset advance (4-byte length
+        // prefix + payload + 1-byte newline) so reads with a capByte don't
+        // truncate the materialized prefix when later chained-fork resolves.
+        const newByteOffset = byteOffset + forkSubOffsetPrefix.length + 5
         streamMeta.currentOffset = `${String(readSeq).padStart(16, `0`)}_${String(newByteOffset).padStart(16, `0`)}`
         // Persist the user-supplied sub-offset verbatim for idempotent
         // re-creation matching, not the encoded byte length.

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -88,9 +88,11 @@ interface StreamMetadata {
    */
   forkOffset?: string
   /**
-   * Sub-offset content bytes refining `forkOffset` (non-JSON forks only).
+   * User-supplied sub-offset value refining `forkOffset` (Section 4.2 of
+   * PROTOCOL.md). Stored verbatim for idempotent re-creation matching:
+   * bytes for non-JSON forks, flattened message count for JSON forks.
    */
-  forkSubOffsetBytes?: number
+  forkSubOffset?: number
   /**
    * Number of forks referencing this stream.
    * Defaults to 0. Optional for backward-compatible deserialization from LMDB.
@@ -767,9 +769,11 @@ export class FileBackedStreamStore {
         const forkOffsetMatches =
           options.forkOffset === undefined ||
           options.forkOffset === existingRaw.forkOffset
-        // Sub-offset: undefined and 0 are equivalent.
+        // Sub-offset: undefined and 0 are equivalent. Compare the raw
+        // user-supplied integer (count for JSON, bytes for binary) so the
+        // comparison is independent of how it was resolved internally.
         const requestedSub = options.forkSubOffset ?? 0
-        const existingSub = existingRaw.forkSubOffsetBytes ?? 0
+        const existingSub = existingRaw.forkSubOffset ?? 0
         const forkSubOffsetMatches = requestedSub === existingSub
 
         if (
@@ -893,7 +897,7 @@ export class FileBackedStreamStore {
       closed: false, // Set to false initially, will be updated after initial append if needed
       forkedFrom: isFork ? options.forkedFrom : undefined,
       forkOffset: isFork ? forkOffset : undefined,
-      forkSubOffsetBytes: undefined,
+      forkSubOffset: undefined,
       refCount: 0,
     }
 
@@ -905,7 +909,7 @@ export class FileBackedStreamStore {
       // in the new segment before persisting metadata or opening the
       // write stream — `openWriteStream` opens with `flags: 'a'` so a
       // pre-existing file is appended to, not truncated. We also
-      // advance `currentOffset` and stamp `forkSubOffsetBytes` so the
+      // advance `currentOffset` and stamp `forkSubOffset` so the
       // metadata written below reflects the post-prefix state.
       if (forkSubOffsetPrefix && forkSubOffsetPrefix.length > 0) {
         const lengthBuf = Buffer.allocUnsafe(4)
@@ -921,7 +925,9 @@ export class FileBackedStreamStore {
         const byteOffset = parts[1]!
         const newByteOffset = byteOffset + forkSubOffsetPrefix.length
         streamMeta.currentOffset = `${String(readSeq).padStart(16, `0`)}_${String(newByteOffset).padStart(16, `0`)}`
-        streamMeta.forkSubOffsetBytes = forkSubOffsetPrefix.length
+        // Persist the user-supplied sub-offset verbatim for idempotent
+        // re-creation matching, not the encoded byte length.
+        streamMeta.forkSubOffset = options.forkSubOffset
       }
       await this.db.put(key, streamMeta)
     } catch (err) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -42,6 +42,7 @@ const SSE_UP_TO_DATE_FIELD = `upToDate`
 // Fork headers (request headers only — not set on responses)
 const STREAM_FORKED_FROM_HEADER = `Stream-Forked-From`
 const STREAM_FORK_OFFSET_HEADER = `Stream-Fork-Offset`
+const STREAM_FORK_SUB_OFFSET_HEADER = `Stream-Fork-Sub-Offset`
 
 /**
  * Encode data for SSE format.
@@ -449,7 +450,7 @@ export class DurableStreamTestServer {
     )
     res.setHeader(
       `access-control-allow-headers`,
-      `content-type, authorization, Stream-Seq, Stream-TTL, Stream-Expires-At, Stream-Closed, Producer-Id, Producer-Epoch, Producer-Seq, Stream-Forked-From, Stream-Fork-Offset`
+      `content-type, authorization, Stream-Seq, Stream-TTL, Stream-Expires-At, Stream-Closed, Producer-Id, Producer-Epoch, Producer-Seq, Stream-Forked-From, Stream-Fork-Offset, Stream-Fork-Sub-Offset`
     )
     res.setHeader(
       `access-control-expose-headers`,
@@ -598,6 +599,13 @@ export class DurableStreamTestServer {
     const forkOffsetHeader = req.headers[
       STREAM_FORK_OFFSET_HEADER.toLowerCase()
     ] as string | undefined
+    const forkSubOffsetHeaderRaw =
+      req.headers[STREAM_FORK_SUB_OFFSET_HEADER.toLowerCase()]
+    // Distinguish "header absent" from "header present but empty"
+    const forkSubOffsetHeaderPresent = forkSubOffsetHeaderRaw !== undefined
+    const forkSubOffsetHeader = Array.isArray(forkSubOffsetHeaderRaw)
+      ? forkSubOffsetHeaderRaw[0]
+      : forkSubOffsetHeaderRaw
 
     // Sanitize content-type: if empty or invalid, use default — but only
     // for non-fork creates. For forks, an omitted Content-Type means "inherit
@@ -667,6 +675,26 @@ export class DurableStreamTestServer {
       }
     }
 
+    // Validate sub-offset if header was present (including empty value)
+    let forkSubOffset: number | undefined
+    if (forkSubOffsetHeaderPresent) {
+      if (!forkedFromHeader) {
+        res.writeHead(400, { "content-type": `text/plain` })
+        res.end(`Stream-Fork-Sub-Offset requires Stream-Forked-From`)
+        return
+      }
+      const subOffsetPattern = /^(0|[1-9]\d*)$/
+      if (
+        forkSubOffsetHeader === undefined ||
+        !subOffsetPattern.test(forkSubOffsetHeader)
+      ) {
+        res.writeHead(400, { "content-type": `text/plain` })
+        res.end(`Invalid Stream-Fork-Sub-Offset format`)
+        return
+      }
+      forkSubOffset = parseInt(forkSubOffsetHeader, 10)
+    }
+
     // Read body if present
     const body = await this.readBody(req)
 
@@ -683,6 +711,7 @@ export class DurableStreamTestServer {
           closed: createClosed,
           forkedFrom: forkedFromHeader,
           forkOffset: forkOffsetHeader,
+          forkSubOffset,
         })
       )
     } catch (err) {
@@ -690,6 +719,11 @@ export class DurableStreamTestServer {
         if (err.message.includes(`Source stream not found`)) {
           res.writeHead(404, { "content-type": `text/plain` })
           res.end(`Source stream not found`)
+          return
+        }
+        if (err.message.includes(`Invalid fork sub-offset`)) {
+          res.writeHead(400, { "content-type": `text/plain` })
+          res.end(`Invalid fork sub-offset`)
           return
         }
         if (err.message.includes(`Invalid fork offset`)) {

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -281,9 +281,11 @@ export class StreamStore {
         const forkOffsetMatches =
           options.forkOffset === undefined ||
           options.forkOffset === existingRaw.forkOffset
-        // Sub-offset: undefined and 0 are equivalent.
+        // Sub-offset: undefined and 0 are equivalent. Compare the raw
+        // user-supplied integer (count for JSON, bytes for binary) so the
+        // comparison is independent of how it was resolved internally.
         const requestedSub = options.forkSubOffset ?? 0
-        const existingSub = existingRaw.forkSubOffsetBytes ?? 0
+        const existingSub = existingRaw.forkSubOffset ?? 0
         const forkSubOffsetMatches = requestedSub === existingSub
 
         if (
@@ -407,7 +409,9 @@ export class StreamStore {
         timestamp: Date.now(),
       })
       stream.currentOffset = newOffset
-      stream.forkSubOffsetBytes = forkSubOffsetPrefix.length
+      // Persist the user-supplied sub-offset verbatim for idempotent
+      // re-creation matching, not the encoded byte length.
+      stream.forkSubOffset = options.forkSubOffset
     }
 
     // If initial data is provided, append it

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -401,7 +401,10 @@ export class StreamStore {
       const parts = stream.currentOffset.split(`_`).map(Number)
       const readSeq = parts[0]!
       const byteOffset = parts[1]!
-      const newByteOffset = byteOffset + forkSubOffsetPrefix.length
+      // Match append()'s frame-inclusive offset advance (4-byte length
+      // prefix + payload + 1-byte newline) so reads with a capByte don't
+      // truncate the materialized prefix when later chained-fork resolves.
+      const newByteOffset = byteOffset + forkSubOffsetPrefix.length + 5
       const newOffset = `${String(readSeq).padStart(16, `0`)}_${String(newByteOffset).padStart(16, `0`)}`
       stream.messages.push({
         data: forkSubOffsetPrefix,

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -247,6 +247,7 @@ export class StreamStore {
       closed?: boolean
       forkedFrom?: string
       forkOffset?: string
+      forkSubOffset?: number
     } = {}
   ): Stream {
     // Check if stream already exists
@@ -280,6 +281,10 @@ export class StreamStore {
         const forkOffsetMatches =
           options.forkOffset === undefined ||
           options.forkOffset === existingRaw.forkOffset
+        // Sub-offset: undefined and 0 are equivalent.
+        const requestedSub = options.forkSubOffset ?? 0
+        const existingSub = existingRaw.forkSubOffsetBytes ?? 0
+        const forkSubOffsetMatches = requestedSub === existingSub
 
         if (
           contentTypeMatches &&
@@ -287,7 +292,8 @@ export class StreamStore {
           expiresMatches &&
           closedMatches &&
           forkedFromMatches &&
-          forkOffsetMatches
+          forkOffsetMatches &&
+          forkSubOffsetMatches
         ) {
           // Idempotent success - return existing stream
           return existingRaw
@@ -305,6 +311,7 @@ export class StreamStore {
     let forkOffset = `0000000000000000_0000000000000000`
     let sourceContentType: string | undefined
     let sourceStream: Stream | undefined
+    let forkSubOffsetPrefix: Uint8Array | undefined
 
     if (isFork) {
       sourceStream = this.streams.get(options.forkedFrom!)
@@ -331,6 +338,18 @@ export class StreamStore {
       const zeroOffset = `0000000000000000_0000000000000000`
       if (forkOffset < zeroOffset || sourceStream.currentOffset < forkOffset) {
         throw new Error(`Invalid fork offset: ${forkOffset}`)
+      }
+
+      // Resolve sub-offset against the source. Both binary and JSON return
+      // a synthetic prefix to materialize as the fork's first own message,
+      // because in this store one POST = one message regardless of mode.
+      if (options.forkSubOffset && options.forkSubOffset > 0) {
+        forkSubOffsetPrefix = this.resolveForkSubOffset(
+          sourceStream,
+          forkOffset,
+          options.forkSubOffset,
+          normalizeContentType(sourceContentType) === `application/json`
+        )
       }
 
       // Increment source refcount
@@ -373,6 +392,22 @@ export class StreamStore {
       refCount: 0,
       forkedFrom: isFork ? options.forkedFrom : undefined,
       forkOffset: isFork ? forkOffset : undefined,
+    }
+
+    // Materialize sub-offset prefix as the fork's first own message.
+    if (forkSubOffsetPrefix && forkSubOffsetPrefix.length > 0) {
+      const parts = stream.currentOffset.split(`_`).map(Number)
+      const readSeq = parts[0]!
+      const byteOffset = parts[1]!
+      const newByteOffset = byteOffset + forkSubOffsetPrefix.length
+      const newOffset = `${String(readSeq).padStart(16, `0`)}_${String(newByteOffset).padStart(16, `0`)}`
+      stream.messages.push({
+        data: forkSubOffsetPrefix,
+        offset: newOffset,
+        timestamp: Date.now(),
+      })
+      stream.currentOffset = newOffset
+      stream.forkSubOffsetBytes = forkSubOffsetPrefix.length
     }
 
     // If initial data is provided, append it
@@ -1235,6 +1270,67 @@ export class StreamStore {
   // ============================================================================
   // Private helpers
   // ============================================================================
+
+  /**
+   * Resolve a sub-offset against a source stream and return the prefix bytes
+   * to materialize as the fork's first own message. Reads from the source
+   * (across its fork chain if any) starting at forkOffset; the first message
+   * returned is the one that starts at forkOffset. Throws if the sub-offset
+   * cannot be satisfied (no message past forkOffset, or overshoots its
+   * content extent).
+   */
+  private resolveForkSubOffset(
+    sourceStream: Stream,
+    forkOffset: string,
+    subOffset: number,
+    isJSON: boolean
+  ): Uint8Array {
+    // Read source past forkOffset across its fork chain
+    let sourceMessages: Array<StreamMessage>
+    if (sourceStream.forkedFrom) {
+      sourceMessages = [
+        ...this.readForkedMessages(
+          sourceStream.forkedFrom,
+          forkOffset,
+          sourceStream.forkOffset!
+        ),
+        ...this.readOwnMessages(sourceStream, forkOffset),
+      ]
+    } else {
+      sourceMessages = this.readOwnMessages(sourceStream, forkOffset)
+    }
+    if (sourceMessages.length === 0) {
+      throw new Error(`Invalid fork sub-offset: no data past forkOffset`)
+    }
+    const first = sourceMessages[0]!
+    if (isJSON) {
+      // The message data is comma-joined JSON values with a trailing comma
+      // (e.g., `{"a":1},{"b":2},`). Wrap in [...] to parse, take first N
+      // elements, re-encode in the same comma-joined format.
+      const text = new TextDecoder().decode(first.data)
+      const trimmed = text.endsWith(`,`) ? text.slice(0, -1) : text
+      let values: Array<unknown>
+      try {
+        values = JSON.parse(`[${trimmed}]`)
+      } catch {
+        throw new Error(`Invalid fork sub-offset: source JSON is unparseable`)
+      }
+      if (subOffset > values.length) {
+        throw new Error(
+          `Invalid fork sub-offset: overshoots source message count`
+        )
+      }
+      const prefix = values.slice(0, subOffset).map((v) => JSON.stringify(v))
+      return new TextEncoder().encode(prefix.join(`,`) + `,`)
+    }
+    // Binary: take first subOffset bytes
+    if (subOffset > first.data.length) {
+      throw new Error(
+        `Invalid fork sub-offset: overshoots source message length`
+      )
+    }
+    return first.data.slice(0, subOffset)
+  }
 
   private appendToStream(
     stream: Stream,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -108,11 +108,12 @@ export interface Stream {
   forkOffset?: string
 
   /**
-   * Sub-offset content bytes refining `forkOffset` (non-JSON forks only).
-   * For JSON forks, the sub-offset is resolved into `forkOffset` itself, so
-   * this field stays 0/undefined.
+   * User-supplied sub-offset value refining `forkOffset` (Section 4.2 of
+   * PROTOCOL.md). Stored verbatim for idempotent re-creation matching:
+   * bytes for non-JSON forks, flattened message count for JSON forks.
+   * `undefined` and `0` are equivalent.
    */
-  forkSubOffsetBytes?: number
+  forkSubOffset?: number
 
   /**
    * Number of forks referencing this stream.

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -108,6 +108,13 @@ export interface Stream {
   forkOffset?: string
 
   /**
+   * Sub-offset content bytes refining `forkOffset` (non-JSON forks only).
+   * For JSON forks, the sub-offset is resolved into `forkOffset` itself, so
+   * this field stays 0/undefined.
+   */
+  forkSubOffsetBytes?: number
+
+  /**
    * Number of forks referencing this stream.
    * Defaults to 0.
    */


### PR DESCRIPTION
Throwaway draft to validate CI for PR #347 rebased onto current main before force-pushing to msfstef/fork-arbitrary-offsets.

## Background

The previous artifact at \`pkg.pr.new/@durable-streams/client@347\` didn't have \`IdempotentProducer.lastSuccessfulOffset\` (added on main after PR #347 branched off), which broke downstream consumers (electric-sql/electric#4410 CI).

## Contents

Rebased PR #347's branch (\`msfstef/fork-arbitrary-offsets\`) onto current main:

- Dropped \`9b6546c9\` (StreamDB subscription hooks) — already in main via PR #365.
- Dropped \`9847120b\` (our pnpm.overrides) — main has its own override (\`@tanstack/db: 0.6.0\`) now.
- Cherry-picked the three remaining commits cleanly:
  - \`feat(server): support Stream-Fork-Sub-Offset for arbitrary-position forks\`
  - \`fix(server): JSON sub-offset fork creation now idempotent on retry\`
  - \`fix(server): sub-offset prefix advances currentOffset by frame size\`

Local build clean. Branch now contains both \`Stream-Fork-Sub-Offset\` (from PR #347) and \`IdempotentProducer.lastSuccessfulOffset\` (from main).

Do not merge — once CI is green, this state is force-pushed to \`msfstef/fork-arbitrary-offsets\`.