### PR TITLE
fix(caddy): full conformance coverage + soft-delete, fork content-type, and live SSE close bugs

### DIFF
--- a/.changeset/fix-soft-delete-fork-sse-close.md
+++ b/.changeset/fix-soft-delete-fork-sse-close.md
@@ -1,0 +1,26 @@
+---
+"@durable-streams/server-conformance-tests": patch
+"@durable-streams/server": patch
+---
+
+fix: close conformance gaps around soft-delete, fork content-type, and live SSE closure
+
+Server conformance tests:
+
+- Add a test asserting a live SSE reader caught up at the tail receives
+  data appended atomically with a stream close (POST + `Stream-Closed`)
+  before the closing control event. A server that emits the
+  `streamClosed` control without first delivering the final append
+  silently loses the last message; the test probes a spread of close
+  timings to catch the race deterministically.
+- Add a test asserting a fork rejected for a content-type mismatch does
+  not leak a reference on the source (the source must still fully delete
+  rather than being pinned in a soft-deleted state).
+
+Reference server:
+
+- Fix a reference-count leak in both the in-memory and file-backed
+  stores: a fork rejected for a content-type mismatch incremented the
+  source's `refCount` before validating the content type, pinning the
+  source in a soft-deleted state forever. Content-type is now validated
+  before the reference is taken.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,31 +242,18 @@ jobs:
           path: packages/caddy-plugin/caddy
           retention-days: 1
 
-  # Parallel conformance test shards
+  # Server conformance tests against the Caddy plugin.
+  #
+  # Runs the entire suite in a single job. This previously used an 8-way matrix
+  # sharded by `--testNamePattern`, but that was an allowlist of describe-block
+  # names that drifted out of sync with the suite: ~half the tests (all Fork
+  # suites, every Stream-Closure suite, idempotent producers, most property
+  # tests) matched no pattern and were silently never run. The full suite takes
+  # ~40s, so sharding isn't worth the maintenance hazard — run everything.
   caddy-conformance:
     runs-on: ubuntu-latest
     needs: [build, build-caddy]
-    strategy:
-      fail-fast: false
-      matrix:
-        shard:
-          - name: "basic"
-            pattern: "Basic Stream Operations|Append Operations|Read Operations"
-          - name: "http-protocol"
-            pattern: "HTTP Protocol|Case-Insensitivity|Content-Type Validation"
-          - name: "long-poll"
-            pattern: "Long-Poll Operations|Long-Poll Edge Cases"
-          - name: "ttl-expiry"
-            pattern: "TTL and Expiry Validation|TTL and Expiry Edge Cases"
-          - name: "metadata"
-            pattern: "HEAD Metadata|Caching and ETag"
-          - name: "advanced"
-            pattern: "Offset Validation and Resumability|Protocol Edge Cases|Chunking and Large Payloads"
-          - name: "streaming"
-            pattern: "SSE Mode|JSON Mode"
-          - name: "consistency"
-            pattern: "Read-Your-Writes Consistency|Property-Based Tests"
-    name: conformance (${{ matrix.shard.name }})
+    name: conformance
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -297,6 +284,5 @@ jobs:
       - name: Make Caddy executable
         run: chmod +x packages/caddy-plugin/caddy
 
-      - name: Run conformance tests (${{ matrix.shard.name }})
-        run: |
-          pnpm vitest run --project caddy --testNamePattern "${{ matrix.shard.pattern }}"
+      - name: Run conformance tests
+        run: pnpm vitest run --project caddy

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -539,7 +539,7 @@ Deletes the stream and all its data. In-flight reads may terminate with a `404 N
 
 **Soft-delete:** When a stream has active forks (reference count > 0), the server **MUST** transition the stream to a soft-deleted state rather than fully removing it. A soft-deleted stream returns `410 Gone` for direct operations, blocks path re-creation via `PUT` (`409 Conflict`), and preserves data for fork readers. When the last fork referencing the stream is deleted, the server cleans up the stream's data via cascading garbage collection (see Section 4.2). This cleanup **MAY** occur asynchronously.
 
-Deleting an already soft-deleted stream **MUST** return `204 No Content` (idempotent).
+Deleting an already soft-deleted stream **MUST** return `410 Gone`, consistent with all other direct operations on a soft-deleted stream (`GET`, `HEAD`, `POST`, `DELETE`).
 
 ### 5.5. Stream Metadata
 

--- a/packages/caddy-plugin/handler.go
+++ b/packages/caddy-plugin/handler.go
@@ -211,6 +211,9 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, path stri
 		if errors.Is(err, store.ErrConfigMismatch) {
 			return newHTTPError(http.StatusConflict, "stream exists with different configuration")
 		}
+		if errors.Is(err, store.ErrContentTypeMismatch) {
+			return newHTTPError(http.StatusConflict, "fork content type does not match source stream")
+		}
 		return err
 	}
 
@@ -733,26 +736,38 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request, path string,
 				if streamIsClosed && clientAtTail {
 					return nil
 				}
+			} else if streamIsClosed {
+				// Initial control was already sent and the stream has since been
+				// closed with no further data to deliver (e.g. a close-only
+				// request). Emit the final control event with streamClosed and
+				// close the connection. (Data appended atomically with a close is
+				// handled by the len(messages) > 0 branch above on this same
+				// iteration.)
+				clientAtTail := currentMeta != nil && currentOffset.Equal(currentMeta.CurrentOffset)
+				if clientAtTail {
+					control := map[string]interface{}{
+						"streamNextOffset": currentOffset.String(),
+						"streamClosed":     true,
+					}
+					controlJSON, _ := json.Marshal(control)
+					fmt.Fprintf(w, "event: control\n")
+					fmt.Fprintf(w, "data:%s\n\n", controlJSON)
+					flusher.Flush()
+					return nil
+				}
 			}
 
-			// Wait for more data or stream closure
+			// Wait for more data or stream closure, then loop back to the top
+			// of the loop. We deliberately do NOT emit the closing control event
+			// here: if the stream was closed with a final append, that data must
+			// be drained by the Read at the top of the next iteration and sent as
+			// a data event before the closing control event. Emitting it here
+			// (with the stale currentOffset) would silently drop the final append
+			// for a live reader that was caught up at the tail.
 			timeout := 100 * time.Millisecond
 			waitCtx, cancel := context.WithTimeout(ctx, timeout)
-			_, _, streamClosed, _ := h.store.WaitForMessages(waitCtx, path, currentOffset, timeout)
+			h.store.WaitForMessages(waitCtx, path, currentOffset, timeout)
 			cancel()
-
-			// If stream was closed during wait, send final control event
-			if streamClosed {
-				control := map[string]interface{}{
-					"streamNextOffset": currentOffset.String(),
-					"streamClosed":     true,
-				}
-				controlJSON, _ := json.Marshal(control)
-				fmt.Fprintf(w, "event: control\n")
-				fmt.Fprintf(w, "data:%s\n\n", controlJSON)
-				flusher.Flush()
-				return nil
-			}
 		}
 	}
 }
@@ -990,6 +1005,9 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, path stri
 	if err != nil {
 		if errors.Is(err, store.ErrStreamNotFound) {
 			return newHTTPError(http.StatusNotFound, "stream not found")
+		}
+		if errors.Is(err, store.ErrStreamSoftDeleted) {
+			return newHTTPError(http.StatusGone, "stream has been deleted")
 		}
 		return err
 	}

--- a/packages/caddy-plugin/store/file_store.go
+++ b/packages/caddy-plugin/store/file_store.go
@@ -168,6 +168,13 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 		sourceMeta = sourceMetaEntry
 		sourceContentType = sourceMeta.ContentType
 
+		// Reject a content-type mismatch up front, before taking a reference on
+		// the source. Doing this after IncrementRefCount would leak a reference
+		// on the failed fork and pin the source in a soft-deleted state forever.
+		if opts.ContentType != "" && !strings.EqualFold(opts.ContentType, sourceContentType) {
+			return nil, false, ErrContentTypeMismatch
+		}
+
 		// Resolve fork offset: use opts.ForkOffset if set, else source's CurrentOffset
 		if opts.ForkOffset != nil {
 			forkOffset = *opts.ForkOffset
@@ -209,7 +216,9 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 		sourceMeta.RefCount++
 	}
 
-	// Determine content type: use opts.ContentType, or inherit from source if fork
+	// Determine content type: use opts.ContentType, or inherit from source if
+	// fork. A fork content-type mismatch is already rejected above, before the
+	// source refcount is taken.
 	contentType := opts.ContentType
 	if contentType == "" {
 		if isFork {
@@ -217,8 +226,6 @@ func (s *FileStore) Create(path string, opts CreateOptions) (*StreamMetadata, bo
 		} else {
 			contentType = "application/octet-stream"
 		}
-	} else if isFork && !strings.EqualFold(contentType, sourceContentType) {
-		return nil, false, ErrContentTypeMismatch
 	}
 
 	// Generate unique directory name
@@ -400,9 +407,10 @@ func (s *FileStore) Delete(path string) error {
 		return ErrStreamNotFound
 	}
 
-	// Already soft-deleted: idempotent success
+	// Already soft-deleted: the stream is gone for direct operations (a
+	// soft-deleted stream returns 410 Gone for GET/HEAD/POST/DELETE).
 	if meta.SoftDeleted {
-		return nil
+		return ErrStreamSoftDeleted
 	}
 
 	// If there are forks referencing this stream, soft-delete instead

--- a/packages/caddy-plugin/store/memory_store.go
+++ b/packages/caddy-plugin/store/memory_store.go
@@ -194,6 +194,14 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		sourceMeta = &ss.metadata
 		sourceContentType = sourceMeta.ContentType
 
+		// Reject a content-type mismatch up front, before taking a reference on
+		// the source. Doing this after the refcount increment would leak a
+		// reference on the failed fork and pin the source in a soft-deleted
+		// state forever.
+		if opts.ContentType != "" && !strings.EqualFold(opts.ContentType, sourceContentType) {
+			return nil, false, ErrContentTypeMismatch
+		}
+
 		// Resolve fork offset: use opts.ForkOffset if set, else source's CurrentOffset
 		if opts.ForkOffset != nil {
 			forkOffset = *opts.ForkOffset
@@ -223,7 +231,9 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		sourceStream.metadata.RefCount++
 	}
 
-	// Determine content type: use opts.ContentType, or inherit from source if fork
+	// Determine content type: use opts.ContentType, or inherit from source if
+	// fork. A fork content-type mismatch is already rejected above, before the
+	// source refcount is taken.
 	contentType := opts.ContentType
 	if contentType == "" {
 		if isFork {
@@ -231,8 +241,6 @@ func (s *MemoryStore) Create(path string, opts CreateOptions) (*StreamMetadata, 
 		} else {
 			contentType = "application/octet-stream"
 		}
-	} else if isFork && !strings.EqualFold(contentType, sourceContentType) {
-		return nil, false, ErrContentTypeMismatch
 	}
 
 	// Build metadata
@@ -379,9 +387,10 @@ func (s *MemoryStore) Delete(path string) error {
 		return ErrStreamNotFound
 	}
 
-	// Already soft-deleted: idempotent success
+	// Already soft-deleted: the stream is gone for direct operations (a
+	// soft-deleted stream returns 410 Gone for GET/HEAD/POST/DELETE).
 	if stream.metadata.SoftDeleted {
-		return nil
+		return ErrStreamSoftDeleted
 	}
 
 	// If there are forks referencing this stream, soft-delete instead

--- a/packages/server-conformance-tests/src/index.ts
+++ b/packages/server-conformance-tests/src/index.ts
@@ -7380,6 +7380,70 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
         // Connection should close quickly, not wait for timeout
         expect(elapsed).toBeLessThan(10000)
       })
+
+      test(`sse-live-reader-receives-final-append-on-close: live reader at tail receives data appended atomically with the close`, async () => {
+        // A live SSE reader that is caught up at the tail must receive data that
+        // is appended atomically with a stream close (POST + Stream-Closed),
+        // followed by the closing control event. A naive server can lose the
+        // final append when the close races the reader's internal poll cycle:
+        // it emits the streamClosed control without first delivering the data.
+        //
+        // The close is timed across a spread of delays to probe that race
+        // window; a correct server delivers the data regardless of timing, so
+        // this never produces false failures against a compliant implementation.
+        const delaysMs = [40, 60, 75, 82, 85, 88, 90, 90, 92, 92, 95, 98]
+
+        for (let i = 0; i < delaysMs.length; i++) {
+          const streamPath = `/v1/stream/sse-live-final-append-${Date.now()}-${i}`
+
+          // Create with initial content and capture the tail offset.
+          const createResponse = await fetch(`${getBaseUrl()}${streamPath}`, {
+            method: `PUT`,
+            headers: { "Content-Type": `text/plain` },
+            body: `initial`,
+          })
+          const tailOffset = createResponse.headers.get(STREAM_OFFSET_HEADER)
+
+          // Start a live SSE reader AT the tail, so it is caught up and waiting
+          // for new data at the moment the stream is closed. Do not await yet.
+          const ssePromise = fetchSSE(
+            `${getBaseUrl()}${streamPath}?offset=${tailOffset}&live=sse`,
+            { timeoutMs: 5000, maxChunks: 30, untilContent: `streamClosed` }
+          )
+
+          // Let the reader connect and reach the tail, then close after the
+          // per-iteration delay.
+          await new Promise((resolve) => setTimeout(resolve, delaysMs[i]))
+
+          // Append a final message AND close atomically (append-and-close).
+          await fetch(`${getBaseUrl()}${streamPath}`, {
+            method: `POST`,
+            headers: {
+              "Content-Type": `text/plain`,
+              [STREAM_CLOSED_HEADER]: `true`,
+            },
+            body: `sse-data`,
+          })
+
+          const { received } = await ssePromise
+          const events = parseSSEEvents(received)
+
+          // The live reader MUST receive the data appended as part of the close.
+          const dataEvents = events.filter((e) => e.type === `data`)
+          const allData = dataEvents.map((e) => e.data).join(``)
+          expect(
+            allData,
+            `iteration ${i} (close ${delaysMs[i]}ms after connect): live SSE reader must receive data appended atomically with the close`
+          ).toContain(`sse-data`)
+
+          // ...followed by a closing control event with streamClosed: true.
+          const controlEvents = events.filter((e) => e.type === `control`)
+          expect(controlEvents.length).toBeGreaterThan(0)
+          const lastControl = controlEvents[controlEvents.length - 1]!
+          const controlData = JSON.parse(lastControl.data)
+          expect(controlData.streamClosed).toBe(true)
+        }
+      })
     })
 
     // ========================================================================
@@ -10121,6 +10185,39 @@ export function runConformanceTests(options: ConformanceTestOptions): void {
         },
       })
       expect(forkRes.status).toBe(409)
+    })
+
+    test(`rejected fork (content-type mismatch) does not leak a source reference`, async () => {
+      const id = uniqueId()
+      const sourcePath = `/v1/stream/fork-ct-noleak-src-${id}`
+      const forkPath = `/v1/stream/fork-ct-noleak-fork-${id}`
+
+      await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `PUT`,
+        headers: { "Content-Type": `text/plain` },
+        body: `data`,
+      })
+
+      // Fork attempt with a mismatched content type is rejected.
+      const forkRes = await fetch(`${getBaseUrl()}${forkPath}`, {
+        method: `PUT`,
+        headers: {
+          "Content-Type": `application/json`,
+          [STREAM_FORKED_FROM_HEADER]: sourcePath,
+        },
+      })
+      expect(forkRes.status).toBe(409)
+
+      // The rejected fork must not have taken a reference on the source: the
+      // source has no live forks, so DELETE fully removes it rather than
+      // soft-deleting it. A leaked reference would pin the source in a
+      // soft-deleted state, so the path would report 410 (gone) afterward
+      // instead of 404 (not found).
+      await fetch(`${getBaseUrl()}${sourcePath}`, { method: `DELETE` })
+      const headRes = await fetch(`${getBaseUrl()}${sourcePath}`, {
+        method: `HEAD`,
+      })
+      expect(headRes.status).toBe(404)
     })
 
     test(`should cascade GC when last fork is deleted`, async () => {

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -818,6 +818,18 @@ export class FileBackedStreamStore {
 
       sourceContentType = sourceMeta.contentType
 
+      // Reject a content-type mismatch up front, before taking a reference on
+      // the source. Doing this after the refCount increment below would leak a
+      // reference on the failed fork and pin the source in a soft-deleted state.
+      if (
+        options.contentType &&
+        options.contentType.trim() !== `` &&
+        normalizeContentType(options.contentType) !==
+          normalizeContentType(sourceContentType)
+      ) {
+        throw new Error(`Content type mismatch with source stream`)
+      }
+
       // Resolve fork offset: use provided or source's currentOffset
       if (options.forkOffset) {
         forkOffset = options.forkOffset
@@ -851,18 +863,14 @@ export class FileBackedStreamStore {
       this.db.putSync(sourceKey, updatedSource)
     }
 
-    // Determine content type: use options, or inherit from source if fork
+    // Determine content type: use options, or inherit from source if fork. A
+    // fork content-type mismatch is already rejected above, before the source
+    // refCount is taken.
     let contentType = options.contentType
     if (!contentType || contentType.trim() === ``) {
       if (isFork) {
         contentType = sourceContentType
       }
-    } else if (
-      isFork &&
-      normalizeContentType(contentType) !==
-        normalizeContentType(sourceContentType)
-    ) {
-      throw new Error(`Content type mismatch with source stream`)
     }
 
     // Compute effective expiry for forks

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -329,6 +329,18 @@ export class StreamStore {
 
       sourceContentType = sourceStream.contentType
 
+      // Reject a content-type mismatch up front, before taking a reference on
+      // the source. Doing this after the refCount increment below would leak a
+      // reference on the failed fork and pin the source in a soft-deleted state.
+      if (
+        options.contentType &&
+        options.contentType.trim() !== `` &&
+        normalizeContentType(options.contentType) !==
+          normalizeContentType(sourceContentType)
+      ) {
+        throw new Error(`Content type mismatch with source stream`)
+      }
+
       // Resolve fork offset: use provided or source's currentOffset
       if (options.forkOffset) {
         forkOffset = options.forkOffset
@@ -358,18 +370,14 @@ export class StreamStore {
       sourceStream.refCount++
     }
 
-    // Determine content type: use options, or inherit from source if fork
+    // Determine content type: use options, or inherit from source if fork. A
+    // fork content-type mismatch is already rejected above, before the source
+    // refCount is taken.
     let contentType = options.contentType
     if (!contentType || contentType.trim() === ``) {
       if (isFork) {
         contentType = sourceContentType
       }
-    } else if (
-      isFork &&
-      normalizeContentType(contentType) !==
-        normalizeContentType(sourceContentType)
-    ) {
-      throw new Error(`Content type mismatch with source stream`)
     }
 
     // Compute effective expiry for forks


### PR DESCRIPTION
## Summary

Running the **full** server conformance suite against the Caddy plugin surfaced three protocol-compliance bugs that CI never caught — because the `caddy-conformance` job sharded by `--testNamePattern`, and those patterns were a hand-maintained allowlist that had drifted out of sync with the suite. ~Half the tests (every Fork suite, every Stream-Closure suite, idempotent producers, most property tests) matched no shard and were silently never run.

This PR fixes the CI gap and the three bugs it was hiding.

## CI: run the whole suite

Replaced the 8-way `--testNamePattern` matrix with a single full-suite job. `vitest --shard` can't substitute here (the caddy project is a single test file, so file-level sharding collapses to one shard), and the full suite runs in ~40s — not worth the maintenance hazard of a name allowlist.

## Bugs fixed

| # | Bug | Root cause | Fix |
|---|-----|-----------|-----|
| 1 | `DELETE` on a soft-deleted source returned **204** instead of `410 Gone` | Both stores treated a repeat DELETE as idempotent success (`return nil`) | Stores return `ErrStreamSoftDeleted`; handler maps it to 410 |
| 2 | Forking with a mismatched content-type returned **500** instead of `409`, **and leaked a source reference** | `handleCreate` had no `ErrContentTypeMismatch` case; the check also ran *after* the refcount increment with no rollback, pinning the source soft-deleted forever | Validate content-type **before** taking the reference (both stores); map the error to 409 |
| 3 | A live SSE reader caught up at the tail **silently lost the final message** when the stream was closed with an atomic append | On `WaitForMessages` reporting closure, the handler emitted the `streamClosed` control with the stale offset and returned without draining the appended data | Loop back to `Read` pending data first, emit it, then the closing control event |

## Tests

- **Live SSE close** (bug #3): converted from the client conformance suite into a server conformance test in `SSE with Stream Closure`. The data loss is a race (~47% per trial at the right close timing relative to the reader's internal poll cycle), so the test sweeps a spread of close delays to catch it deterministically while never producing false failures against a correct implementation.
- **Fork refcount no-leak** (bug #2): asserts a rejected mismatched fork leaves the source fully deletable (404 after DELETE), not pinned soft-deleted (410).

Both new tests also caught the **refcount leak in the reference TS server** (in-memory *and* file-backed stores) — fixed here too.

After the fix: full caddy conformance **326 passed / 0 failed** (was 322 / 2 failed), reference server **684 passed**, Go tests / gofmt / eslint / prettier / typecheck all clean.

## ⚠️ Protocol spec change — needs ecosystem awareness

`PROTOCOL.md` §5.4 contradicted itself: three statements said a soft-deleted stream returns `410 Gone` for **all** direct operations (GET/HEAD/POST/DELETE), but one line said deleting an already-soft-deleted stream "**MUST** return `204 No Content` (idempotent)". The reference server and conformance suite already enforce 410, so the stale 204 line is corrected to 410.

This is binding on every implementation — other language clients/servers may have code expecting 204 from a repeat delete, and stratovolt's `stream-worker` (which pins this conformance package) will run the two new tests when it next bumps the pin. Worth a look across the ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)