### PR TITLE
feat(yjs): add snapshot availability webhooks

### DIFF
--- a/.changeset/calm-yaks-listen.md
+++ b/.changeset/calm-yaks-listen.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/y-durable-streams": patch
+---
+
+Add service-scoped webhook subscriptions for `snapshot.available` events, backed by Durable Streams subscriptions over Yjs snapshot index streams.

--- a/.changeset/calm-yaks-listen.md
+++ b/.changeset/calm-yaks-listen.md
@@ -2,4 +2,4 @@
 "@durable-streams/y-durable-streams": patch
 ---
 
-Add service-scoped webhook subscriptions for `snapshot.available` events, backed by Durable Streams subscriptions over Yjs snapshot index streams.
+Add service-scoped webhook subscriptions for `snapshot.available` events, backed by Durable Streams subscriptions over Yjs snapshot index streams. Isolate internal awareness bookkeeping from snapshot triggers and reject awareness names that could collide with reserved stream paths.

--- a/docs/yjs.md
+++ b/docs/yjs.md
@@ -12,7 +12,7 @@ outline: [2, 3]
 
 Sync [Yjs](https://yjs.dev/) CRDT documents over Durable Streams using plain HTTP — no WebSocket infrastructure needed.
 
-y-durable-streams provides a Yjs provider and server that handle snapshot discovery, live updates via long-polling or SSE, automatic server-side compaction, and optional awareness (presence) for cursors and user status.
+y-durable-streams provides a Yjs provider and server that handle snapshot discovery, live updates via long-polling or SSE, automatic server-side compaction, snapshot availability webhooks, and optional awareness (presence) for cursors and user status.
 
 ## Installation
 
@@ -169,6 +169,30 @@ y-durable-streams uses a four-step sync protocol over HTTP. For the full wire fo
 ### Compaction
 
 y-durable-streams automatically compacts documents when accumulated updates exceed a size threshold. Compaction creates a new snapshot at the current offset, keeping initial sync fast for new clients. This is transparent to connected clients — existing connections continue uninterrupted.
+
+### Snapshot webhooks
+
+Create a service-scoped webhook subscription to persist snapshots in external storage:
+
+```ts
+await fetch(`${baseUrl}/__ds/subscriptions/snapshot-archive`, {
+  method: "PUT",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    type: "webhook",
+    events: ["snapshot.available"],
+    document_pattern: "projects/**",
+    webhook: { url: "https://archive.example/hooks/yjs" },
+    lease_ttl_ms: 30_000,
+  }),
+})
+```
+
+`document_pattern` is relative to the service. `*` matches one path segment and `**` matches recursively. The underlying Durable Streams server must support webhook subscriptions.
+
+The signed webhook is a wake notification and may represent more than one compaction. For every pending `.index` stream in the payload, derive the document path, request its current snapshot with `?offset=snapshot`, and persist the returned binary. Respond with `{ "done": true }` only after persistence succeeds; failed deliveries are retried by the Durable Streams subscription system.
+
+Subscriptions observe future snapshots. They do not immediately deliver the snapshot that was current when the subscription was created.
 
 ### URL structure
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "pnpm -r --filter '!@durable-streams-internal/caddy-plugin' --filter '!@durable-streams/example-*' build",
     "dev": "pnpm -r --parallel dev",
     "test": "vitest",
-    "test:run": "vitest run --project client --project server --project state --project tanstack-transport --project aisdk-transport",
+    "test:run": "vitest run --project client --project server --project state --project tanstack-transport --project aisdk-transport --project y-durable-streams",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/packages/y-durable-streams/README.md
+++ b/packages/y-durable-streams/README.md
@@ -10,6 +10,7 @@ Key benefits:
 
 - **No WebSocket infrastructure** - Works with standard HTTP load balancers and CDNs
 - **Automatic compaction** - Server manages document snapshots to keep sync fast
+- **Snapshot webhooks** - Wake external workers to persist the latest snapshot
 - **Scalable** - Stateless server design, documents stored in durable streams
 - **Presence support** - Optional awareness for cursors, selections, and user status
 
@@ -174,6 +175,41 @@ const server = new YjsServer({
 await server.start()
 console.log(`Yjs server running at ${server.url}`)
 ```
+
+### Snapshot webhooks
+
+Subscribe a webhook to be woken whenever a newer snapshot is available for a
+matching document:
+
+```typescript
+await fetch(
+  `${server.url}/v1/yjs/my-service/__ds/subscriptions/snapshot-archive`,
+  {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      type: "webhook",
+      events: ["snapshot.available"],
+      document_pattern: "projects/**",
+      webhook: { url: "https://archive.example/hooks/yjs" },
+      lease_ttl_ms: 30_000,
+    }),
+  }
+)
+```
+
+`document_pattern` is relative to the service's document namespace. `*`
+matches one path segment and `**` matches recursively. The underlying Durable
+Streams server must support webhook subscriptions.
+
+Webhook requests use the standard Durable Streams subscription payload and
+signature. A notification means one or more newer snapshots are available; it
+does not carry the snapshot bytes and may coalesce multiple compactions. For
+each pending `.index` stream, derive the document path and fetch its latest
+snapshot with `?offset=snapshot`. Return `{ "done": true }` only after the
+snapshot has been persisted successfully. New subscriptions observe future
+snapshots and do not replay the snapshot that was current when they were
+created.
 
 ## Conformance Tests
 

--- a/packages/y-durable-streams/YJS-PROTOCOL.md
+++ b/packages/y-durable-streams/YJS-PROTOCOL.md
@@ -10,7 +10,7 @@
 
 ## Abstract
 
-This document specifies the Durable Streams Yjs Protocol, an extension of the Durable Streams Protocol [PROTOCOL] that defines an HTTP-based protocol for Yjs document synchronization. The protocol provides durable, append-only streams for Yjs updates with automatic server-side compaction, snapshot management, and ephemeral awareness streams. It is designed to enable real-time collaborative editing over standard HTTP infrastructure without WebSocket complexity.
+This document specifies the Durable Streams Yjs Protocol, an extension of the Durable Streams Protocol [PROTOCOL] that defines an HTTP-based protocol for Yjs document synchronization. The protocol provides durable, append-only streams for Yjs updates with automatic server-side compaction, snapshot management, snapshot availability webhooks, and ephemeral awareness streams. It is designed to enable real-time collaborative editing over standard HTTP infrastructure without WebSocket complexity.
 
 ## Copyright Notice
 
@@ -35,6 +35,7 @@ Copyright (c) 2026 ElectricSQL
    - 5.8. [Create Awareness Stream](#58-create-awareness-stream)
    - 5.9. [Delete document](#59-delete-document)
    - 5.10. [Delete awareness stream](#510-delete-awareness-stream)
+   - 5.11. [Subscribe to snapshot availability](#511-subscribe-to-snapshot-availability)
 6. [Offset Sentinels](#6-offset-sentinels)
 7. [Binary Framing](#7-binary-framing)
    - 7.1. [Variable-Length Integer Encoding](#71-variable-length-integer-encoding)
@@ -163,10 +164,11 @@ The document stream, snapshots, and awareness streams all share the same URL pat
 
 The following HTTP methods are supported on document and awareness URLs:
 
-| Endpoint                          | Supported methods            | All other methods      |
-| --------------------------------- | ---------------------------- | ---------------------- |
-| `{document-url}`                  | GET, HEAD, POST, PUT, DELETE | 405 Method Not Allowed |
-| `{document-url}?awareness=<name>` | GET, HEAD, POST, PUT, DELETE | 405 Method Not Allowed |
+| Endpoint                                | Supported methods            | All other methods      |
+| --------------------------------------- | ---------------------------- | ---------------------- |
+| `{document-url}`                        | GET, HEAD, POST, PUT, DELETE | 405 Method Not Allowed |
+| `{document-url}?awareness=<name>`       | GET, HEAD, POST, PUT, DELETE | 405 Method Not Allowed |
+| `{service-url}/__ds/subscriptions/{id}` | GET, PUT, DELETE             | 405 Method Not Allowed |
 
 Servers **MUST** return `405 Method Not Allowed` for any HTTP method not listed above.
 
@@ -475,6 +477,69 @@ HTTP/1.1 404 Not Found
 #### Behavior
 
 The server MUST delete the specified awareness stream.
+
+### 5.11. Subscribe to snapshot availability
+
+Servers backed by a Durable Streams implementation that supports webhook subscriptions MAY expose service-scoped snapshot subscriptions. These subscriptions use the delivery, signing, retry, lease, and acknowledgement behavior from [PROTOCOL] Sections 6 and 7.
+
+#### Create or re-confirm a subscription
+
+```http
+PUT {service-url}/__ds/subscriptions/{id}
+Content-Type: application/json
+
+{
+  "type": "webhook",
+  "events": ["snapshot.available"],
+  "document_pattern": "projects/**",
+  "webhook": { "url": "https://archive.example/hooks/yjs" },
+  "lease_ttl_ms": 30000,
+  "description": "Archive project snapshots"
+}
+```
+
+`document_pattern` is relative to the service's document namespace. `*` matches exactly one path segment and `**` matches zero or more path segments. The only event defined by this version is `snapshot.available`.
+
+The response uses the base subscription representation with these additional fields:
+
+```json
+{
+  "id": "snapshot-archive",
+  "subscription_id": "snapshot-archive",
+  "delivery_subscription_id": "yjs:<base64url-service>:<base64url-id>",
+  "service": "my-service",
+  "events": ["snapshot.available"],
+  "document_pattern": "projects/**"
+}
+```
+
+`delivery_subscription_id` is the opaque, namespaced subscription identifier used in signed webhook payloads. Receivers that validate the expected `subscription_id` MUST compare webhook deliveries with this value.
+
+Creation returns `201 Created`. Re-confirming an identical subscription returns `200 OK`, and reusing the same ID with different configuration returns `409 Conflict`.
+
+#### Read or delete a subscription
+
+```http
+GET {service-url}/__ds/subscriptions/{id}
+DELETE {service-url}/__ds/subscriptions/{id}
+```
+
+GET returns the service-scoped subscription representation. DELETE is idempotent and returns `204 No Content`.
+
+#### Delivery semantics
+
+Snapshot webhooks are wake notifications and do not include snapshot bytes. A wake indicates that one or more matching documents have a newer current snapshot. Multiple compactions MAY be coalesced into a single wake.
+
+The reference server uses each document's snapshot index stream as the subscription trigger. Its stream-root-relative path is `yjs/{service}/docs/{doc-path}/.index`. For each pending index stream in the webhook payload, a receiver:
+
+1. Derives the document path from the index stream path.
+2. Requests `{document-url}?offset=snapshot` and follows the redirect to the current snapshot.
+3. Persists the binary snapshot outside the Durable Streams server.
+4. Returns `{ "done": true }` only after persistence succeeds, or uses the callback flow from [PROTOCOL] Section 7.1.
+
+The semantic guarantee is latest-snapshot convergence, not delivery of every intermediate compaction snapshot. If another snapshot is created while a wake is being processed, the subscription remains pending and wakes again after the current delivery is acknowledged.
+
+New subscriptions start at the current tail of matching index streams and therefore observe future snapshots only. Applications that also need the snapshot current at subscription creation MUST fetch it separately using snapshot discovery.
 
 ## 6. Offset Sentinels
 
@@ -898,6 +963,14 @@ This appendix specifies a conformance test suite for validating Yjs Protocol imp
 | `delete.awareness-returns-404`            | DELETE on non-existent awareness stream returns 404                  |
 | `delete.awareness-preserves-document`     | DELETE awareness does not affect parent document                     |
 | `delete.awareness-post-requires-document` | POST to awareness on deleted document returns 404 DOCUMENT_NOT_FOUND |
+
+#### A.1.8. Snapshot subscriptions
+
+| Test                                   | Description                                                                |
+| -------------------------------------- | -------------------------------------------------------------------------- |
+| `snapshot-subscription.lifecycle`      | Create, re-confirm, read, and delete a snapshot availability subscription  |
+| `snapshot-subscription.delivery`       | A matching snapshot index append produces a signed webhook wake            |
+| `snapshot-subscription.invalid-filter` | Events other than `snapshot.available` are rejected with `INVALID_REQUEST` |
 
 ### A.2. Running Conformance Tests
 

--- a/packages/y-durable-streams/YJS-PROTOCOL.md
+++ b/packages/y-durable-streams/YJS-PROTOCOL.md
@@ -338,9 +338,11 @@ Awareness is accessed via the `awareness` query parameter on the same document U
 
 - `?awareness=default`: Default stream for cursor positions, selections, user presence
 - `?awareness=admin`: Separate stream for admin-only awareness (e.g., moderator cursors)
-- `?awareness=<name>`: Any custom name for role-based or feature-specific awareness
+- `?awareness=<name>`: A custom name for role-based or feature-specific awareness
 
 Awareness streams are scoped to the document path. Two documents (`/docs/a` and `/docs/b`) have completely separate awareness streams, even if they use the same name.
+
+Awareness names MUST be 1–256 ASCII letters, digits, `.`, `_`, or `-`, and MUST NOT be `.`, `..`, or `.index`. Names identify one path segment; `.index` is reserved for snapshot bookkeeping.
 
 #### Request (SSE)
 
@@ -499,6 +501,8 @@ Content-Type: application/json
 ```
 
 `document_pattern` is relative to the service's document namespace. `*` matches exactly one path segment and `**` matches zero or more path segments. The only event defined by this version is `snapshot.available`.
+
+The reference server accepts service path segments containing ASCII letters, digits, `.`, `_`, and `-` (excluding `.` and `..`). This restriction keeps the service segment literal when translating the request to a Durable Streams subscription glob.
 
 The response uses the base subscription representation with these additional fields:
 
@@ -966,11 +970,13 @@ This appendix specifies a conformance test suite for validating Yjs Protocol imp
 
 #### A.1.8. Snapshot subscriptions
 
-| Test                                   | Description                                                                |
-| -------------------------------------- | -------------------------------------------------------------------------- |
-| `snapshot-subscription.lifecycle`      | Create, re-confirm, read, and delete a snapshot availability subscription  |
-| `snapshot-subscription.delivery`       | A matching snapshot index append produces a signed webhook wake            |
-| `snapshot-subscription.invalid-filter` | Events other than `snapshot.available` are rejected with `INVALID_REQUEST` |
+| Test                                   | Description                                                                                           |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `snapshot-subscription.lifecycle`      | Create, normalize, re-confirm, conflict, read, and delete a snapshot availability subscription        |
+| `snapshot-subscription.delivery`       | A matching snapshot index append produces a signed wake while awareness registry updates do not       |
+| `snapshot-subscription.invalid-filter` | Unsupported events and document patterns are rejected with `INVALID_REQUEST`                          |
+| `snapshot-subscription.service`        | Subscription routes accept the reference server's documented dotted service names                     |
+| `snapshot-subscription.proxy`          | Configured upstream headers win, invalid upstream scopes are omitted, and connection failures use 502 |
 
 ### A.2. Running Conformance Tests
 

--- a/packages/y-durable-streams/src/server/snapshot-subscriptions.ts
+++ b/packages/y-durable-streams/src/server/snapshot-subscriptions.ts
@@ -1,0 +1,320 @@
+import type { IncomingMessage, ServerResponse } from "node:http"
+
+const SNAPSHOT_AVAILABLE_EVENT = `snapshot.available`
+
+export interface SnapshotSubscriptionRoute {
+  service: string
+  subscriptionId: string
+}
+
+interface SnapshotSubscriptionInput {
+  type: `webhook`
+  events: Array<typeof SNAPSHOT_AVAILABLE_EVENT>
+  documentPattern: string
+  webhook: { url: string }
+  leaseTtlMs?: number
+  description?: string
+}
+
+export function parseSnapshotSubscriptionRoute(
+  path: string
+): SnapshotSubscriptionRoute | null {
+  const match = path.match(/^\/v1\/yjs\/([^/]+)\/__ds\/subscriptions\/([^/]+)$/)
+  if (!match) return null
+
+  try {
+    const service = decodeURIComponent(match[1]!)
+    const subscriptionId = decodeURIComponent(match[2]!)
+    if (!/^[a-zA-Z0-9_-]+$/.test(service)) return null
+    if (
+      subscriptionId.length === 0 ||
+      subscriptionId.length > 256 ||
+      subscriptionId.includes(`/`)
+    ) {
+      return null
+    }
+    return { service, subscriptionId }
+  } catch {
+    return null
+  }
+}
+
+export class SnapshotSubscriptionHandler {
+  private readonly dsServerUrl: string
+  private readonly dsServerHeaders: Record<string, string>
+
+  constructor(options: {
+    dsServerUrl: string
+    dsServerHeaders: Record<string, string>
+  }) {
+    this.dsServerUrl = options.dsServerUrl
+    this.dsServerHeaders = options.dsServerHeaders
+  }
+
+  async handle(
+    req: IncomingMessage,
+    res: ServerResponse,
+    route: SnapshotSubscriptionRoute
+  ): Promise<void> {
+    const method = req.method?.toUpperCase()
+    if (method === `PUT`) {
+      await this.createOrConfirm(req, res, route)
+      return
+    }
+    if (method === `GET`) {
+      await this.read(req, res, route)
+      return
+    }
+    if (method === `DELETE`) {
+      await this.delete(req, res, route)
+      return
+    }
+
+    this.writeError(res, 405, `INVALID_REQUEST`, `Method not allowed`)
+  }
+
+  private async createOrConfirm(
+    req: IncomingMessage,
+    res: ServerResponse,
+    route: SnapshotSubscriptionRoute
+  ): Promise<void> {
+    let body: unknown
+    try {
+      body = JSON.parse((await this.readBody(req)).toString(`utf8`))
+    } catch {
+      this.writeError(res, 400, `INVALID_REQUEST`, `Invalid JSON body`)
+      return
+    }
+
+    const parsed = this.parseInput(body)
+    if (`error` in parsed) {
+      this.writeError(res, 400, `INVALID_REQUEST`, parsed.error)
+      return
+    }
+
+    const input = parsed.value
+    const response = await fetch(this.subscriptionUrl(route), {
+      method: `PUT`,
+      headers: this.requestHeaders(req, true),
+      body: JSON.stringify({
+        type: input.type,
+        pattern: this.indexPattern(route.service, input.documentPattern),
+        webhook: input.webhook,
+        lease_ttl_ms: input.leaseTtlMs,
+        description: input.description,
+      }),
+    })
+
+    await this.forwardResponse(res, response, route)
+  }
+
+  private async read(
+    req: IncomingMessage,
+    res: ServerResponse,
+    route: SnapshotSubscriptionRoute
+  ): Promise<void> {
+    const response = await fetch(this.subscriptionUrl(route), {
+      method: `GET`,
+      headers: this.requestHeaders(req),
+    })
+    await this.forwardResponse(res, response, route)
+  }
+
+  private async delete(
+    req: IncomingMessage,
+    res: ServerResponse,
+    route: SnapshotSubscriptionRoute
+  ): Promise<void> {
+    const response = await fetch(this.subscriptionUrl(route), {
+      method: `DELETE`,
+      headers: this.requestHeaders(req),
+    })
+    await this.forwardResponse(res, response, route)
+  }
+
+  private parseInput(
+    body: unknown
+  ): { value: SnapshotSubscriptionInput } | { error: string } {
+    if (!body || typeof body !== `object`) {
+      return { error: `Request body must be a JSON object` }
+    }
+
+    const input = body as Record<string, unknown>
+    if (input.type !== `webhook`) {
+      return { error: `type must be webhook` }
+    }
+    if (
+      !Array.isArray(input.events) ||
+      input.events.length !== 1 ||
+      input.events[0] !== SNAPSHOT_AVAILABLE_EVENT
+    ) {
+      return { error: `events must contain only snapshot.available` }
+    }
+
+    const documentPattern = this.normalizeDocumentPattern(
+      input.document_pattern
+    )
+    if (!documentPattern) {
+      return { error: `document_pattern must be a valid document glob` }
+    }
+
+    const webhook = input.webhook
+    if (!webhook || typeof webhook !== `object`) {
+      return { error: `webhook subscriptions require webhook.url` }
+    }
+    const webhookUrl = (webhook as Record<string, unknown>).url
+    if (typeof webhookUrl !== `string` || webhookUrl.length === 0) {
+      return { error: `webhook subscriptions require webhook.url` }
+    }
+
+    if (
+      input.lease_ttl_ms !== undefined &&
+      (typeof input.lease_ttl_ms !== `number` ||
+        !Number.isInteger(input.lease_ttl_ms))
+    ) {
+      return { error: `lease_ttl_ms must be an integer` }
+    }
+    if (
+      input.description !== undefined &&
+      typeof input.description !== `string`
+    ) {
+      return { error: `description must be a string` }
+    }
+
+    return {
+      value: {
+        type: `webhook`,
+        events: [SNAPSHOT_AVAILABLE_EVENT],
+        documentPattern,
+        webhook: { url: webhookUrl },
+        leaseTtlMs: input.lease_ttl_ms,
+        description: input.description,
+      },
+    }
+  }
+
+  private normalizeDocumentPattern(value: unknown): string | null {
+    if (typeof value !== `string`) return null
+    const normalized = value.replace(/^\/+|\/+$/g, ``)
+    if (normalized.length === 0 || normalized.length > 256) return null
+
+    const segments = normalized.split(`/`)
+    for (const segment of segments) {
+      if (segment === `*` || segment === `**`) continue
+      if (!/^[a-zA-Z0-9_-]+$/.test(segment)) return null
+    }
+    return normalized
+  }
+
+  private indexPattern(service: string, documentPattern: string): string {
+    return `yjs/${service}/docs/${documentPattern}/.index`
+  }
+
+  private subscriptionUrl(route: SnapshotSubscriptionRoute): string {
+    const deliveryId = this.deliverySubscriptionId(route)
+    return `${this.dsServerUrl}/v1/stream/__ds/subscriptions/${encodeURIComponent(deliveryId)}`
+  }
+
+  private deliverySubscriptionId(route: SnapshotSubscriptionRoute): string {
+    const service = Buffer.from(route.service).toString(`base64url`)
+    const id = Buffer.from(route.subscriptionId).toString(`base64url`)
+    return `yjs:${service}:${id}`
+  }
+
+  private requestHeaders(
+    req: IncomingMessage,
+    jsonBody: boolean = false
+  ): Record<string, string> {
+    const headers: Record<string, string> = { ...this.dsServerHeaders }
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (
+        key.toLowerCase() !== `host` &&
+        key.toLowerCase() !== `content-length` &&
+        value
+      ) {
+        headers[key] = Array.isArray(value) ? value.join(`, `) : value
+      }
+    }
+    if (jsonBody) headers[`content-type`] = `application/json`
+    return headers
+  }
+
+  private async forwardResponse(
+    res: ServerResponse,
+    response: globalThis.Response,
+    route: SnapshotSubscriptionRoute
+  ): Promise<void> {
+    if (response.status === 204) {
+      await response.arrayBuffer()
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    const contentType = response.headers.get(`content-type`)
+    if (!response.ok || !contentType?.includes(`application/json`)) {
+      const body = new Uint8Array(await response.arrayBuffer())
+      const headers: Record<string, string> = {}
+      response.headers.forEach((value, key) => {
+        if (key !== `content-length` && key !== `content-encoding`) {
+          headers[key] = value
+        }
+      })
+      res.writeHead(response.status, headers)
+      res.end(body)
+      return
+    }
+
+    const subscription = (await response.json()) as Record<string, unknown>
+    const deliverySubscriptionId =
+      typeof subscription.subscription_id === `string`
+        ? subscription.subscription_id
+        : this.deliverySubscriptionId(route)
+    const documentPattern = this.documentPatternFromSubscription(
+      subscription,
+      route.service
+    )
+    delete subscription.pattern
+
+    res.writeHead(response.status, { "content-type": `application/json` })
+    res.end(
+      JSON.stringify({
+        ...subscription,
+        id: route.subscriptionId,
+        subscription_id: route.subscriptionId,
+        delivery_subscription_id: deliverySubscriptionId,
+        service: route.service,
+        events: [SNAPSHOT_AVAILABLE_EVENT],
+        document_pattern: documentPattern,
+      })
+    )
+  }
+
+  private documentPatternFromSubscription(
+    subscription: Record<string, unknown>,
+    service: string
+  ): string {
+    const pattern = subscription.pattern
+    if (typeof pattern !== `string`) return `**`
+    const prefix = `yjs/${service}/docs/`
+    const suffix = `/.index`
+    if (!pattern.startsWith(prefix) || !pattern.endsWith(suffix)) return `**`
+    return pattern.slice(prefix.length, -suffix.length)
+  }
+
+  private async readBody(req: IncomingMessage): Promise<Buffer> {
+    const chunks: Array<Buffer> = []
+    for await (const chunk of req) chunks.push(chunk as Buffer)
+    return Buffer.concat(chunks)
+  }
+
+  private writeError(
+    res: ServerResponse,
+    status: number,
+    code: string,
+    message: string
+  ): void {
+    res.writeHead(status, { "content-type": `application/json` })
+    res.end(JSON.stringify({ error: { code, message } }))
+  }
+}

--- a/packages/y-durable-streams/src/server/snapshot-subscriptions.ts
+++ b/packages/y-durable-streams/src/server/snapshot-subscriptions.ts
@@ -23,9 +23,17 @@ export function parseSnapshotSubscriptionRoute(
   if (!match) return null
 
   try {
-    const service = decodeURIComponent(match[1]!)
+    const service = match[1]!
     const subscriptionId = decodeURIComponent(match[2]!)
-    if (!/^[a-zA-Z0-9_-]+$/.test(service)) return null
+    if (
+      service.length === 0 ||
+      service.length > 256 ||
+      service === `.` ||
+      service === `..` ||
+      !/^[a-zA-Z0-9_.-]+$/.test(service)
+    ) {
+      return null
+    }
     if (
       subscriptionId.length === 0 ||
       subscriptionId.length > 256 ||
@@ -93,7 +101,7 @@ export class SnapshotSubscriptionHandler {
     }
 
     const input = parsed.value
-    const response = await fetch(this.subscriptionUrl(route), {
+    const response = await this.requestSubscription(res, route, {
       method: `PUT`,
       headers: this.requestHeaders(req, true),
       body: JSON.stringify({
@@ -104,6 +112,7 @@ export class SnapshotSubscriptionHandler {
         description: input.description,
       }),
     })
+    if (!response) return
 
     await this.forwardResponse(res, response, route)
   }
@@ -113,10 +122,11 @@ export class SnapshotSubscriptionHandler {
     res: ServerResponse,
     route: SnapshotSubscriptionRoute
   ): Promise<void> {
-    const response = await fetch(this.subscriptionUrl(route), {
+    const response = await this.requestSubscription(res, route, {
       method: `GET`,
       headers: this.requestHeaders(req),
     })
+    if (!response) return
     await this.forwardResponse(res, response, route)
   }
 
@@ -125,10 +135,11 @@ export class SnapshotSubscriptionHandler {
     res: ServerResponse,
     route: SnapshotSubscriptionRoute
   ): Promise<void> {
-    const response = await fetch(this.subscriptionUrl(route), {
+    const response = await this.requestSubscription(res, route, {
       method: `DELETE`,
       headers: this.requestHeaders(req),
     })
+    if (!response) return
     await this.forwardResponse(res, response, route)
   }
 
@@ -224,19 +235,62 @@ export class SnapshotSubscriptionHandler {
   private requestHeaders(
     req: IncomingMessage,
     jsonBody: boolean = false
-  ): Record<string, string> {
-    const headers: Record<string, string> = { ...this.dsServerHeaders }
-    for (const [key, value] of Object.entries(req.headers)) {
-      if (
-        key.toLowerCase() !== `host` &&
-        key.toLowerCase() !== `content-length` &&
-        value
-      ) {
-        headers[key] = Array.isArray(value) ? value.join(`, `) : value
+  ): globalThis.Headers {
+    const excludedHeaders = new Set([
+      `connection`,
+      `content-length`,
+      `host`,
+      `keep-alive`,
+      `proxy-authenticate`,
+      `proxy-authorization`,
+      `proxy-connection`,
+      `te`,
+      `trailer`,
+      `transfer-encoding`,
+      `upgrade`,
+    ])
+    const connection = req.headers.connection
+    const connectionValues = Array.isArray(connection)
+      ? connection
+      : connection === undefined
+        ? []
+        : [connection]
+    for (const value of connectionValues) {
+      for (const name of value.split(`,`)) {
+        const normalized = name.trim().toLowerCase()
+        if (normalized) excludedHeaders.add(normalized)
       }
     }
-    if (jsonBody) headers[`content-type`] = `application/json`
+
+    const headers = new globalThis.Headers()
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!excludedHeaders.has(key.toLowerCase()) && value !== undefined) {
+        headers.set(key, Array.isArray(value) ? value.join(`, `) : value)
+      }
+    }
+    for (const [key, value] of Object.entries(this.dsServerHeaders)) {
+      headers.set(key, value)
+    }
+    if (jsonBody) headers.set(`content-type`, `application/json`)
     return headers
+  }
+
+  private async requestSubscription(
+    res: ServerResponse,
+    route: SnapshotSubscriptionRoute,
+    init: globalThis.RequestInit
+  ): Promise<globalThis.Response | null> {
+    try {
+      return await fetch(this.subscriptionUrl(route), init)
+    } catch {
+      this.writeError(
+        res,
+        502,
+        `PROXY_ERROR`,
+        `Failed to reach Durable Streams server`
+      )
+      return null
+    }
   }
 
   private async forwardResponse(
@@ -285,7 +339,9 @@ export class SnapshotSubscriptionHandler {
         delivery_subscription_id: deliverySubscriptionId,
         service: route.service,
         events: [SNAPSHOT_AVAILABLE_EVENT],
-        document_pattern: documentPattern,
+        ...(documentPattern === undefined
+          ? {}
+          : { document_pattern: documentPattern }),
       })
     )
   }
@@ -293,13 +349,16 @@ export class SnapshotSubscriptionHandler {
   private documentPatternFromSubscription(
     subscription: Record<string, unknown>,
     service: string
-  ): string {
+  ): string | undefined {
     const pattern = subscription.pattern
-    if (typeof pattern !== `string`) return `**`
+    if (typeof pattern !== `string`) return undefined
     const prefix = `yjs/${service}/docs/`
     const suffix = `/.index`
-    if (!pattern.startsWith(prefix) || !pattern.endsWith(suffix)) return `**`
-    return pattern.slice(prefix.length, -suffix.length)
+    if (!pattern.startsWith(prefix) || !pattern.endsWith(suffix)) {
+      return undefined
+    }
+    const documentPattern = pattern.slice(prefix.length, -suffix.length)
+    return documentPattern.length > 0 ? documentPattern : undefined
   }
 
   private async readBody(req: IncomingMessage): Promise<Buffer> {

--- a/packages/y-durable-streams/src/server/types.ts
+++ b/packages/y-durable-streams/src/server/types.ts
@@ -156,12 +156,23 @@ export const YjsStreamPaths = {
   },
 
   /**
-   * Get the awareness index stream path for a document.
-   * This append-only stream tracks which named awareness streams have been created,
-   * enabling discovery during cascade delete.
+   * Get the legacy awareness index stream path for a document.
+   *
+   * @deprecated New writes use awarenessRegistryStream so snapshot subscription
+   * globs cannot mistake awareness registry updates for snapshot availability.
+   * Retained for cleanup of streams created by earlier server versions.
    */
   awarenessIndexStream(service: string, docPath: string): string {
     return `/v1/stream/yjs/${service}/docs/${docPath}/.awareness/.index`
+  },
+
+  /**
+   * Get the awareness registry stream path for a document.
+   * New awareness names are recorded here so they cannot match snapshot
+   * subscriptions or collide with a valid named awareness stream.
+   */
+  awarenessRegistryStream(service: string, docPath: string): string {
+    return `/v1/stream/yjs/${service}/docs/${docPath}/.awareness-index`
   },
 
   /**

--- a/packages/y-durable-streams/src/server/yjs-server.ts
+++ b/packages/y-durable-streams/src/server/yjs-server.ts
@@ -6,6 +6,7 @@
  * - Single URL path per document with query parameters
  * - Snapshot discovery via offset=snapshot sentinel (307 redirects)
  * - Automatic compaction when updates exceed threshold
+ * - Snapshot availability webhooks backed by Durable Streams subscriptions
  * - Awareness via ?awareness=<name> query parameter
  *
  * Protocol: https://github.com/durable-streams/durable-streams/blob/main/packages/y-durable-streams/PROTOCOL.md
@@ -18,6 +19,10 @@ import {
   FetchError,
 } from "@durable-streams/client"
 import { Compactor } from "./compaction"
+import {
+  SnapshotSubscriptionHandler,
+  parseSnapshotSubscriptionRoute,
+} from "./snapshot-subscriptions"
 import { PathUtils, YJS_HEADERS, YjsStreamPaths } from "./types"
 import type { IncomingMessage, Server, ServerResponse } from "node:http"
 import type { YjsDocumentState, YjsIndexEntry, YjsServerOptions } from "./types"
@@ -71,6 +76,7 @@ export class YjsServer {
   private readonly host: string
 
   private readonly compactor: Compactor
+  private readonly snapshotSubscriptions: SnapshotSubscriptionHandler
   private readonly documentStates = new Map<string, YjsDocumentState>()
 
   private stateKey(service: string, docPath: string): string {
@@ -89,6 +95,10 @@ export class YjsServer {
     this.host = options.host ?? `127.0.0.1`
 
     this.compactor = new Compactor(this)
+    this.snapshotSubscriptions = new SnapshotSubscriptionHandler({
+      dsServerUrl: this.dsServerUrl,
+      dsServerHeaders: this.dsServerHeaders,
+    })
   }
 
   async start(): Promise<string> {
@@ -195,6 +205,12 @@ export class YjsServer {
           error: { code: `INVALID_REQUEST`, message: `Invalid document path` },
         })
       )
+      return
+    }
+
+    const subscriptionRoute = parseSnapshotSubscriptionRoute(path)
+    if (subscriptionRoute) {
+      await this.snapshotSubscriptions.handle(req, res, subscriptionRoute)
       return
     }
 

--- a/packages/y-durable-streams/src/server/yjs-server.ts
+++ b/packages/y-durable-streams/src/server/yjs-server.ts
@@ -29,6 +29,17 @@ import type { YjsDocumentState, YjsIndexEntry, YjsServerOptions } from "./types"
 
 const DEFAULT_COMPACTION_THRESHOLD = 1024 * 1024 // 1MB
 
+function isValidAwarenessName(name: string): boolean {
+  return (
+    name.length > 0 &&
+    name.length <= 256 &&
+    name !== `.` &&
+    name !== `..` &&
+    name !== `.index` &&
+    /^[a-zA-Z0-9_.-]+$/.test(name)
+  )
+}
+
 /**
  * Check if an error is a 404 Not Found error.
  */
@@ -243,6 +254,18 @@ export class YjsServer {
     try {
       // Handle awareness streams
       if (awareness !== null) {
+        if (!isValidAwarenessName(awareness)) {
+          res.writeHead(400, { "content-type": `application/json` })
+          res.end(
+            JSON.stringify({
+              error: {
+                code: `INVALID_REQUEST`,
+                message: `Invalid awareness name`,
+              },
+            })
+          )
+          return
+        }
         await this.handleAwareness(req, res, route, awareness, url)
         return
       }
@@ -923,16 +946,21 @@ export class YjsServer {
     }
 
     // Load indices in parallel
-    const [snapshotOffsets, awarenessNames] = await Promise.all([
-      this.loadIndexEntries(
-        YjsStreamPaths.indexStream(service, docPath),
-        (entry) => entry.snapshotOffset as string | undefined
-      ),
-      this.loadIndexEntries(
-        YjsStreamPaths.awarenessIndexStream(service, docPath),
-        (entry) => entry.name as string | undefined
-      ),
-    ])
+    const [snapshotOffsets, awarenessNames, legacyAwarenessNames] =
+      await Promise.all([
+        this.loadIndexEntries(
+          YjsStreamPaths.indexStream(service, docPath),
+          (entry) => entry.snapshotOffset as string | undefined
+        ),
+        this.loadIndexEntries(
+          YjsStreamPaths.awarenessRegistryStream(service, docPath),
+          (entry) => entry.name as string | undefined
+        ),
+        this.loadIndexEntries(
+          YjsStreamPaths.awarenessIndexStream(service, docPath),
+          (entry) => entry.name as string | undefined
+        ),
+      ])
 
     // Build list of all paths to delete
     const pathsToDelete: Array<string> = []
@@ -948,9 +976,10 @@ export class YjsServer {
     pathsToDelete.push(
       YjsStreamPaths.awarenessStream(service, docPath, `default`)
     )
-    for (const name of awarenessNames) {
+    for (const name of new Set([...awarenessNames, ...legacyAwarenessNames])) {
       pathsToDelete.push(YjsStreamPaths.awarenessStream(service, docPath, name))
     }
+    pathsToDelete.push(YjsStreamPaths.awarenessRegistryStream(service, docPath))
     pathsToDelete.push(YjsStreamPaths.awarenessIndexStream(service, docPath))
 
     // Delete all streams in parallel (best-effort)
@@ -1069,9 +1098,9 @@ export class YjsServer {
       try {
         const created = await this.tryCreateStream(dsPath)
 
-        // Record non-default awareness streams in the awareness index for discovery
+        // Record non-default awareness streams in the registry for discovery
         if (created && awarenessName !== `default`) {
-          const indexPath = YjsStreamPaths.awarenessIndexStream(
+          const indexPath = YjsStreamPaths.awarenessRegistryStream(
             route.service,
             route.docPath
           )
@@ -1080,7 +1109,7 @@ export class YjsServer {
             createdAt: Date.now(),
           }).catch((err) => {
             console.error(
-              `[YjsServer] Failed to append to awareness index:`,
+              `[YjsServer] Failed to append to awareness registry:`,
               err
             )
           })

--- a/packages/y-durable-streams/test/yjs-conformance.test.ts
+++ b/packages/y-durable-streams/test/yjs-conformance.test.ts
@@ -9,6 +9,7 @@
  * Protocol: https://github.com/durable-streams/durable-streams/blob/main/packages/y-durable-streams/YJS-PROTOCOL.md
  */
 
+import { createServer as createHttpServer } from "node:http"
 import {
   afterAll,
   afterEach,
@@ -26,6 +27,73 @@ import { YjsServer } from "../src/server"
 
 const DEFAULT_TIMEOUT_MS = 10000
 const POLL_INTERVAL_MS = 50
+
+async function createWebhookReceiver(): Promise<{
+  url: string
+  waitForRequest: (timeoutMs?: number) => Promise<{
+    body: Record<string, unknown>
+    signature: string | null
+  }>
+  close: () => Promise<void>
+}> {
+  const received: Array<{
+    body: Record<string, unknown>
+    signature: string | null
+  }> = []
+  const waiters: Array<() => void> = []
+
+  const server = createHttpServer((req, res) => {
+    const chunks: Array<Buffer> = []
+    req.on(`data`, (chunk: Buffer) => chunks.push(chunk))
+    req.on(`end`, () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString(`utf8`)) as Record<
+        string,
+        unknown
+      >
+      const signatureHeader = req.headers[`webhook-signature`]
+      received.push({
+        body,
+        signature: typeof signatureHeader === `string` ? signatureHeader : null,
+      })
+      for (const waiter of waiters.splice(0)) waiter()
+      res.writeHead(200, { "content-type": `application/json` })
+      res.end(JSON.stringify({ done: true }))
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.on(`error`, reject)
+    server.listen(0, `127.0.0.1`, resolve)
+  })
+
+  const address = server.address()
+  if (!address || typeof address === `string`) {
+    throw new Error(`Failed to start webhook receiver`)
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/webhook`,
+    waitForRequest: async (timeoutMs = DEFAULT_TIMEOUT_MS) => {
+      if (received.length === 0) {
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error(`Timed out waiting for webhook request`)),
+            timeoutMs
+          )
+          waiters.push(() => {
+            clearTimeout(timeout)
+            resolve()
+          })
+        })
+      }
+      return received[received.length - 1]!
+    },
+    close: async () => {
+      server.closeAllConnections()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    },
+  }
+}
 
 async function waitForCondition(
   condition: () => boolean | Promise<boolean>,
@@ -211,7 +279,7 @@ describe(`Yjs Durable Streams Protocol`, () => {
       console.log(`Using external Yjs server: ${baseUrl}`)
     } else {
       // Start local servers for testing
-      dsServer = new DurableStreamTestServer({ port: 0 })
+      dsServer = new DurableStreamTestServer({ port: 0, webhooks: true })
       await dsServer.start()
 
       yjsServer = new YjsServer({
@@ -236,6 +304,182 @@ describe(`Yjs Durable Streams Protocol`, () => {
     // Give a moment for cleanup
     await new Promise((r) => setTimeout(r, 200))
   }, 5000)
+
+  describe.skipIf(!!externalServerUrl)(`Snapshot Subscriptions`, () => {
+    it(`snapshot-subscription.lifecycle creates, reads, and deletes a webhook subscription`, async () => {
+      const receiver = await createWebhookReceiver()
+      const subscriptionId = `snapshot-lifecycle-${Date.now()}`
+      const subscriptionUrl = `${baseUrl}/__ds/subscriptions/${subscriptionId}`
+      const request = {
+        type: `webhook`,
+        events: [`snapshot.available`],
+        document_pattern: `projects/**`,
+        webhook: { url: receiver.url },
+        lease_ttl_ms: 1000,
+        description: `Archive project snapshots`,
+      }
+
+      try {
+        const createdResponse = await fetch(subscriptionUrl, {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify(request),
+        })
+        expect(createdResponse.status).toBe(201)
+        const created = (await createdResponse.json()) as {
+          id: string
+          subscription_id: string
+          delivery_subscription_id: string
+          service: string
+          events: Array<string>
+          document_pattern: string
+          webhook: {
+            url: string
+            signing: { alg: string; jwks_url: string }
+          }
+        }
+        expect(created.id).toBe(subscriptionId)
+        expect(created.subscription_id).toBe(subscriptionId)
+        expect(created.delivery_subscription_id).toMatch(/^yjs:/)
+        expect(created.service).toBe(`test`)
+        expect(created.events).toEqual([`snapshot.available`])
+        expect(created.document_pattern).toBe(`projects/**`)
+        expect(created.webhook.url).toBe(receiver.url)
+        expect(created.webhook.signing.alg).toBe(`ed25519`)
+        expect(created.webhook.signing.jwks_url).toContain(
+          `/v1/stream/__ds/jwks.json`
+        )
+
+        const confirmedResponse = await fetch(subscriptionUrl, {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify(request),
+        })
+        expect(confirmedResponse.status).toBe(200)
+
+        const getResponse = await fetch(subscriptionUrl)
+        expect(getResponse.status).toBe(200)
+        const subscription = (await getResponse.json()) as {
+          id: string
+          events: Array<string>
+          document_pattern: string
+        }
+        expect(subscription.id).toBe(subscriptionId)
+        expect(subscription.events).toEqual([`snapshot.available`])
+        expect(subscription.document_pattern).toBe(`projects/**`)
+
+        const deleteResponse = await fetch(subscriptionUrl, {
+          method: `DELETE`,
+        })
+        expect(deleteResponse.status).toBe(204)
+
+        const deletedResponse = await fetch(subscriptionUrl)
+        expect(deletedResponse.status).toBe(404)
+      } finally {
+        await fetch(subscriptionUrl, { method: `DELETE` })
+        await receiver.close()
+      }
+    })
+
+    it(`snapshot-subscription.delivery wakes a webhook for a matching document`, async () => {
+      const receiver = await createWebhookReceiver()
+      const subscriptionId = `snapshot-delivery-${Date.now()}`
+      const subscriptionUrl = `${baseUrl}/__ds/subscriptions/${subscriptionId}`
+      const docId = `projects/webhook-${Date.now()}`
+      let provider: YjsProvider | null = null
+
+      try {
+        const createSubscriptionResponse = await fetch(subscriptionUrl, {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify({
+            type: `webhook`,
+            events: [`snapshot.available`],
+            document_pattern: `projects/**`,
+            webhook: { url: receiver.url },
+            lease_ttl_ms: 1000,
+          }),
+        })
+        expect(createSubscriptionResponse.status).toBe(201)
+        const subscription = (await createSubscriptionResponse.json()) as {
+          delivery_subscription_id: string
+        }
+
+        const doc = new Y.Doc()
+        provider = new YjsProvider({ doc, baseUrl, docId })
+        await waitForSync(provider)
+
+        const text = doc.getText(`content`)
+        await appendWithSync(provider, text, `W`.repeat(200), 10)
+        await waitForSnapshot(baseUrl, docId)
+
+        const delivery = await receiver.waitForRequest()
+        expect(delivery.signature).toMatch(
+          /^t=\d+,kid=.+,ed25519=[A-Za-z0-9_-]+$/
+        )
+        expect(delivery.body.subscription_id).toBe(
+          subscription.delivery_subscription_id
+        )
+        const stream = (
+          delivery.body.streams as Array<{
+            path: string
+            has_pending: boolean
+          }>
+        ).find(
+          (candidate) => candidate.path === `yjs/test/docs/${docId}/.index`
+        )
+        expect(stream).toEqual(
+          expect.objectContaining({
+            path: `yjs/test/docs/${docId}/.index`,
+            has_pending: true,
+          })
+        )
+
+        const snapshotDiscovery = await fetch(
+          `${baseUrl}/docs/${docId}?offset=snapshot`,
+          { redirect: `manual` }
+        )
+        expect(snapshotDiscovery.status).toBe(307)
+        const snapshotLocation = snapshotDiscovery.headers.get(`location`)
+        expect(snapshotLocation).toContain(`_snapshot`)
+
+        const snapshotResponse = await fetch(
+          new URL(snapshotLocation!, `${baseUrl}/docs/${docId}`).toString()
+        )
+        expect(snapshotResponse.status).toBe(200)
+        expect(
+          (await snapshotResponse.arrayBuffer()).byteLength
+        ).toBeGreaterThan(0)
+      } finally {
+        provider?.destroy()
+        await fetch(subscriptionUrl, { method: `DELETE` })
+        await receiver.close()
+      }
+    })
+
+    it(`snapshot-subscription.invalid-filter rejects unsupported events`, async () => {
+      const response = await fetch(
+        `${baseUrl}/__ds/subscriptions/invalid-${Date.now()}`,
+        {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify({
+            type: `webhook`,
+            events: [`snapshot.created`],
+            document_pattern: `**`,
+            webhook: { url: `http://127.0.0.1:1/webhook` },
+          }),
+        }
+      )
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: {
+          code: `INVALID_REQUEST`,
+          message: `events must contain only snapshot.available`,
+        },
+      })
+    })
+  })
 
   describe(`Snapshot Discovery`, () => {
     describe(`snapshot.discovery-new-doc`, () => {

--- a/packages/y-durable-streams/test/yjs-conformance.test.ts
+++ b/packages/y-durable-streams/test/yjs-conformance.test.ts
@@ -9,7 +9,10 @@
  * Protocol: https://github.com/durable-streams/durable-streams/blob/main/packages/y-durable-streams/YJS-PROTOCOL.md
  */
 
-import { createServer as createHttpServer } from "node:http"
+import {
+  request as createHttpRequest,
+  createServer as createHttpServer,
+} from "node:http"
 import {
   afterAll,
   afterEach,
@@ -23,7 +26,7 @@ import { DurableStreamTestServer } from "@durable-streams/server"
 import * as Y from "yjs"
 import { Awareness } from "y-protocols/awareness"
 import { YjsProvider } from "../src"
-import { YjsServer } from "../src/server"
+import { YjsServer, YjsStreamPaths } from "../src/server"
 
 const DEFAULT_TIMEOUT_MS = 10000
 const POLL_INTERVAL_MS = 50
@@ -34,6 +37,7 @@ async function createWebhookReceiver(): Promise<{
     body: Record<string, unknown>
     signature: string | null
   }>
+  requestCount: () => number
   close: () => Promise<void>
 }> {
   const received: Array<{
@@ -88,6 +92,7 @@ async function createWebhookReceiver(): Promise<{
       }
       return received[received.length - 1]!
     },
+    requestCount: () => received.length,
     close: async () => {
       server.closeAllConnections()
       await new Promise<void>((resolve) => server.close(() => resolve()))
@@ -357,6 +362,26 @@ describe(`Yjs Durable Streams Protocol`, () => {
         })
         expect(confirmedResponse.status).toBe(200)
 
+        const normalizedResponse = await fetch(subscriptionUrl, {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify({
+            ...request,
+            document_pattern: `/projects/**/`,
+          }),
+        })
+        expect(normalizedResponse.status).toBe(200)
+
+        const conflictResponse = await fetch(subscriptionUrl, {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify({
+            ...request,
+            webhook: { url: `${receiver.url}/different` },
+          }),
+        })
+        expect(conflictResponse.status).toBe(409)
+
         const getResponse = await fetch(subscriptionUrl)
         expect(getResponse.status).toBe(200)
         const subscription = (await getResponse.json()) as {
@@ -408,6 +433,26 @@ describe(`Yjs Durable Streams Protocol`, () => {
         const doc = new Y.Doc()
         provider = new YjsProvider({ doc, baseUrl, docId })
         await waitForSync(provider)
+
+        const reservedAwarenessResponse = await fetch(
+          `${baseUrl}/docs/${docId}?awareness=.index`,
+          { method: `PUT` }
+        )
+        expect(reservedAwarenessResponse.status).toBe(400)
+        expect(await reservedAwarenessResponse.json()).toEqual({
+          error: {
+            code: `INVALID_REQUEST`,
+            message: `Invalid awareness name`,
+          },
+        })
+
+        const awarenessResponse = await fetch(
+          `${baseUrl}/docs/${docId}?awareness=presence`,
+          { method: `PUT` }
+        )
+        expect(awarenessResponse.status).toBe(201)
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        expect(receiver.requestCount()).toBe(0)
 
         const text = doc.getText(`content`)
         await appendWithSync(provider, text, `W`.repeat(200), 10)
@@ -478,6 +523,194 @@ describe(`Yjs Durable Streams Protocol`, () => {
           message: `events must contain only snapshot.available`,
         },
       })
+
+      const invalidPatternResponse = await fetch(
+        `${baseUrl}/__ds/subscriptions/invalid-pattern-${Date.now()}`,
+        {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify({
+            type: `webhook`,
+            events: [`snapshot.available`],
+            document_pattern: `projects/[invalid]`,
+            webhook: { url: `http://127.0.0.1:1/webhook` },
+          }),
+        }
+      )
+      expect(invalidPatternResponse.status).toBe(400)
+      expect(await invalidPatternResponse.json()).toEqual({
+        error: {
+          code: `INVALID_REQUEST`,
+          message: `document_pattern must be a valid document glob`,
+        },
+      })
+    })
+
+    it(`snapshot-subscription.service supports dotted service names`, async () => {
+      const receiver = await createWebhookReceiver()
+      const subscriptionId = `snapshot-dotted-service-${Date.now()}`
+      const subscriptionUrl = `${yjsServer!.url}/v1/yjs/my.svc/__ds/subscriptions/${subscriptionId}`
+      const request = {
+        type: `webhook`,
+        events: [`snapshot.available`],
+        document_pattern: `**`,
+        webhook: { url: receiver.url },
+      }
+
+      try {
+        const response = await fetch(subscriptionUrl, {
+          method: `PUT`,
+          headers: { "content-type": `application/json` },
+          body: JSON.stringify(request),
+        })
+        expect(response.status).toBe(201)
+
+        const encodedServiceResponse = await fetch(
+          `${yjsServer!.url}/v1/yjs/my%2Esvc/__ds/subscriptions/encoded-service`,
+          {
+            method: `PUT`,
+            headers: { "content-type": `application/json` },
+            body: JSON.stringify(request),
+          }
+        )
+        expect(encodedServiceResponse.status).toBe(400)
+      } finally {
+        await fetch(subscriptionUrl, { method: `DELETE` })
+        await receiver.close()
+      }
+    })
+
+    it(`snapshot-subscription.proxy preserves configured headers and reports outages`, async () => {
+      let authorization: string | undefined
+      let transferEncoding: string | undefined
+      const upstream = createHttpServer((req, res) => {
+        authorization = req.headers.authorization
+        transferEncoding = req.headers[`transfer-encoding`]
+        req.resume()
+        res.writeHead(201, { "content-type": `application/json` })
+        res.end(
+          JSON.stringify({
+            id: `delivery-id`,
+            subscription_id: `delivery-id`,
+            type: `webhook`,
+            pattern: `malformed-upstream-pattern`,
+            webhook: { url: `http://127.0.0.1:1/webhook` },
+          })
+        )
+      })
+      await new Promise<void>((resolve, reject) => {
+        upstream.on(`error`, reject)
+        upstream.listen(0, `127.0.0.1`, resolve)
+      })
+      const address = upstream.address()
+      if (!address || typeof address === `string`) {
+        throw new Error(`Failed to start fake Durable Streams server`)
+      }
+
+      const facade = new YjsServer({
+        port: 0,
+        dsServerUrl: `http://127.0.0.1:${address.port}`,
+        dsServerHeaders: { authorization: `Bearer configured` },
+      })
+      await facade.start()
+      const subscriptionUrl = `${facade.url}/v1/yjs/test/__ds/subscriptions/proxy-test`
+
+      try {
+        const requestBody = JSON.stringify({
+          type: `webhook`,
+          events: [`snapshot.available`],
+          document_pattern: `**`,
+          webhook: { url: `http://127.0.0.1:1/webhook` },
+        })
+        const created = await new Promise<{
+          status: number
+          body: Record<string, unknown>
+        }>((resolve, reject) => {
+          const request = createHttpRequest(
+            subscriptionUrl,
+            {
+              method: `PUT`,
+              headers: {
+                authorization: `Bearer caller`,
+                "content-type": `application/json`,
+              },
+            },
+            (response) => {
+              const chunks: Array<Buffer> = []
+              response.on(`data`, (chunk: Buffer) => chunks.push(chunk))
+              response.on(`end`, () => {
+                try {
+                  resolve({
+                    status: response.statusCode ?? 0,
+                    body: JSON.parse(
+                      Buffer.concat(chunks).toString(`utf8`)
+                    ) as Record<string, unknown>,
+                  })
+                } catch (error) {
+                  reject(error)
+                }
+              })
+            }
+          )
+          request.on(`error`, reject)
+          const splitAt = Math.floor(requestBody.length / 2)
+          request.write(requestBody.slice(0, splitAt))
+          request.end(requestBody.slice(splitAt))
+        })
+
+        expect(created.status).toBe(201)
+        expect(authorization).toBe(`Bearer configured`)
+        expect(transferEncoding).toBeUndefined()
+        expect(created.body).not.toHaveProperty(`document_pattern`)
+
+        upstream.closeAllConnections()
+        await new Promise<void>((resolve) => upstream.close(() => resolve()))
+
+        const unavailable = await fetch(subscriptionUrl)
+        expect(unavailable.status).toBe(502)
+        expect(await unavailable.json()).toEqual({
+          error: {
+            code: `PROXY_ERROR`,
+            message: `Failed to reach Durable Streams server`,
+          },
+        })
+      } finally {
+        await facade.stop()
+        if (upstream.listening) {
+          upstream.closeAllConnections()
+          await new Promise<void>((resolve) => upstream.close(() => resolve()))
+        }
+      }
+    })
+  })
+
+  describe(`Awareness registry`, () => {
+    it(`does not collide with a dot-prefixed awareness name`, async () => {
+      const docId = `aw-registry-name-${Date.now()}`
+      await createDocument(baseUrl, docId)
+
+      const first = await fetch(`${baseUrl}/docs/${docId}?awareness=presence`, {
+        method: `PUT`,
+      })
+      expect(first.status).toBe(201)
+
+      const named = await fetch(
+        `${baseUrl}/docs/${docId}?awareness=.registry`,
+        {
+          method: `PUT`,
+        }
+      )
+      expect(named.status).toBe(201)
+
+      const posted = await fetch(
+        `${baseUrl}/docs/${docId}?awareness=.registry`,
+        {
+          method: `POST`,
+          headers: { "content-type": `application/octet-stream` },
+          body: new Uint8Array([1, 2, 3]),
+        }
+      )
+      expect(posted.status).toBe(204)
     })
   })
 
@@ -1603,6 +1836,57 @@ describe(`Yjs Durable Streams Protocol`, () => {
         expect(headAfter2.status).toBe(404)
       })
     })
+
+    describe.skipIf(!!externalServerUrl)(
+      `delete.doc-cascades-legacy-awareness-index`,
+      () => {
+        it(`should clean up awareness streams recorded by an earlier server version`, async () => {
+          const docId = `del-cascade-legacy-aw-${Date.now()}`
+          const awarenessName = `legacy-presence`
+          await createDocument(baseUrl, docId)
+
+          const awarenessPath = YjsStreamPaths.awarenessStream(
+            `test`,
+            docId,
+            awarenessName
+          )
+          const createAwareness = await fetch(
+            `${dsServer!.url}${awarenessPath}`,
+            {
+              method: `PUT`,
+              headers: { "content-type": `application/octet-stream` },
+            }
+          )
+          expect(createAwareness.status).toBe(201)
+
+          const legacyIndexPath = YjsStreamPaths.awarenessIndexStream(
+            `test`,
+            docId
+          )
+          await yjsServer!.appendToIndexStream(legacyIndexPath, {
+            name: awarenessName,
+            createdAt: Date.now(),
+          })
+
+          const deleteDocument = await fetch(`${baseUrl}/docs/${docId}`, {
+            method: `DELETE`,
+          })
+          expect(deleteDocument.status).toBe(204)
+
+          const awarenessAfter = await fetch(
+            `${dsServer!.url}${awarenessPath}`,
+            { method: `HEAD` }
+          )
+          expect(awarenessAfter.status).toBe(404)
+
+          const legacyIndexAfter = await fetch(
+            `${dsServer!.url}${legacyIndexPath}`,
+            { method: `HEAD` }
+          )
+          expect(legacyIndexAfter.status).toBe(404)
+        })
+      }
+    )
 
     describe(`delete.doc-cascades-snapshots`, () => {
       let providers: Array<YjsProvider> = []


### PR DESCRIPTION
## Motivation

Yjs snapshots are currently an internal implementation detail. External persistence workers have no supported way to learn when the current snapshot advances without polling or coupling directly to internal stream layout.

## What changed

- Add service-scoped PUT, GET, and DELETE endpoints for `snapshot.available` webhook subscriptions.
- Translate document globs to Durable Streams subscriptions over each matching document's `.index` stream.
- Reuse the existing Durable Streams signing, retry, lease, callback, and acknowledgement machinery.
- Return the public subscription ID alongside the opaque delivery subscription ID used in signed webhook payloads.
- Add lifecycle, delivery, and invalid-event conformance coverage, and include the Yjs project in the repository test command.
- Document the API and add a patch changeset for `@durable-streams/y-durable-streams`.

## Design decisions

Webhook deliveries are wake notifications, not snapshot payloads. Receivers derive the document from each pending index stream, fetch `?offset=snapshot`, and persist the current binary snapshot before acknowledging completion.

The guarantee is latest-snapshot convergence: multiple compactions may coalesce, and acknowledgements retain pending work when a newer snapshot arrives during processing. New subscriptions observe future snapshots only; consumers that need the snapshot current at subscription creation bootstrap it separately.

This facade depends on an underlying Durable Streams implementation that supports the current reserved subscription API and webhook delivery.