### PR TITLE
fix(state): make @tanstack/db a peer dependency again

### DIFF
--- a/.changeset/state-tanstack-db-peer.md
+++ b/.changeset/state-tanstack-db-peer.md
@@ -1,0 +1,11 @@
+---
+"@durable-streams/state": minor
+---
+
+Move `@tanstack/db` from a regular dependency to a peer dependency (`>=0.6.0 <1.0.0`).
+
+`@tanstack/db` is a singleton: collections, transactions, and live queries rely on `instanceof` checks and module-level shared state, so two copies in a dependency tree don't interoperate. Pinning it as a regular dependency (`^0.6.0`) meant that as soon as a consuming app upgraded `@tanstack/react-db` (which pins `@tanstack/db` at an exact version per release) past the `0.6` line, the app's copy and `state`'s copy diverged into two instances — breaking StreamDB collections at runtime.
+
+Declaring it as a peer dependency makes `state` bind to the single `@tanstack/db` the consuming app already has, and the permissive range keeps that binding valid as the app moves across `0.x` minors.
+
+**Breaking change:** consumers must now install `@tanstack/db` themselves (any `>=0.6.0 <1.0.0`). Apps already depending on `@tanstack/db` or `@tanstack/react-db` are unaffected.

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -50,11 +50,14 @@
   ],
   "dependencies": {
     "@durable-streams/client": "workspace:*",
-    "@standard-schema/spec": "^1.0.0",
-    "@tanstack/db": "^0.6.0"
+    "@standard-schema/spec": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@tanstack/db": ">=0.6.0 <1.0.0"
   },
   "devDependencies": {
     "@durable-streams/server": "workspace:*",
+    "@tanstack/db": "0.6.0",
     "@tanstack/intent": "latest",
     "tsdown": "^0.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,13 +616,13 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
-      '@tanstack/db':
-        specifier: 0.6.0
-        version: 0.6.0(typescript@5.9.3)
     devDependencies:
       '@durable-streams/server':
         specifier: workspace:*
         version: link:../server
+      '@tanstack/db':
+        specifier: 0.6.0
+        version: 0.6.0(typescript@5.9.3)
       '@tanstack/intent':
         specifier: latest
         version: 0.0.23
@@ -2579,18 +2579,8 @@ packages:
     engines: {node: '>=18'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  '@tanstack/db-ivm@0.1.17':
-    resolution: {integrity: sha512-DK7vm56CDxNuRAdsbiPs+gITJ+16tUtYgZg3BRTLYKGIDsy8sdIO7sQFq5zl7Y+aIKAPmMAbVp9UjJ75FTtwgQ==}
-    peerDependencies:
-      typescript: '>=4.7'
-
   '@tanstack/db-ivm@0.1.18':
     resolution: {integrity: sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==}
-    peerDependencies:
-      typescript: '>=4.7'
-
-  '@tanstack/db@0.5.33':
-    resolution: {integrity: sha512-8pV3jZdqx6VgDubuddoT0UbQi8RrlCJ/kjhmgPIZUjvfhD3sz1TRMK4RTwOOf/JPTQ4qwWy5ggYLUTJxZZRB2w==}
     peerDependencies:
       typescript: '>=4.7'
 
@@ -7870,23 +7860,10 @@ snapshots:
       - typescript
       - vite
 
-  '@tanstack/db-ivm@0.1.17(typescript@5.9.3)':
-    dependencies:
-      fractional-indexing: 3.2.0
-      sorted-btree: 1.8.1
-      typescript: 5.9.3
-
   '@tanstack/db-ivm@0.1.18(typescript@5.9.3)':
     dependencies:
       fractional-indexing: 3.2.0
       sorted-btree: 1.8.1
-      typescript: 5.9.3
-
-  '@tanstack/db@0.5.33(typescript@5.9.3)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db-ivm': 0.1.17(typescript@5.9.3)
-      '@tanstack/pacer-lite': 0.2.1
       typescript: 5.9.3
 
   '@tanstack/db@0.6.0(typescript@5.9.3)':


### PR DESCRIPTION
## Summary

Moves `@tanstack/db` on `@durable-streams/state` from a regular dependency (`^0.6.0`) back to a **peer dependency** (`>=0.6.0 <1.0.0`).

cc @kevin-dp for review.

## Why

`@tanstack/db` is effectively a **singleton library**. Collections, transactions, and live queries rely on `instanceof` checks and module-level shared state, and `Collection` carries private fields so TypeScript treats it nominally. If two copies of `@tanstack/db` end up in a dependency tree, collections created by one don't interoperate with the other — at both the type level (`Collection<…>` not assignable to `Collection<…>`) and at runtime.

As a **regular dependency**, the published `@durable-streams/state` ships its own pinned `@tanstack/db`. Any downstream app that also depends on `@tanstack/db` — directly, or transitively via `@tanstack/react-db`/`@tanstack/electric-db-collection`, which pin `@tanstack/db` at an **exact** version per release — gets a second copy the instant the versions drift across a `0.x` minor. That duplication is exactly what broke StreamDB for a downstream consumer (the Electric monorepo resolves 6 distinct `@tanstack/db` versions at once).

Making it a **peer dependency** means `state` no longer ships its own copy; it binds to the single `@tanstack/db` the consuming app already has. The permissive range keeps that binding valid as the app moves across `0.x` minors — a closed `^0.6.0` peer would re-create the split at `0.7.0`.

### Why this exact range (`>=0.6.0 <1.0.0`)

`@tanstack/db` is pre-1.0, so each **minor** (`0.6 → 0.7`) is a breaking boundary under semver — but for a singleton, a too-tight upper bound is itself what causes the duplicate-copy bug (non-overlapping ranges silently install two copies rather than failing loudly). So:

- **Floor `>=0.6.0`** — the API surface `state` actually uses; the lowest version real consumers install is `0.6.4`, so this won't force anyone.
- **Ceiling `<1.0.0`** — covers every future `0.x` minor (so `state` won't fragment as consumers bump `react-db` through `0.7.x`/`0.8.x`), while making `1.0` a deliberate re-test/bump boundary.

## Why a `minor` release

Per the repo convention, pre-1.0 packages use `patch` **unless the change is breaking**. Requiring consumers to install `@tanstack/db` themselves is a breaking change. This also matches direct precedent: `0.2.0` (#187) shipped this **exact** peer-dependency change as a `minor` marked **BREAKING**.

## Why we're reinstating a previously-reverted fix

This is a round trip, and the reason it was reverted no longer holds for downstream consumers:

| Version | Change | Bump |
| --- | --- | --- |
| 0.2.0 (#187) | regular → **peer** (`>=0.5.0`), BREAKING | `minor` |
| 0.2.7 (#365) | **peer → regular** (`^0.6.0`) + root `pnpm.overrides` pin | `patch` |
| this PR | regular → **peer** (`>=0.6.0 <1.0.0`) | `minor` |

#365 moved it back to a regular dep and fixed the resulting in-repo type-duplication with a root `pnpm.overrides: { "@tanstack/db": "0.6.0" }`. That override only dedupes **within this monorepo** (it makes the examples build) — it does nothing for external consumers, who still receive a hard-pinned `@tanstack/db` from the published package. So the underlying problem #187 solved was never actually fixed for downstream; it was just hidden internally. This PR restores the correct fix (with a tighter, bounded range) and **keeps** the root override, so the in-repo examples stay deduped and #365's build break does not return.

## Notes

- The root `pnpm.overrides` pin is intentionally kept; the dev-dependency is aligned to `0.6.0` to match what actually resolves in-repo.
- Consumers already depending on `@tanstack/db` or `@tanstack/react-db` are unaffected.

## Test plan

- [x] `pnpm --filter @durable-streams/state build` — succeeds, `@tanstack/db` resolves
- [x] `pnpm --filter @durable-streams/state typecheck` — clean
- [x] `vitest run packages/state/test` — 64/64 pass
- [x] `pnpm install` — single `@tanstack/db` resolution preserved via root override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
