### PR TITLE
Fix TypeScript conformance on Node 24

### DIFF
--- a/.changeset/quiet-lions-escape.md
+++ b/.changeset/quiet-lions-escape.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/client-conformance-tests": patch
+---
+
+Escape Unicode line separator characters in the JSONL adapter protocol so Node 24 readline does not split conformance test commands mid-payload.

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -27,7 +27,34 @@ jobs:
             node_modules/.pnpm
           retention-days: 1
 
-  # Parallel conformance tests by client
+  # TypeScript conformance across supported Node.js release lines.
+  conformance-typescript:
+    needs: build-ts
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24, 26]
+    name: conformance (typescript, node ${{ matrix.node-version }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: ts-build
+
+      - name: Run TypeScript conformance tests
+        run: |
+          cd packages/client-conformance-tests
+          pnpm tsx src/cli.ts --run ts
+
+  # Parallel conformance tests by non-TypeScript client
   conformance:
     needs: build-ts
     runs-on: ubuntu-latest
@@ -35,9 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         client:
-          - name: typescript
-            cmd: ts
-            setup: ""
           - name: go
             cmd: ../../packages/client-go/conformance-adapter
             setup: |

--- a/packages/client-conformance-tests/src/protocol.ts
+++ b/packages/client-conformance-tests/src/protocol.ts
@@ -744,7 +744,7 @@ export function parseCommand(line: string): TestCommand {
  * Serialize a TestResult to a JSON line.
  */
 export function serializeResult(result: TestResult): string {
-  return JSON.stringify(result)
+  return serializeJsonLine(result)
 }
 
 /**
@@ -758,7 +758,13 @@ export function parseResult(line: string): TestResult {
  * Serialize a TestCommand to a JSON line.
  */
 export function serializeCommand(command: TestCommand): string {
-  return JSON.stringify(command)
+  return serializeJsonLine(command)
+}
+
+function serializeJsonLine(value: unknown): string {
+  return JSON.stringify(value).replace(/[\u2028\u2029]/g, (char) =>
+    char === `\u2028` ? `\\u2028` : `\\u2029`
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary
- Escape Unicode line separator characters in the client conformance JSONL adapter protocol so Node 24 readline does not split commands or results mid-payload.
- Add a TypeScript client conformance CI matrix for supported Node release lines: 22, 24, and 26.

## Test plan
- `nvm use 24 && pnpm --filter @durable-streams/client-conformance-tests test:run`


Made with [Cursor](https://cursor.com)