### PR TITLE
docs: add server-side HTTP caching example

### DIFF
--- a/docs/typescript-client.md
+++ b/docs/typescript-client.md
@@ -70,6 +70,66 @@ const unsubscribe = res.subscribeJson(async (batch) => {
 
 Save the returned offset from subscriber batches if you want to resume from the same place later.
 
+## Server-side HTTP caching
+
+Durable Streams reads are ordinary HTTP responses with cache headers such as `Cache-Control` and `ETag`. On a Node.js server, you can use Undici's cache interceptor as a cache-aware `fetch` implementation and pass it to the TypeScript client.
+
+Install Undici if your app does not already depend on it:
+
+```bash
+npm install undici
+```
+
+Create a cached fetch with an in-memory 100 MiB cache:
+
+```typescript
+import { Agent, cacheStores, interceptors } from "undici"
+import { stream } from "@durable-streams/client"
+
+const dispatcher = new Agent().compose(
+  interceptors.cache({
+    store: new cacheStores.MemoryCacheStore({
+      maxSize: 100 * 1024 * 1024, // 100 MiB, in bytes
+    }),
+  })
+)
+
+const cachedFetch: typeof fetch = (input, init) => {
+  return fetch(input, {
+    ...init,
+    dispatcher,
+  } as RequestInit)
+}
+
+const res = await stream<{ message: string }>({
+  url: "https://streams.example.com/my-account/chat/room-1",
+  fetch: cachedFetch,
+  live: false,
+})
+
+const items = await res.json()
+```
+
+Undici handles the HTTP cache semantics for you, including `Cache-Control`, `ETag` validation, `304 Not Modified`, `Expires`, `Last-Modified`, and `Vary`. This works well for catch-up reads because the TypeScript client intentionally sends the initial catch-up request without a `live` query parameter, allowing standard HTTP caches to store it when the server marks it cacheable.
+
+You can also install the cached dispatcher globally for all Undici-backed fetch calls in the process:
+
+```typescript
+import { Agent, cacheStores, interceptors, setGlobalDispatcher } from "undici"
+
+setGlobalDispatcher(
+  new Agent().compose(
+    interceptors.cache({
+      store: new cacheStores.MemoryCacheStore({
+        maxSize: 100 * 1024 * 1024,
+      }),
+    })
+  )
+)
+```
+
+For streams that contain user-specific or confidential data, make sure your server returns appropriate `Cache-Control` headers such as `private` or `no-store`. Shared caches should only store responses that are safe to share between users.
+
 ## Exactly-once writes
 
 For reliable, high-throughput writes with exactly-once semantics, use `IdempotentProducer`:


### PR DESCRIPTION
## Summary
- document using Undici's cache interceptor as a server-side cached fetch for the TypeScript client
- show a 100 MiB in-memory cache example and global dispatcher setup
- note cache-control considerations for user-specific streams

## Testing
- pnpm --dir docs build