### PR TITLE
feat(state)!: move TanStack DB surface to @durable-streams/state/db subpath

### DIFF
--- a/.changeset/state-db-subpath.md
+++ b/.changeset/state-db-subpath.md
@@ -1,0 +1,21 @@
+---
+"@durable-streams/state": minor
+---
+
+feat(state)!: move the TanStack DB-backed surface to a `@durable-streams/state/db` subpath
+
+The main `@durable-streams/state` entry is now free of `@tanstack/db`. It exposes only the db-free protocol surface — `createStateSchema` and its change-event helpers, `MaterializedState`, and the state-event types/guards — so producers and backends (e.g. `@durable-streams/server`) can depend on it without the `@tanstack/db` peer dependency installed. Previously the entry eagerly re-exported `@tanstack/db`, so importing anything from the package forced that peer to be resolvable, breaking publishable dependents that don't use the reactive layer.
+
+The reactive, TanStack DB-backed layer now lives at `@durable-streams/state/db`:
+
+- `createStreamDB`, `getStreamDBCollectionId`, and the `StreamDB*` / `Action*` types
+- the convenience re-exports of `@tanstack/db` (`createCollection`, `createOptimisticAction`, `eq`, `and`, `count`, …)
+
+The subpath is a strict superset of the main entry (it also re-exports `createStateSchema`), so existing reactive consumers only change the import path:
+
+```diff
+-import { createStateSchema, createStreamDB } from "@durable-streams/state"
++import { createStateSchema, createStreamDB } from "@durable-streams/state/db"
+```
+
+BREAKING CHANGE: `createStreamDB`, `getStreamDBCollectionId`, the StreamDB/Action types, and the `@tanstack/db` re-exports are no longer exported from `@durable-streams/state`. Import them from `@durable-streams/state/db` instead. The db-free APIs (`createStateSchema`, `MaterializedState`, event types/guards) are unchanged on the main entry.

--- a/docs/durable-state.md
+++ b/docs/durable-state.md
@@ -117,7 +117,7 @@ const allUsers = state.getType("user") // Map of all users
 
 For applications that need reactive queries, filtering, joins, and optimistic updates, use [StreamDB](stream-db.md).
 
-StreamDB is the `createStreamDB` / `StreamDB` layer in `@durable-streams/state`, built on top of State Streams and [TanStack DB](https://tanstack.com/db).
+StreamDB is the `createStreamDB` / `StreamDB` layer in `@durable-streams/state/db`, built on top of State Streams and [TanStack DB](https://tanstack.com/db).
 
 ## Durable Sessions
 

--- a/docs/stream-db.md
+++ b/docs/stream-db.md
@@ -19,14 +19,15 @@ Pass in a [StandardSchema](#define-a-standardschema) and get typed collections, 
 npm install @durable-streams/state @tanstack/db
 ```
 
-`@tanstack/db` is a peer dependency required for StreamDB collections and queries.
+`@tanstack/db` is a peer dependency required for StreamDB collections and queries. The StreamDB API is published under the `@durable-streams/state/db` subpath; the db-free protocol primitives (see [Durable State](durable-state.md)) live on the main `@durable-streams/state` entry and need no extra dependencies.
 
 ## Define a StandardSchema
 
 Define your state structure with `createStateSchema`. Each collection maps an entity type to a [Standard Schema](https://standardschema.dev/) validator and a primary key field:
 
 ```typescript
-import { createStateSchema, createStreamDB } from "@durable-streams/state"
+import { createStateSchema } from "@durable-streams/state"
+import { createStreamDB } from "@durable-streams/state/db"
 import { z } from "zod"
 
 const userSchema = z.object({

--- a/examples/state/wikipedia-events/src/lib/stream-db.tsx
+++ b/examples/state/wikipedia-events/src/lib/stream-db.tsx
@@ -5,7 +5,7 @@ import {
   onMount,
   useContext,
 } from "solid-js"
-import { createStateSchema, createStreamDB } from "@durable-streams/state"
+import { createStateSchema, createStreamDB } from "@durable-streams/state/db"
 import { wikipediaEventSchema } from "./types"
 import type { JSX } from "solid-js"
 

--- a/examples/stream-db/src/App.tsx
+++ b/examples/stream-db/src/App.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { createStateSchema, createStreamDB } from "@durable-streams/state"
+import { createStateSchema, createStreamDB } from "@durable-streams/state/db"
 import { useLiveQuery } from "@tanstack/react-db"
 
 const STREAM_URL = import.meta.env.VITE_STREAM_URL

--- a/examples/test-ui/src/lib/stream-db-context.tsx
+++ b/examples/test-ui/src/lib/stream-db-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react"
 import { DurableStream } from "@durable-streams/client"
-import { createStreamDB } from "@durable-streams/state"
+import { createStreamDB } from "@durable-streams/state/db"
 import { presenceStateSchema, registryStateSchema } from "./schemas"
 import type { PresenceData, StreamMetadata } from "./schemas"
 import type { ReactNode } from "react"

--- a/examples/yjs-demo/src/components/registry-context.tsx
+++ b/examples/yjs-demo/src/components/registry-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react"
 import { DurableStream } from "@durable-streams/client"
-import { createStreamDB } from "@durable-streams/state"
+import { createStreamDB } from "@durable-streams/state/db"
 import { registryStateSchema } from "../utils/schemas"
 import { useServerEndpoint } from "../components/server-endpoint-context"
 import type { RoomMetadata } from "../utils/schemas"

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -5,10 +5,19 @@ Building blocks for transmitting structured state over Durable Streams. Use thes
 ## Installation
 
 ```bash
+pnpm add @durable-streams/state
+```
+
+The package exposes two entry points:
+
+- **`@durable-streams/state`** — the db-free protocol surface: `createStateSchema` and event helpers, `MaterializedState`, and the event types/guards. No extra dependencies.
+- **`@durable-streams/state/db`** — the reactive, TanStack DB-backed layer (`createStreamDB`, live queries, optimistic actions). This entry requires the `@tanstack/db` peer dependency:
+
+```bash
 pnpm add @durable-streams/state @tanstack/db
 ```
 
-> **Note:** `@tanstack/db` is a peer dependency that must be installed alongside this package. This ensures type compatibility when using StreamDB collections with TanStack DB's query utilities like `useLiveQuery` from `@tanstack/react-db`.
+> **Note:** `@tanstack/db` is a peer dependency of the `/db` entry only. Installing it ensures type compatibility when using StreamDB collections with TanStack DB's query utilities like `useLiveQuery` from `@tanstack/react-db`.
 
 ## Overview
 
@@ -49,7 +58,8 @@ const allTokens = state.getType("token")
 Add schemas and validation for structured entities:
 
 ```typescript
-import { createStateSchema, createStreamDB } from "@durable-streams/state"
+import { createStateSchema } from "@durable-streams/state"
+import { createStreamDB } from "@durable-streams/state/db"
 
 // Define your schema
 const schema = createStateSchema({

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -33,6 +33,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./db": {
+      "import": {
+        "types": "./dist/db.d.ts",
+        "default": "./dist/db.js"
+      },
+      "require": {
+        "types": "./dist/db.d.cts",
+        "default": "./dist/db.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/state/skills/stream-db/SKILL.md
+++ b/packages/state/skills/stream-db/SKILL.md
@@ -28,7 +28,7 @@ optimistic actions, and transaction confirmation.
 ## Setup
 
 ```typescript
-import { createStreamDB, createStateSchema } from "@durable-streams/state"
+import { createStreamDB, createStateSchema } from "@durable-streams/state/db"
 import { DurableStream } from "@durable-streams/client"
 import { z } from "zod"
 
@@ -83,7 +83,7 @@ StreamDB collections are TanStack DB collections. Use framework adapters for rea
 
 ```typescript
 import { useLiveQuery } from "@tanstack/react-db"
-import { eq } from "@durable-streams/state"
+import { eq } from "@durable-streams/state/db"
 
 // List query — destructure { data } with a default empty array
 function UserList() {
@@ -111,7 +111,7 @@ function UserProfile({ userId }: { userId: string }) {
 ### Optimistic actions with server confirmation
 
 ```typescript
-import { createStreamDB, createStateSchema } from "@durable-streams/state"
+import { createStreamDB, createStateSchema } from "@durable-streams/state/db"
 import { z } from "zod"
 
 const schema = createStateSchema({

--- a/packages/state/src/db.ts
+++ b/packages/state/src/db.ts
@@ -1,0 +1,61 @@
+// `@durable-streams/state/db`: the full surface, including the reactive,
+// TanStack DB-backed StreamDB layer. Importing this entry pulls in @tanstack/db,
+// which is a peer dependency — consumers using this subpath must install it.
+//
+// It is a strict superset of the db-free main entry (`@durable-streams/state`),
+// so code that uses both `createStateSchema` and `createStreamDB` can import
+// everything from here.
+
+export * from "./index"
+
+// Reactive StreamDB layer
+export { createStreamDB, getStreamDBCollectionId } from "./stream-db"
+export type {
+  CreateStreamDBOptions,
+  StreamDB,
+  StreamDBMethods,
+  StreamDBUtils,
+  StreamDBWithActions,
+  ActionFactory,
+  ActionMap,
+  ActionDefinition,
+} from "./stream-db"
+
+// Re-export key types and utilities from @tanstack/db for convenience.
+// This ensures consumers can use the same module resolution for type compatibility.
+export type { Collection, SyncConfig } from "@tanstack/db"
+export {
+  createCollection,
+  createLiveQueryCollection,
+  createOptimisticAction,
+  createTransaction,
+  deepEquals,
+  localOnlyCollectionOptions,
+  queryOnce,
+  // Comparison operators
+  eq,
+  gt,
+  gte,
+  lt,
+  lte,
+  like,
+  ilike,
+  inArray,
+  // Logical operators
+  and,
+  or,
+  not,
+  // Null checking
+  isNull,
+  isUndefined,
+  // Aggregate functions
+  count,
+  sum,
+  avg,
+  min,
+  max,
+  // Includes/projection functions
+  concat,
+  coalesce,
+  toArray,
+} from "@tanstack/db"

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,3 +1,11 @@
+// Main entry: the db-free surface of the state protocol.
+//
+// Everything exported here works without @tanstack/db installed — defining
+// schemas, constructing/validating change events, and materializing state
+// in-memory. The reactive, TanStack DB-backed StreamDB layer (createStreamDB,
+// live queries, optimistic actions) lives under the `@durable-streams/state/db`
+// subpath, which carries the `@tanstack/db` peer dependency.
+
 // Types
 export type {
   Operation,
@@ -11,66 +19,15 @@ export type {
 
 export { isChangeEvent, isControlEvent } from "./types"
 
-// Classes
+// In-memory materialization
 export { MaterializedState } from "./materialized-state"
 
-// Stream DB
-export {
-  createStreamDB,
-  createStateSchema,
-  getStreamDBCollectionId,
-} from "./stream-db"
+// Schema definition + event construction (producer side)
+export { createStateSchema } from "./schema"
 export type {
   CollectionDefinition,
   CollectionEventHelpers,
   CollectionWithHelpers,
   StreamStateDefinition,
   StateSchema,
-  CreateStreamDBOptions,
-  StreamDB,
-  StreamDBMethods,
-  StreamDBUtils,
-  StreamDBWithActions,
-  ActionFactory,
-  ActionMap,
-  ActionDefinition,
-} from "./stream-db"
-
-// Re-export key types and utilities from @tanstack/db for convenience
-// This ensures consumers can use the same module resolution for type compatibility
-export type { Collection, SyncConfig } from "@tanstack/db"
-export {
-  createCollection,
-  createLiveQueryCollection,
-  createOptimisticAction,
-  createTransaction,
-  deepEquals,
-  localOnlyCollectionOptions,
-  queryOnce,
-  // Comparison operators
-  eq,
-  gt,
-  gte,
-  lt,
-  lte,
-  like,
-  ilike,
-  inArray,
-  // Logical operators
-  and,
-  or,
-  not,
-  // Null checking
-  isNull,
-  isUndefined,
-  // Aggregate functions
-  count,
-  sum,
-  avg,
-  min,
-  max,
-  // Includes/projection functions
-  concat,
-  coalesce,
-  toArray,
-} from "@tanstack/db"
+} from "./schema"

--- a/packages/state/src/schema.ts
+++ b/packages/state/src/schema.ts
@@ -1,0 +1,265 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec"
+import type { ChangeEvent } from "./types"
+
+// ============================================================================
+// Schema Definitions
+//
+// This module is intentionally free of any @tanstack/db dependency: it covers
+// the producer side of the state protocol (defining schemas and constructing
+// validated change events). The reactive, TanStack DB-backed surface lives in
+// ./stream-db and is published under the `@durable-streams/state/db` subpath.
+// ============================================================================
+
+/**
+ * Definition for a single collection in the stream state
+ */
+export interface CollectionDefinition<T = unknown> {
+  /** Standard Schema for validating values */
+  schema: StandardSchemaV1<T>
+  /** The type field value in change events that map to this collection */
+  type: string
+  /** The property name in T that serves as the primary key */
+  primaryKey: string
+}
+
+/**
+ * Helper methods for creating change events for a collection
+ */
+export interface CollectionEventHelpers<T> {
+  /**
+   * Create an insert change event
+   */
+  insert: (params: {
+    key?: string
+    value: T
+    headers?: Omit<Record<string, string>, `operation`>
+  }) => ChangeEvent<T>
+  /**
+   * Create an update change event
+   */
+  update: (params: {
+    key?: string
+    value: T
+    oldValue?: T
+    headers?: Omit<Record<string, string>, `operation`>
+  }) => ChangeEvent<T>
+  /**
+   * Create a delete change event
+   */
+  delete: (params: {
+    key?: string
+    oldValue?: T
+    headers?: Omit<Record<string, string>, `operation`>
+  }) => ChangeEvent<T>
+  /**
+   * Create an upsert change event (insert or update)
+   */
+  upsert: (params: {
+    key?: string
+    value: T
+    headers?: Omit<Record<string, string>, `operation`>
+  }) => ChangeEvent<T>
+}
+
+/**
+ * Collection definition enhanced with event creation helpers
+ */
+export type CollectionWithHelpers<T = unknown> = CollectionDefinition<T> &
+  CollectionEventHelpers<T>
+
+/**
+ * Stream state definition containing all collections
+ */
+export type StreamStateDefinition = Record<string, CollectionDefinition>
+
+/**
+ * Stream state schema with helper methods for creating change events
+ */
+export type StateSchema<T extends Record<string, CollectionDefinition>> = {
+  [K in keyof T]: CollectionWithHelpers<
+    T[K] extends CollectionDefinition<infer U> ? U : unknown
+  >
+}
+
+/**
+ * Reserved collection names that would collide with StreamDB properties
+ * (collections are now namespaced, but we still prevent internal name collisions)
+ */
+const RESERVED_COLLECTION_NAMES = new Set([
+  `collections`,
+  `preload`,
+  `close`,
+  `utils`,
+  `actions`,
+])
+
+/**
+ * Create helper functions for a collection
+ */
+function createCollectionHelpers<T>(
+  eventType: string,
+  primaryKey: string,
+  schema: StandardSchemaV1<T>
+): CollectionEventHelpers<T> {
+  return {
+    insert: ({ key, value, headers }): ChangeEvent<T> => {
+      // Validate value
+      const result = schema[`~standard`].validate(value)
+      if (`issues` in result) {
+        throw new Error(
+          `Validation failed for ${eventType} insert: ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
+        )
+      }
+
+      // Derive key from value if not explicitly provided
+      const derived = (value as any)[primaryKey]
+      const finalKey =
+        key ?? (derived != null && derived !== `` ? String(derived) : undefined)
+      if (finalKey == null || finalKey === ``) {
+        throw new Error(
+          `Cannot create ${eventType} insert event: must provide either 'key' or a value with a non-empty '${primaryKey}' field`
+        )
+      }
+
+      return {
+        type: eventType,
+        key: finalKey,
+        value,
+        headers: { ...headers, operation: `insert` },
+      }
+    },
+    update: ({ key, value, oldValue, headers }): ChangeEvent<T> => {
+      // Validate value
+      const result = schema[`~standard`].validate(value)
+      if (`issues` in result) {
+        throw new Error(
+          `Validation failed for ${eventType} update: ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
+        )
+      }
+
+      // Optionally validate oldValue if provided
+      if (oldValue !== undefined) {
+        const oldResult = schema[`~standard`].validate(oldValue)
+        if (`issues` in oldResult) {
+          throw new Error(
+            `Validation failed for ${eventType} update (oldValue): ${oldResult.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
+          )
+        }
+      }
+
+      // Derive key from value if not explicitly provided
+      const derived = (value as any)[primaryKey]
+      const finalKey =
+        key ?? (derived != null && derived !== `` ? String(derived) : undefined)
+      if (finalKey == null || finalKey === ``) {
+        throw new Error(
+          `Cannot create ${eventType} update event: must provide either 'key' or a value with a non-empty '${primaryKey}' field`
+        )
+      }
+
+      return {
+        type: eventType,
+        key: finalKey,
+        value,
+        old_value: oldValue,
+        headers: { ...headers, operation: `update` },
+      }
+    },
+    delete: ({ key, oldValue, headers }): ChangeEvent<T> => {
+      // Optionally validate oldValue if provided
+      if (oldValue !== undefined) {
+        const result = schema[`~standard`].validate(oldValue)
+        if (`issues` in result) {
+          throw new Error(
+            `Validation failed for ${eventType} delete (oldValue): ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
+          )
+        }
+      }
+
+      // Ensure we have either key or oldValue to derive the key from
+      const finalKey =
+        key ?? (oldValue ? String((oldValue as any)[primaryKey]) : undefined)
+      if (!finalKey) {
+        throw new Error(
+          `Cannot create ${eventType} delete event: must provide either 'key' or 'oldValue' with a ${primaryKey} field`
+        )
+      }
+
+      return {
+        type: eventType,
+        key: finalKey,
+        old_value: oldValue,
+        headers: { ...headers, operation: `delete` },
+      }
+    },
+    upsert: ({ key, value, headers }): ChangeEvent<T> => {
+      // Validate value
+      const result = schema[`~standard`].validate(value)
+      if (`issues` in result) {
+        throw new Error(
+          `Validation failed for ${eventType} upsert: ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
+        )
+      }
+
+      // Derive key from value if not explicitly provided
+      const derived = (value as any)[primaryKey]
+      const finalKey =
+        key ?? (derived != null && derived !== `` ? String(derived) : undefined)
+      if (finalKey == null || finalKey === ``) {
+        throw new Error(
+          `Cannot create ${eventType} upsert event: must provide either 'key' or a value with a non-empty '${primaryKey}' field`
+        )
+      }
+
+      return {
+        type: eventType,
+        key: finalKey,
+        value,
+        headers: { ...headers, operation: `upsert` },
+      }
+    },
+  }
+}
+
+/**
+ * Create a state schema definition with typed collections and event helpers
+ */
+export function createStateSchema<
+  T extends Record<string, CollectionDefinition>,
+>(collections: T): StateSchema<T> {
+  // Validate no reserved collection names
+  for (const name of Object.keys(collections)) {
+    if (RESERVED_COLLECTION_NAMES.has(name)) {
+      throw new Error(
+        `Reserved collection name "${name}" - this would collide with StreamDB properties (${Array.from(RESERVED_COLLECTION_NAMES).join(`, `)})`
+      )
+    }
+  }
+
+  // Validate no duplicate event types
+  const typeToCollection = new Map<string, string>()
+  for (const [collectionName, def] of Object.entries(collections)) {
+    const existing = typeToCollection.get(def.type)
+    if (existing) {
+      throw new Error(
+        `Duplicate event type "${def.type}" - used by both "${existing}" and "${collectionName}" collections`
+      )
+    }
+    typeToCollection.set(def.type, collectionName)
+  }
+
+  // Enhance collections with helper methods
+  const enhancedCollections: any = {}
+  for (const [name, collectionDef] of Object.entries(collections)) {
+    enhancedCollections[name] = {
+      ...collectionDef,
+      ...createCollectionHelpers(
+        collectionDef.type,
+        collectionDef.primaryKey,
+        collectionDef.schema
+      ),
+    }
+  }
+
+  return enhancedCollections
+}

--- a/packages/state/src/stream-db.ts
+++ b/packages/state/src/stream-db.ts
@@ -15,81 +15,23 @@ import type {
   LiveMode,
   StreamResponse,
 } from "@durable-streams/client"
+import type { CollectionDefinition, StreamStateDefinition } from "./schema"
+
+// Schema definitions and event construction are db-free and live in ./schema.
+// Re-export them here so the TanStack-backed `@durable-streams/state/db`
+// surface stays a superset of the db-free main entry.
+export { createStateSchema } from "./schema"
+export type {
+  CollectionDefinition,
+  CollectionEventHelpers,
+  CollectionWithHelpers,
+  StreamStateDefinition,
+  StateSchema,
+} from "./schema"
 
 // ============================================================================
 // Type Definitions
 // ============================================================================
-
-/**
- * Definition for a single collection in the stream state
- */
-export interface CollectionDefinition<T = unknown> {
-  /** Standard Schema for validating values */
-  schema: StandardSchemaV1<T>
-  /** The type field value in change events that map to this collection */
-  type: string
-  /** The property name in T that serves as the primary key */
-  primaryKey: string
-}
-
-/**
- * Helper methods for creating change events for a collection
- */
-export interface CollectionEventHelpers<T> {
-  /**
-   * Create an insert change event
-   */
-  insert: (params: {
-    key?: string
-    value: T
-    headers?: Omit<Record<string, string>, `operation`>
-  }) => ChangeEvent<T>
-  /**
-   * Create an update change event
-   */
-  update: (params: {
-    key?: string
-    value: T
-    oldValue?: T
-    headers?: Omit<Record<string, string>, `operation`>
-  }) => ChangeEvent<T>
-  /**
-   * Create a delete change event
-   */
-  delete: (params: {
-    key?: string
-    oldValue?: T
-    headers?: Omit<Record<string, string>, `operation`>
-  }) => ChangeEvent<T>
-  /**
-   * Create an upsert change event (insert or update)
-   */
-  upsert: (params: {
-    key?: string
-    value: T
-    headers?: Omit<Record<string, string>, `operation`>
-  }) => ChangeEvent<T>
-}
-
-/**
- * Collection definition enhanced with event creation helpers
- */
-export type CollectionWithHelpers<T = unknown> = CollectionDefinition<T> &
-  CollectionEventHelpers<T>
-
-/**
- * Stream state definition containing all collections
- */
-export type StreamStateDefinition = Record<string, CollectionDefinition>
-
-/**
- * Stream state schema with helper methods for creating change events
- */
-export type StateSchema<T extends Record<string, CollectionDefinition>> = {
-  [K in keyof T]: CollectionWithHelpers<
-    T[K] extends CollectionDefinition<infer U> ? U : unknown
-  >
-}
 
 /**
  * Definition for a single action that can be passed to createOptimisticAction
@@ -618,189 +560,6 @@ function createStreamSyncConfig<T extends object>(
 // ============================================================================
 // Main Implementation
 // ============================================================================
-
-/**
- * Reserved collection names that would collide with StreamDB properties
- * (collections are now namespaced, but we still prevent internal name collisions)
- */
-const RESERVED_COLLECTION_NAMES = new Set([
-  `collections`,
-  `preload`,
-  `close`,
-  `utils`,
-  `actions`,
-])
-
-/**
- * Create helper functions for a collection
- */
-function createCollectionHelpers<T>(
-  eventType: string,
-  primaryKey: string,
-  schema: StandardSchemaV1<T>
-): CollectionEventHelpers<T> {
-  return {
-    insert: ({ key, value, headers }): ChangeEvent<T> => {
-      // Validate value
-      const result = schema[`~standard`].validate(value)
-      if (`issues` in result) {
-        throw new Error(
-          `Validation failed for ${eventType} insert: ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
-        )
-      }
-
-      // Derive key from value if not explicitly provided
-      const derived = (value as any)[primaryKey]
-      const finalKey =
-        key ?? (derived != null && derived !== `` ? String(derived) : undefined)
-      if (finalKey == null || finalKey === ``) {
-        throw new Error(
-          `Cannot create ${eventType} insert event: must provide either 'key' or a value with a non-empty '${primaryKey}' field`
-        )
-      }
-
-      return {
-        type: eventType,
-        key: finalKey,
-        value,
-        headers: { ...headers, operation: `insert` },
-      }
-    },
-    update: ({ key, value, oldValue, headers }): ChangeEvent<T> => {
-      // Validate value
-      const result = schema[`~standard`].validate(value)
-      if (`issues` in result) {
-        throw new Error(
-          `Validation failed for ${eventType} update: ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
-        )
-      }
-
-      // Optionally validate oldValue if provided
-      if (oldValue !== undefined) {
-        const oldResult = schema[`~standard`].validate(oldValue)
-        if (`issues` in oldResult) {
-          throw new Error(
-            `Validation failed for ${eventType} update (oldValue): ${oldResult.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
-          )
-        }
-      }
-
-      // Derive key from value if not explicitly provided
-      const derived = (value as any)[primaryKey]
-      const finalKey =
-        key ?? (derived != null && derived !== `` ? String(derived) : undefined)
-      if (finalKey == null || finalKey === ``) {
-        throw new Error(
-          `Cannot create ${eventType} update event: must provide either 'key' or a value with a non-empty '${primaryKey}' field`
-        )
-      }
-
-      return {
-        type: eventType,
-        key: finalKey,
-        value,
-        old_value: oldValue,
-        headers: { ...headers, operation: `update` },
-      }
-    },
-    delete: ({ key, oldValue, headers }): ChangeEvent<T> => {
-      // Optionally validate oldValue if provided
-      if (oldValue !== undefined) {
-        const result = schema[`~standard`].validate(oldValue)
-        if (`issues` in result) {
-          throw new Error(
-            `Validation failed for ${eventType} delete (oldValue): ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
-          )
-        }
-      }
-
-      // Ensure we have either key or oldValue to derive the key from
-      const finalKey =
-        key ?? (oldValue ? String((oldValue as any)[primaryKey]) : undefined)
-      if (!finalKey) {
-        throw new Error(
-          `Cannot create ${eventType} delete event: must provide either 'key' or 'oldValue' with a ${primaryKey} field`
-        )
-      }
-
-      return {
-        type: eventType,
-        key: finalKey,
-        old_value: oldValue,
-        headers: { ...headers, operation: `delete` },
-      }
-    },
-    upsert: ({ key, value, headers }): ChangeEvent<T> => {
-      // Validate value
-      const result = schema[`~standard`].validate(value)
-      if (`issues` in result) {
-        throw new Error(
-          `Validation failed for ${eventType} upsert: ${result.issues?.map((i) => i.message).join(`, `) ?? `Unknown validation error`}`
-        )
-      }
-
-      // Derive key from value if not explicitly provided
-      const derived = (value as any)[primaryKey]
-      const finalKey =
-        key ?? (derived != null && derived !== `` ? String(derived) : undefined)
-      if (finalKey == null || finalKey === ``) {
-        throw new Error(
-          `Cannot create ${eventType} upsert event: must provide either 'key' or a value with a non-empty '${primaryKey}' field`
-        )
-      }
-
-      return {
-        type: eventType,
-        key: finalKey,
-        value,
-        headers: { ...headers, operation: `upsert` },
-      }
-    },
-  }
-}
-
-/**
- * Create a state schema definition with typed collections and event helpers
- */
-export function createStateSchema<
-  T extends Record<string, CollectionDefinition>,
->(collections: T): StateSchema<T> {
-  // Validate no reserved collection names
-  for (const name of Object.keys(collections)) {
-    if (RESERVED_COLLECTION_NAMES.has(name)) {
-      throw new Error(
-        `Reserved collection name "${name}" - this would collide with StreamDB properties (${Array.from(RESERVED_COLLECTION_NAMES).join(`, `)})`
-      )
-    }
-  }
-
-  // Validate no duplicate event types
-  const typeToCollection = new Map<string, string>()
-  for (const [collectionName, def] of Object.entries(collections)) {
-    const existing = typeToCollection.get(def.type)
-    if (existing) {
-      throw new Error(
-        `Duplicate event type "${def.type}" - used by both "${existing}" and "${collectionName}" collections`
-      )
-    }
-    typeToCollection.set(def.type, collectionName)
-  }
-
-  // Enhance collections with helper methods
-  const enhancedCollections: any = {}
-  for (const [name, collectionDef] of Object.entries(collections)) {
-    enhancedCollections[name] = {
-      ...collectionDef,
-      ...createCollectionHelpers(
-        collectionDef.type,
-        collectionDef.primaryKey,
-        collectionDef.schema
-      ),
-    }
-  }
-
-  return enhancedCollections
-}
 
 /**
  * Create a stream-backed database with TanStack DB collections

--- a/packages/state/test/db-free-entry.test.ts
+++ b/packages/state/test/db-free-entry.test.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const srcDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  `../src`
+)
+
+// Resolve a relative import specifier (e.g. "./types") to an on-disk .ts file.
+function resolveRelative(fromFile: string, spec: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), spec)
+  for (const candidate of [base, `${base}.ts`, path.join(base, `index.ts`)]) {
+    if (candidate.endsWith(`.ts`) && existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+// Collect every source module reachable from `entry` by following relative imports.
+function moduleGraph(entry: string): Array<string> {
+  const seen = new Set<string>()
+  const stack = [entry]
+  while (stack.length > 0) {
+    const file = stack.pop()!
+    if (seen.has(file)) continue
+    seen.add(file)
+    const code = readFileSync(file, `utf8`)
+    const relativeImport = /(?:from|import)\s*\(?\s*["'](\.[^"']+)["']/g
+    let match: RegExpExecArray | null
+    while ((match = relativeImport.exec(code)) !== null) {
+      const resolved = resolveRelative(file, match[1]!)
+      if (resolved) stack.push(resolved)
+    }
+  }
+  return [...seen]
+}
+
+function modulesImportingTanstackDb(files: Array<string>): Array<string> {
+  return files
+    .filter((f) => /["']@tanstack\/db["']/.test(readFileSync(f, `utf8`)))
+    .map((f) => path.relative(srcDir, f))
+}
+
+describe(`@durable-streams/state main entry`, () => {
+  it(`does not pull in @tanstack/db anywhere in its module graph`, () => {
+    const offenders = modulesImportingTanstackDb(
+      moduleGraph(path.join(srcDir, `index.ts`))
+    )
+    expect(offenders).toEqual([])
+  })
+
+  it(`exposes the db-free protocol surface`, async () => {
+    const mod = await import(`../src/index`)
+    expect(typeof mod.createStateSchema).toBe(`function`)
+    expect(typeof mod.MaterializedState).toBe(`function`)
+    expect(typeof mod.isChangeEvent).toBe(`function`)
+    // createStreamDB is reactive/TanStack-backed: it must NOT live on the main entry.
+    expect(`createStreamDB` in mod).toBe(false)
+  })
+})
+
+describe(`@durable-streams/state/db subpath`, () => {
+  it(`is where the TanStack-backed surface lives`, async () => {
+    const dbEntry = path.join(srcDir, `db.ts`)
+    expect(existsSync(dbEntry)).toBe(true)
+    // The /db entry is expected to depend on @tanstack/db.
+    expect(
+      modulesImportingTanstackDb(moduleGraph(dbEntry)).length
+    ).toBeGreaterThan(0)
+
+    const mod = await import(`../src/db`)
+    expect(typeof mod.createStreamDB).toBe(`function`)
+    // Convenience re-export from the db-free entry stays available here too.
+    expect(typeof mod.createStateSchema).toBe(`function`)
+  })
+})

--- a/packages/state/tsdown.config.ts
+++ b/packages/state/tsdown.config.ts
@@ -1,7 +1,7 @@
 import type { Options } from "tsdown"
 
 const config: Options = {
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/db.ts"],
   format: ["esm", "cjs"],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Why

#381 correctly made `@tanstack/db` a **peer dependency** of `@durable-streams/state` — it's a singleton (collections/transactions/live queries rely on `instanceof` and module-level state), so two copies in a tree don't interoperate.

But the package's main entry **eagerly re-exported ~30 runtime values** from `@tanstack/db`, so importing *anything* from `@durable-streams/state` forced that peer to be resolvable at module-load time.

That broke publishable dependents that don't use the reactive layer. The clearest case is **`@durable-streams/server`**, which imports only `createStateSchema` (pure schema validation — no `@tanstack/db` at runtime) yet crashed on import:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@tanstack/db'
  imported from .../packages/state/dist/index.js
```

for any consumer that hadn't installed the unmet peer. npm v7+ auto-installs peers, but **pnpm and yarn do not** — so a published `server` was effectively broken for them.

## What

Split the package along the protocol's natural **write/read boundary**:

- **`@durable-streams/state`** (main entry) is now **free of `@tanstack/db`**. It exposes the producer/backend surface: `createStateSchema` + change-event helpers, `MaterializedState`, and the state-event types/guards. Backends like the server depend on it without the peer.
- **`@durable-streams/state/db`** (new subpath) holds the reactive, TanStack DB-backed layer: `createStreamDB`, `getStreamDBCollectionId`, the `StreamDB*`/`Action*` types, and the `@tanstack/db` convenience re-exports. It's a **strict superset** of the main entry, so reactive consumers only change the import path:

```diff
-import { createStateSchema, createStreamDB } from "@durable-streams/state"
+import { createStateSchema, createStreamDB } from "@durable-streams/state/db"
```

### Mechanics
- Extracted the db-free schema/event-construction code into `src/schema.ts`.
- `src/index.ts` re-exports only the db-free surface; `src/db.ts` is the new superset entry; `stream-db.ts` re-exports `createStateSchema` for back-compat (kept the large existing test untouched).
- Added the `./db` export-map entry and a second tsdown build entry.
- Updated the four examples that use `createStreamDB` to import from `/db` (one-line path change each).

## Testing
- New `test/db-free-entry.test.ts` traces each entry's **module graph** and asserts the main entry never imports `@tanstack/db` while `/db` does. It failed before the split and passes now.
- Verified the built `server` imports cleanly with `@tanstack/db` removed from the tree (previously `ERR_MODULE_NOT_FOUND`).
- `state` typechecks; 67/67 state tests pass; `/db` subpath typechecks in the `wikipedia-events`, `test-ui`, and `yjs-demo` examples.

## Dependency notes
- No **publishable** package needs `@tanstack/db` added — none consume the reactive `/db` layer.
- The `/db`-consuming examples are all `private: true`, don't import `@tanstack/db` directly, and the root `pnpm.overrides` already pins `@tanstack/db` to a single monorepo-wide version, so no explicit dep is added there.

## Breaking change
`createStreamDB`, `getStreamDBCollectionId`, the StreamDB/Action types, and the `@tanstack/db` re-exports are no longer exported from `@durable-streams/state` — import them from `@durable-streams/state/db`. The db-free APIs are unchanged on the main entry. Released as a `minor` bump (pre-1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)