### PR TITLE
Remove noisy store append slow logs

### DIFF
--- a/.changeset/upset-snails-bake.md
+++ b/.changeset/upset-snails-bake.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/server": patch
+---
+
+Remove noisy file-backed store slow append/create debug logs.

--- a/packages/server/src/file-store.ts
+++ b/packages/server/src/file-store.ts
@@ -885,8 +885,6 @@ export class FileBackedStreamStore {
     // Define key for LMDB operations
     const key = `stream:${streamPath}`
 
-    const t0 = performance.now()
-
     // Initialize metadata
     // Note: We set closed to false initially, then set it true after appending initial data
     // This prevents the closed check from rejecting the initial append
@@ -908,8 +906,6 @@ export class FileBackedStreamStore {
       forkSubOffset: undefined,
       refCount: 0,
     }
-
-    const tAfterMeta = performance.now()
 
     const segmentPath = segmentFile(this.dataDir, streamMeta.directoryName)
     try {
@@ -979,7 +975,6 @@ export class FileBackedStreamStore {
       )
       throw err
     }
-    const tAfterLmdb = performance.now()
     try {
       await this.fileHandlePool.openWriteStream(segmentPath)
     } catch (err) {
@@ -990,7 +985,6 @@ export class FileBackedStreamStore {
       )
       throw err
     }
-    const tAfterOpen = performance.now()
 
     // Append initial data if provided
     if (options.initialData && options.initialData.length > 0) {
@@ -1017,7 +1011,6 @@ export class FileBackedStreamStore {
         throw err
       }
     }
-    const tAfterAppend = performance.now()
 
     // Now set closed flag if requested (after initial append succeeded)
     if (options.closed) {
@@ -1028,22 +1021,6 @@ export class FileBackedStreamStore {
 
     // Re-fetch updated metadata
     const updated = this.db.get(key) as StreamMetadata
-    const totalMs = performance.now() - t0
-    if (totalMs > 50) {
-      serverLog.event(
-        {
-          event: `store.create`,
-          path: streamPath,
-          totalMs: +totalMs.toFixed(2),
-          metaMs: +(tAfterMeta - t0).toFixed(2),
-          lmdbMs: +(tAfterLmdb - tAfterMeta).toFixed(2),
-          openMs: +(tAfterOpen - tAfterLmdb).toFixed(2),
-          appendMs: +(tAfterAppend - tAfterOpen).toFixed(2),
-          initBytes: options.initialData?.length ?? 0,
-        },
-        `store.create slow`
-      )
-    }
     return this.streamMetaToStream(updated)
   }
 
@@ -1267,8 +1244,6 @@ export class FileBackedStreamStore {
 
     const segmentPath = segmentFile(this.dataDir, streamMeta.directoryName)
 
-    const tAppendStart = performance.now()
-
     // Get write stream from pool
     const stream = this.fileHandlePool.getWriteStream(segmentPath)
 
@@ -1289,8 +1264,6 @@ export class FileBackedStreamStore {
       })
     })
 
-    const tAfterWrite = performance.now()
-
     // 2. Create message object for return value
     const message: StreamMessage = {
       data: processedData,
@@ -1300,8 +1273,6 @@ export class FileBackedStreamStore {
 
     // 3. Flush to disk (blocks here until durable)
     await this.fileHandlePool.fsyncFile(segmentPath)
-
-    const tAfterFsync = performance.now()
 
     // 4. Update LMDB metadata atomically (only after flush, so metadata reflects durability)
     //    This includes both the offset update and producer state update
@@ -1332,24 +1303,6 @@ export class FileBackedStreamStore {
     }
     const key = `stream:${streamPath}`
     await this.db.put(key, updatedMeta)
-
-    const tAfterLmdb = performance.now()
-    const appendTotal = tAfterLmdb - tAppendStart
-    if (appendTotal > 50) {
-      serverLog.event(
-        {
-          event: `store.append`,
-          path: streamPath,
-          totalMs: +appendTotal.toFixed(2),
-          writeMs: +(tAfterWrite - tAppendStart).toFixed(2),
-          fsyncMs: +(tAfterFsync - tAfterWrite).toFixed(2),
-          lmdbMs: +(tAfterLmdb - tAfterFsync).toFixed(2),
-          bytes: processedData.length,
-          isInitial: options.isInitialCreate ?? false,
-        },
-        `store.append slow`
-      )
-    }
 
     // 5. Notify long-polls (data is now readable from disk)
     this.notifyLongPolls(streamPath)


### PR DESCRIPTION
Remove debug-only slow-operation logging from the file-backed stream store. Users running the server no longer see noisy `store.create slow` / `store.append slow` log lines during normal disk or CI slowness; stream behavior and durability semantics are unchanged.

## Root Cause

The file-backed store still contained performance-debug instrumentation from earlier append/create investigations. Those diagnostics emitted structured `serverLog.event(...)` records whenever create or append crossed a fixed 50ms threshold, which is common enough on slower disks, loaded dev machines, and CI to become background noise rather than actionable signal.

## Approach

Remove the slow-log instrumentation and its now-unused timing probes from `FileBackedStreamStore` while leaving the actual write path intact:

- create still persists metadata, opens the segment file, optionally appends initial data, and returns the refreshed stream metadata
- append still frames data, waits for the write callback, fsyncs, updates LMDB metadata, and notifies long-pollers
- error/recovery logs remain in place for actionable failures and recovery events

## Key Invariants

- File-backed append durability is unchanged: data is written and fsynced before LMDB metadata acknowledges the new offset.
- Long-poll notifications still happen only after data is readable from disk.
- Stream create, initial data append, close handling, fork metadata, and producer sequencing semantics are unchanged.
- Only non-actionable performance debug logging is removed.

## Non-goals

- This does not change append performance, fsync behavior, offset math, or recovery behavior.
- This does not remove error, warning, startup, or recovery logs.
- This does not introduce a configurable performance logging facility; it simply removes stale debug noise.

## Trade-offs

The alternative was to keep the timing code behind a config flag or raise the threshold. Since these logs were added for a temporary debugging pass and are no longer actively used, removing them keeps the hot path simpler and avoids carrying a dormant observability feature with an arbitrary threshold.

## Verification

```bash
pnpm install
pnpm --filter @durable-streams/client build
pnpm --filter @durable-streams/server-conformance-tests build
pnpm --filter @durable-streams/server typecheck
pnpm test:run -- --project server
```

Note: the final command uses the repo's existing `test:run` script, which still executes the configured Vitest projects; it completed successfully with 27 files / 1091 tests passing and 3 skipped.

## Files changed

- `packages/server/src/file-store.ts` — removes the `store.create slow` / `store.append slow` log events and their timing variables.
- `.changeset/upset-snails-bake.md` — records a patch changeset for `@durable-streams/server`.
