### PR TITLE
ci: automate Go client releases

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,47 @@
+name: Release Go client
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/client-go/package.json"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: packages/client-go/go.mod
+          cache-dependency-path: packages/client-go/go.mod
+
+      - name: Test
+        working-directory: packages/client-go
+        run: go test ./...
+
+      - name: Tag release
+        run: |
+          version="$(jq -er '.version' packages/client-go/package.json)"
+          tag="packages/client-go/v${version}"
+
+          if git rev-parse --verify --quiet "refs/tags/${tag}"; then
+            echo "${tag} already exists"
+            exit 0
+          fi
+
+          git tag "${tag}"
+          git push origin "${tag}"

--- a/packages/client-go/package.json
+++ b/packages/client-go/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@durable-streams-internal/client-go",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Bridge package for Changesets; the actual package is a Go module"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,8 @@ importers:
 
   packages/client-dotnet: {}
 
+  packages/client-go: {}
+
   packages/client-py: {}
 
   packages/proxy:


### PR DESCRIPTION
## Summary

- add a private Changesets bridge for the Go client, seeded at the released v0.2.0
- add a workflow that tests the Go module and creates path-prefixed module tags when the bridge version changes on main
- skip tag creation when the version already exists, making the initial merge and reruns safe

## Release flow

1. Add a changeset for @durable-streams-internal/client-go with Go client changes.
2. Merge the Changesets version PR.
3. The bridge package version change triggers this workflow.
4. The workflow runs the Go tests and pushes packages/client-go/vX.Y.Z.

## Validation

- go test ./...
- pnpm changeset status with a temporary patch changeset
- pnpm exec prettier --check .github/workflows/release-go.yml packages/client-go/package.json pnpm-lock.yaml
- git diff --check
- existing v0.2.0 tag no-op path
