### PR TITLE
ci: harden release workflows

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   changeset-check:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - uses: actions/upload-artifact@v4
         with:
@@ -123,7 +123,7 @@ jobs:
           bundler-cache: true
           working-directory: packages/client-rb
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: ts-build
@@ -155,7 +155,7 @@ jobs:
           elixir-version: "1.18"
           otp-version: "27"
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: ts-build
@@ -288,7 +288,7 @@ jobs:
           bundler-cache: true
           working-directory: packages/client-rb
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: ts-build
@@ -334,7 +334,7 @@ jobs:
           elixir-version: "1.18"
           otp-version: "27"
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: ts-build
@@ -382,7 +382,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release-caddy.yml
+++ b/.github/workflows/release-caddy.yml
@@ -13,25 +13,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.25"
-          cache-dependency-path: packages/caddy-plugin/go.sum
+          cache: false
 
       - name: Extract version from tag
         id: version
         run: echo "TAG=${GITHUB_REF_NAME#caddy-}" >> "$GITHUB_OUTPUT"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.12.2
           args: release --clean --skip=validate
           workdir: packages/caddy-plugin
         env:
@@ -39,7 +39,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG }}
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-artifacts
           path: packages/caddy-plugin/dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,18 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
-          cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
       # Workaround for npm/cli#9151: Node 22.22.2 ships npm 10.9.7 which
@@ -54,7 +53,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@8eb63fb4cfc7f9643537c7d39d0b68c835012a19
         with:
           version: pnpm run changeset:version
           publish: pnpm run changeset:publish
@@ -65,6 +64,6 @@ jobs:
 
       - name: Comment on PRs about release
         if: steps.changesets.outputs.published == 'true'
-        uses: tanstack/config/.github/comment-on-release@main
+        uses: tanstack/config/.github/comment-on-release@a4c6d06ed525a310901e3e9fbed9b2301ebecfd5
         with:
           published-packages: ${{ steps.changesets.outputs.publishedPackages }}


### PR DESCRIPTION
## Summary
- remove dependency caches from privileged release workflows
- pin release workflow actions to commit SHAs and pin GoReleaser version
- drop unused pull-requests write permission from changeset check
- make client test pnpm installs frozen for reproducibility

## Verification
- parsed updated workflow YAML with Ruby YAML.load_file
- confirmed GoReleaser v2.12.2 tag exists