### PR TITLE
fix(server-cloudflare): set publishConfig access to public

### DIFF
--- a/packages/server-cloudflare/package.json
+++ b/packages/server-cloudflare/package.json
@@ -12,6 +12,9 @@
   "bugs": {
     "url": "https://github.com/durable-streams/durable-streams/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "durable-streams",
     "cloudflare",


### PR DESCRIPTION
## Summary
- Adds `publishConfig.access: "public"` to allow publishing scoped package to npm

Scoped packages (`@org/name`) default to private on npm, which requires a paid account. This config makes it publish as public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)