### PR TITLE
fix(state): mark @tanstack/db peer dependency as optional

### DIFF
--- a/.changeset/optional-tanstack-db-peer.md
+++ b/.changeset/optional-tanstack-db-peer.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/state": patch
+---
+
+Mark `@tanstack/db` as an optional peer dependency. The TanStack DB surface lives behind the `@durable-streams/state/db` subpath and the main entry is db-free, so consumers that don't use the reactive layer no longer get unmet-peer warnings (or errors under strict pnpm).

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -65,6 +65,11 @@
   "peerDependencies": {
     "@tanstack/db": ">=0.6.0 <1.0.0"
   },
+  "peerDependenciesMeta": {
+    "@tanstack/db": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@durable-streams/server": "workspace:*",
     "@tanstack/db": "0.6.0",


### PR DESCRIPTION
## Summary

#382 moved the TanStack DB surface behind the `@durable-streams/state/db` subpath and made the package's main entry (`@durable-streams/state`) completely db-free. The intent was that consumers who don't use the reactive layer wouldn't need `@tanstack/db` installed at all.

However, the peer dependency was never actually marked optional. So despite all the work to isolate the dependency:

```json
"peerDependencies": {
  "@tanstack/db": ">=0.6.0 <1.0.0"
}
```

...package managers (notably pnpm in strict mode) still flag `@tanstack/db` as an unmet peer for consumers of the db-free entry.

This PR adds the missing `peerDependenciesMeta.optional` flag so the metadata matches the intended (and already-implemented) behavior:

```json
"peerDependenciesMeta": {
  "@tanstack/db": {
    "optional": true
  }
}
```

## Verification

- `@tanstack/db` is only imported from `src/db.ts` / `src/stream-db.ts`, which ship exclusively via the `./db` subpath; `src/index.ts` is db-free.
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `vitest run --project state` — 67/67 passing ✅

Includes a `patch` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)