### PR TITLE
fix: discover conformance tests under npx

### DIFF
--- a/.changeset/fix-server-conformance-cli-vitest-config.md
+++ b/.changeset/fix-server-conformance-cli-vitest-config.md
@@ -1,0 +1,5 @@
+---
+"@durable-streams/server-conformance-tests": patch
+---
+
+Fix CLI test discovery when run via `npx` from a consumer project. Vitest no longer inherits the host project's include/exclude patterns (which previously caused "No test files found" for `test-runner.js` under `node_modules`).

--- a/packages/server-conformance-tests/package.json
+++ b/packages/server-conformance-tests/package.json
@@ -44,7 +44,8 @@
   "files": [
     "dist",
     "src",
-    "bin"
+    "bin",
+    "vitest.cli.config.mjs"
   ],
   "scripts": {
     "build": "tsdown",

--- a/packages/server-conformance-tests/src/cli.ts
+++ b/packages/server-conformance-tests/src/cli.ts
@@ -152,18 +152,26 @@ function findVitestBinary(): string {
   return `vitest`
 }
 
+function buildVitestArgs(runnerPath: string): Array<string> {
+  const vitestConfigPath = join(__dirname, `../vitest.cli.config.mjs`)
+  return [
+    `run`,
+    runnerPath,
+    // Use an isolated config so host-project vitest/vite configs (and their
+    // include/exclude patterns) do not hide this package's test-runner.
+    `--config`,
+    vitestConfigPath,
+    `--no-coverage`,
+    `--reporter=default`,
+    `--passWithNoTests=false`,
+  ]
+}
+
 function runTests(baseUrl: string): Promise<number> {
   return new Promise((resolvePromise) => {
     const runnerPath = getTestRunnerPath()
     const vitestPath = findVitestBinary()
-
-    const args = [
-      `run`,
-      runnerPath,
-      `--no-coverage`,
-      `--reporter=default`,
-      `--passWithNoTests=false`,
-    ]
+    const args = buildVitestArgs(runnerPath)
 
     const child = spawn(vitestPath, args, {
       stdio: `inherit`,
@@ -203,14 +211,7 @@ async function runWatch(
   const spawnTests = (): ChildProcess => {
     const runnerPath = getTestRunnerPath()
     const vitestPath = findVitestBinary()
-
-    const args = [
-      `run`,
-      runnerPath,
-      `--no-coverage`,
-      `--reporter=default`,
-      `--passWithNoTests=false`,
-    ]
+    const args = buildVitestArgs(runnerPath)
 
     return spawn(vitestPath, args, {
       stdio: `inherit`,

--- a/packages/server-conformance-tests/vitest.cli.config.mjs
+++ b/packages/server-conformance-tests/vitest.cli.config.mjs
@@ -1,0 +1,30 @@
+import { defineConfig } from "vitest/config"
+import { existsSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = dirname(fileURLToPath(import.meta.url))
+
+// Prefer the built runner when present (published / normal CLI use). Fall back
+// to the TypeScript source for local `tsx` development.
+const runnerEntry = existsSync(join(root, `dist/test-runner.js`))
+  ? `dist/test-runner.js`
+  : `src/test-runner.ts`
+
+// Isolated Vitest config for the conformance CLI.
+//
+// Consumer projects often ship their own vitest/vite config with include
+// patterns like src/**/*.test.ts and exclude **/node_modules/**. Without an
+// explicit --config, Vitest picks those up from cwd and never discovers this
+// package's test-runner entry.
+
+export default defineConfig({
+  root,
+  test: {
+    include: [runnerEntry],
+    // Clear defaults so the entry under node_modules/dist is not filtered out.
+    exclude: [],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+})


### PR DESCRIPTION
`npx @durable-streams/server-conformance-tests --run <url>` fails from consumer projects with:

```text
No test files found, exiting with code 1

filter: .../node_modules/@durable-streams/server-conformance-tests/dist/test-runner.js
include: src/**/*.test.ts, test/**/*.test.ts
exclude: **/node_modules/**, **/.git/**
```

The CLI shells out to Vitest with dist/test-runner.js, but without an isolated config Vitest loads the host project's config from cwd. Host include patterns don't match test-runner.js, and exclude typically drops node_modules, so the suite never discovers.

closes #284
