### PR TITLE
fix(client-conformance-tests): escape U+2028/U+2029 in stdio line protocol

### DIFF
--- a/.changeset/node24-readline-line-separators.md
+++ b/.changeset/node24-readline-line-separators.md
@@ -1,0 +1,21 @@
+---
+"@durable-streams/client-conformance-tests": patch
+---
+
+fix: make the stdio test protocol robust to Node 24's readline behavior
+
+Node 24's `node:readline` splits input lines on the Unicode line separators
+U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR), in addition to
+`\n`/`\r\n`/`\r` (Node 22 only split on the latter). The conformance harness
+exchanges newline-delimited JSON between the runner and the client adapter over
+stdin/stdout via `readline`, and `JSON.stringify` leaves U+2028/U+2029 raw
+(they are legal inside JSON strings). When a test payload contained one of these
+characters, Node 24 split a single protocol message across multiple `line`
+events, desyncing the command/response stream and producing spurious failures
+(status-code swaps, wrong-stream data, undefined-variable cascades) that varied
+run to run.
+
+`serializeCommand` and `serializeResult` now escape U+2028/U+2029 to their
+`\uXXXX` forms — still valid JSON that parses back to the identical characters,
+but no longer treated as line terminators by readline. The suite now passes on
+both Node 22 and Node 24.

--- a/packages/client-conformance-tests/src/protocol.ts
+++ b/packages/client-conformance-tests/src/protocol.ts
@@ -741,10 +741,24 @@ export function parseCommand(line: string): TestCommand {
 }
 
 /**
+ * Escape Unicode line separators (U+2028, U+2029) that `JSON.stringify` leaves
+ * raw. These are legal inside JSON strings, but Node 24's `readline` treats them
+ * as line terminators — so a single newline-delimited protocol message
+ * containing one would be split across multiple `line` events, desyncing the
+ * command/response stream. The escaped sequences are still valid JSON and parse
+ * back to the identical characters.
+ */
+function escapeLineSeparators(json: string): string {
+  return json
+    .replace(new RegExp(String.fromCharCode(0x2028), `g`), `\\u2028`)
+    .replace(new RegExp(String.fromCharCode(0x2029), `g`), `\\u2029`)
+}
+
+/**
  * Serialize a TestResult to a JSON line.
  */
 export function serializeResult(result: TestResult): string {
-  return JSON.stringify(result)
+  return escapeLineSeparators(JSON.stringify(result))
 }
 
 /**
@@ -758,7 +772,7 @@ export function parseResult(line: string): TestResult {
  * Serialize a TestCommand to a JSON line.
  */
 export function serializeCommand(command: TestCommand): string {
-  return JSON.stringify(command)
+  return escapeLineSeparators(JSON.stringify(command))
 }
 
 /**


### PR DESCRIPTION
## Problem

The TypeScript client-conformance suite failed on **Node 24** (3–62 failures, varying run to run) while passing 259/0 on **Node 22**. CI stayed green only because it runs on Node 22.

## Root cause

**Node 24's `node:readline` now splits input lines on the Unicode line separators U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR)**, in addition to `\n`/`\r\n`/`\r`. Node 22 only split on the latter.

```js
// one "\n"-terminated string containing U+2028 + U+2029, fed to createInterface:
//   Node 22 → 1 line   ✓
//   Node 24 → 3 lines  ✗
```

The conformance harness exchanges **newline-delimited JSON** between the runner and the client adapter over stdin/stdout via `readline.createInterface`. `JSON.stringify` leaves U+2028/U+2029 **raw** (they're legal inside JSON strings). So when a test payload contained one, Node 24 split a single protocol message across multiple `line` events, desyncing the command↔response pairing (`ClientAdapter` resolves one pending response per `line`). That surfaced as status-code swaps (201↔200), wrong-stream data, and `Undefined variable` cascades — with the variance coming from the separators only appearing in some data-dependent messages.

This is **not** an HTTP / undici / server / `@durable-streams/client` issue — purely the test harness's stdio line framing. A Node 24 server with Node 22 clients passes 100%.

## Fix

`serializeCommand` and `serializeResult` now escape U+2028/U+2029 to their `\uXXXX` forms — still valid JSON that parses back to the identical characters, but no longer treated as line terminators by readline.

## Verification (full suite, real `--run ts` entry)

| | Before | After |
|---|---|---|
| Node 24 | 3–62 failures (variable) | **259/0, 4/4 runs** |
| Node 22 | 259/0 | 259/0 (no regression) |

Typecheck, ESLint, and Prettier all pass.

## Note

The same readline gotcha could affect any other newline-delimited-JSON-over-stdio protocol in the repo on Node 24 (a follow-up audit may be worthwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)